### PR TITLE
update repo path to sigs.k8s.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ IMAGE_NAME=secrets-store-csi
 IMAGE_VERSION?=v0.0.7
 IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_VERSION)
 IMAGE_TAG_LATEST=$(REGISTRY_NAME)/$(IMAGE_NAME):latest
-LDFLAGS?='-X github.com/deislabs/secrets-store-csi-driver/pkg/secrets-store.vendorVersion=$(IMAGE_VERSION) -extldflags "-static"'
+LDFLAGS?='-X sigs.k8s.io/secrets-store-csi-driver/pkg/secrets-store.vendorVersion=$(IMAGE_VERSION) -extldflags "-static"'
 GO_FILES=$(shell go list ./... | grep -v /test/sanity)
 
 .PHONY: all build image clean test-style

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ To verify that Secrets Store CSI Driver has started, run:
 
   kubectl --namespace=dev get pods -l "app=secrets-store-csi-driver"
 
-Now you can follow these steps https://github.com/deislabs/secrets-store-csi-driver#use-the-secrets-store-csi-driver
+Now you can follow these steps https://github.com/kubernetes-sigs/secrets-store-csi-driver#use-the-secrets-store-csi-driver
 to create a SecretProviderClass resource, and a deployment using the SecretProviderClass.
 
 ```
@@ -249,11 +249,11 @@ This project features a pluggable provider interface developers can implement th
 
 Here is a list of criteria for supported provider:
 1. Code audit of the provider implementation to ensure it adheres to the required provider-driver interface, which includes:
-    - implementation of provider command args https://github.com/deislabs/secrets-store-csi-driver/blob/master/pkg/secrets-store/nodeserver.go#L223-L236
+    - implementation of provider command args https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/pkg/secrets-store/nodeserver.go#L223-L236
     - provider binary naming convention and semver convention
     - provider binary deployment volume path
     - provider logs are written to stdout and stderr so they can be part of the driver logs
-1. Add provider to the e2e test suite to demonstrate it functions as expected https://github.com/deislabs/secrets-store-csi-driver/tree/master/test/bats Please use existing providers e2e tests as a reference.
+1. Add provider to the e2e test suite to demonstrate it functions as expected https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/test/bats Please use existing providers e2e tests as a reference.
 1. If any update is made by a provider (not limited to security updates), the provider is expected to update the provider's e2e test in this repo
 
 ### Removal from Supported Providers

--- a/charts/secrets-store-csi-driver/Chart.yaml
+++ b/charts/secrets-store-csi-driver/Chart.yaml
@@ -5,7 +5,7 @@ kubeVersion: ">=1.15.0-0"
 description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 sources:
-  - https://github.com/deislabs/secrets-store-csi-driver
+  - https://github.com/kubernetes-sigs/secrets-store-csi-driver
 maintainers:
   - name: Rita Zhang
     email: ritazh@microsoft.com

--- a/charts/secrets-store-csi-driver/templates/NOTES.txt
+++ b/charts/secrets-store-csi-driver/templates/NOTES.txt
@@ -4,5 +4,5 @@ To verify that Secrets Store CSI Driver has started, run:
 
   kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "sscd.name" . }}"
 
-Now you can follow these steps https://github.com/deislabs/secrets-store-csi-driver#use-the-secrets-store-csi-driver
+Now you can follow these steps https://github.com/kubernetes-sigs/secrets-store-csi-driver#use-the-secrets-store-csi-driver
 to create a SecretProviderClass resource, and a deployment using the SecretProviderClass.

--- a/cmd/secrets-store-csi-driver/main.go
+++ b/cmd/secrets-store-csi-driver/main.go
@@ -21,7 +21,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	secretsstore "github.com/deislabs/secrets-store-csi-driver/pkg/secrets-store"
+	secretsstore "sigs.k8s.io/secrets-store-csi-driver/pkg/secrets-store"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/deislabs/secrets-store-csi-driver
+module sigs.k8s.io/secrets-store-csi-driver
 
 go 1.12
 

--- a/pkg/secrets-store/controllerserver.go
+++ b/pkg/secrets-store/controllerserver.go
@@ -20,9 +20,9 @@ import (
 	"sync/atomic"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	csicommon "github.com/deislabs/secrets-store-csi-driver/pkg/csi-common"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	csicommon "sigs.k8s.io/secrets-store-csi-driver/pkg/csi-common"
 
 	"golang.org/x/net/context"
 )

--- a/pkg/secrets-store/identityserver.go
+++ b/pkg/secrets-store/identityserver.go
@@ -18,8 +18,8 @@ package secretsstore
 
 import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	csicommon "github.com/deislabs/secrets-store-csi-driver/pkg/csi-common"
 	"golang.org/x/net/context"
+	csicommon "sigs.k8s.io/secrets-store-csi-driver/pkg/csi-common"
 
 	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 )

--- a/pkg/secrets-store/nodeserver.go
+++ b/pkg/secrets-store/nodeserver.go
@@ -27,8 +27,8 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/spf13/cast"
 
-	csicommon "github.com/deislabs/secrets-store-csi-driver/pkg/csi-common"
-	version "github.com/deislabs/secrets-store-csi-driver/pkg/version"
+	csicommon "sigs.k8s.io/secrets-store-csi-driver/pkg/csi-common"
+	version "sigs.k8s.io/secrets-store-csi-driver/pkg/version"
 
 	log "github.com/sirupsen/logrus"
 

--- a/pkg/secrets-store/secrets-store.go
+++ b/pkg/secrets-store/secrets-store.go
@@ -19,8 +19,8 @@ package secretsstore
 import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 
-	csicommon "github.com/deislabs/secrets-store-csi-driver/pkg/csi-common"
-	version "github.com/deislabs/secrets-store-csi-driver/pkg/version"
+	csicommon "sigs.k8s.io/secrets-store-csi-driver/pkg/csi-common"
+	version "sigs.k8s.io/secrets-store-csi-driver/pkg/version"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/secrets-store/secrets-store_test.go
+++ b/pkg/secrets-store/secrets-store_test.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package secretsstore
 
-import csicommon "github.com/deislabs/secrets-store-csi-driver/pkg/csi-common"
+import csicommon "sigs.k8s.io/secrets-store-csi-driver/pkg/csi-common"
 
 const (
 	fakeDriverName = "fake"

--- a/secretProviderClass/PROJECT
+++ b/secretProviderClass/PROJECT
@@ -1,3 +1,3 @@
 version: "2"
 domain: secrets-store.csi.x-k8s.io
-repo: github.com/deislabs/secrets-store-csi-driver
+repo: sigs.k8s.io/secrets-store-csi-driver

--- a/secretProviderClass/go.mod
+++ b/secretProviderClass/go.mod
@@ -1,4 +1,4 @@
-module github.com/deislabs/secrets-store-csi-driver
+module sigs.k8s.io/secrets-store-csi-driver
 
 go 1.12
 

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/kubernetes-csi/csi-test/pkg/sanity"
 
-	secretsstore "github.com/deislabs/secrets-store-csi-driver/pkg/secrets-store"
+	secretsstore "sigs.k8s.io/secrets-store-csi-driver/pkg/secrets-store"
 )
 
 const (


### PR DESCRIPTION
Since the repo move to `kubernetes-sigs` is complete, we can update the path alias to `sigs.k8s.io`.