### PR TITLE
helm: switch to using version instead of gitversion

### DIFF
--- a/charts/secrets-store-csi-driver/templates/csidriver.yaml
+++ b/charts/secrets-store-csi-driver/templates/csidriver.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   podInfoOnMount: true
   attachRequired: false
-{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.Version }}
   # Added in Kubernetes 1.16 with default mode of Persistent. Secrets store csi driver needs Ephermeral to be set.
   volumeLifecycleModes: 
   - Ephemeral


### PR DESCRIPTION
`Capabilities.KubeVersion.Version` is deprecated, so switching to use `Capabilities.KubeVersion.Version` as recommended here - https://github.com/helm/helm/blob/master/pkg/chartutil/capabilities.go#L58-L61