### PR TITLE
bump csi-node-driver-registrar to v1.2.0

### DIFF
--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -17,7 +17,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/deploy/secrets-store-csi-driver.yaml
+++ b/deploy/secrets-store-csi-driver.yaml
@@ -15,7 +15,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
- bump `csi-node-driver-registrar` image to latest available release `v1.2.0`

/assign @ritazh 