### PR TITLE
add liveness probe sidecar to deploy manifest

### DIFF
--- a/deploy/secrets-store-csi-driver.yaml
+++ b/deploy/secrets-store-csi-driver.yaml
@@ -59,6 +59,18 @@ spec:
           imagePullPolicy: Always
           securityContext:
             privileged: true
+          ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+              failureThreshold: 5
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 30
+              timeoutSeconds: 10
+              periodSeconds: 15
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
@@ -67,6 +79,16 @@ spec:
               mountPropagation: Bidirectional
             - name: providers-dir
               mountPath: /etc/kubernetes/secrets-store-csi-providers
+        - name: liveness-probe
+          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          imagePullPolicy: Always
+          args:
+          - --csi-address=/csi/csi.sock
+          - --probe-timeout=3s
+          - --health-port=9808
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
       volumes:
         - name: mountpoint-dir
           hostPath:


### PR DESCRIPTION
liveness probe support PR was merged - https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/142. Helm charts already have the changes included. Updating the deployment manifests also to include the side car now that new release has been cut with the changes.

/assign @ritazh 