### PR TITLE
restructure docs and add windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,8 @@ secretproviderclasses.secrets-store.csi.x-k8s.io
 
 ### Use the Secrets Store CSI Driver with a Provider
 
-Select a provider from the [list of supported providers](#providers) and deploy the provider yaml
-
-Configuration for each individual provider and examples -
--  [Azure Provider](https://github.com/Azure/secrets-store-csi-driver-provider-azure)
+Select a provider from the following list, then follow the installation steps for the provider:
+-  [Azure Provider](https://github.com/Azure/secrets-store-csi-driver-provider-azure#install-the-azure-key-vault-provider)
 -  [Vault Provider](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault)
 
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ secretproviderclasses.secrets-store.csi.x-k8s.io
 ### Use the Secrets Store CSI Driver with a Provider
 
 Select a provider from the following list, then follow the installation steps for the provider:
--  [Azure Provider](https://github.com/Azure/secrets-store-csi-driver-provider-azure#install-the-azure-key-vault-provider)
+-  [Azure Provider](https://github.com/Azure/secrets-store-csi-driver-provider-azure#usage)
 -  [Vault Provider](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault)
 
 
@@ -152,6 +152,8 @@ Run unit tests locally with `make test`.
 ### End-to-end Tests
 
 End-to-end tests automatically runs on Prow when a PR is submitted. If you want to run using a local or remote Kubernetes cluster, make sure to have `kubectl`, `helm` and `bats` set up in your local environment and then run `make e2e-azure` or `make e2e-vault` with custom images.
+
+Job config for test jobs run for each PR in prow can be found [here](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml)
 
 ## Known Issues and Workarounds
 

--- a/charts/secrets-store-csi-driver/README.md
+++ b/charts/secrets-store-csi-driver/README.md
@@ -1,0 +1,47 @@
+# secrets-store-csi-driver
+
+## Installation with Helm 3
+
+Quick start instructions for the setup and configuration for secrets-store-csi-driver using Helm.
+
+### Prerequisites
+
+- [Helm v3.0+](https://helm.sh/docs/intro/quickstart/#install-helm)
+
+### Install charts
+
+**Get the source**
+```bash
+$ go get -d sigs.k8s.io/secrets-store-csi-driver
+$ cd "$(go env GOPATH)/src/sigs.k8s.io/secrets-store-csi-driver"
+```
+
+**Create the desired namespace if not exists**
+```bash
+NAMESPACE=csi-secrets-store
+kubectl create ns $NAMESPACE
+```
+
+**Install on linux only cluster**
+```bash
+$ helm install csi-secrets-store charts/secrets-store-csi-driver -n $NAMESPACE
+```
+
+**Install on windows only cluster**
+```bash
+$ helm install csi-secrets-store charts/secrets-store-csi-driver --set linux.enabled=false --set windows.enabled=true -n $NAMESPACE
+```
+
+**Install on linux and windows hybrid cluster**
+```bash
+$ helm install csi-secrets-store charts/secrets-store-csi-driver --set windows.enabled=true -n $NAMESPACE
+```
+
+### Uninstall
+
+To uninstall/delete the last deployment:
+
+```bash
+$ helm ls
+$ helm delete csi-secrets-store
+``` 

--- a/charts/secrets-store-csi-driver/README.md
+++ b/charts/secrets-store-csi-driver/README.md
@@ -1,47 +1,37 @@
 # secrets-store-csi-driver
 
-## Installation with Helm 3
+## Installation
 
-Quick start instructions for the setup and configuration for secrets-store-csi-driver using Helm.
+Quick start instructions for the setup and configuration of secrets-store-csi-driver using Helm.
 
 ### Prerequisites
 
 - [Helm v3.0+](https://helm.sh/docs/intro/quickstart/#install-helm)
 
-### Install charts
+### Installing the chart
 
-**Get the source**
 ```bash
-$ go get -d sigs.k8s.io/secrets-store-csi-driver
-$ cd "$(go env GOPATH)/src/sigs.k8s.io/secrets-store-csi-driver"
+$ helm repo add secrets-store-csi-driver https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
+$ helm install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver
 ```
 
-**Create the desired namespace if not exists**
-```bash
-NAMESPACE=csi-secrets-store
-kubectl create ns $NAMESPACE
-```
+### Configuration
 
-**Install on linux only cluster**
-```bash
-$ helm install csi-secrets-store charts/secrets-store-csi-driver -n $NAMESPACE
-```
+The following table lists the configurable parameters of the csi-secrets-store-provider-azure chart and their default values.
 
-**Install on windows only cluster**
-```bash
-$ helm install csi-secrets-store charts/secrets-store-csi-driver --set linux.enabled=false --set windows.enabled=true -n $NAMESPACE
-```
-
-**Install on linux and windows hybrid cluster**
-```bash
-$ helm install csi-secrets-store charts/secrets-store-csi-driver --set windows.enabled=true -n $NAMESPACE
-```
-
-### Uninstall
-
-To uninstall/delete the last deployment:
-
-```bash
-$ helm ls
-$ helm delete csi-secrets-store
-``` 
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `nameOverride` | String to partially override secrets-store-csi-driver.fullname template with a string (will prepend the release name) | `""` |
+| `fullnameOverride` | String to fully override secrets-store-csi-driver.fullname template with a string | `""` |
+| `linux.image.repository` | Linux image repository | `docker.io/deislabs/secrets-store-csi` |
+| `linux.image.pullPolicy` | Linux image pull policy | `Always` |
+| `linux.image.tag` | Linux image tag | `v0.0.9` |
+| `linux.enabled` | Install secrets store csi driver on linux nodes | true |
+| `windows.image.repository` | Windows image repository | `mcr.microsoft.com/k8s/csi/secrets-store/driver` |
+| `windows.image.pullPolicy` | Windows image pull policy | `IfNotPresent` |
+| `windows.image.tag` | Windows image tag | `v0.0.9` |
+| `windows.enabled` | Install secrets store csi driver on windows nodes | false |
+| `logLevel.debug` | Enable debug logging | true |
+| `livenessProbe.port` | Liveness probe port | `9808` |
+| `rbac.install` | Install default rbac roles and bindings | true |
+| `minimumProviderVersions` | A comma delimited list of key-value pairs of minimum provider versions with driver | `""` |


### PR DESCRIPTION
fixes https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/182, fixes https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/115

- Moves helm install instructions to new `README` under charts/*
- Adds install instructions for windows
- Removes references to examples that are no longer in the repo
- Points to provider configuration and install steps 
- Removes references to helm2