### PR TITLE
update base image with debian base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
-FROM debian:9
-RUN apt-get update && apt-get install -y ca-certificates cifs-utils
+FROM golang:1.13.10-alpine3.10 as builder
+WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver
+ADD . .
+ARG TARGETARCH
+ARG TARGETOS
+ARG LDFLAGS
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "${LDFLAGS}" -o _output/secrets-store-csi ./cmd/secrets-store-csi-driver
+
+FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:v2.1.0
+COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi
+RUN clean-install ca-certificates cifs-utils mount
+
 LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"
 
-COPY ./_output/secrets-store-csi /secrets-store-csi
 ENTRYPOINT ["/secrets-store-csi"]

--- a/windows.Dockerfile
+++ b/windows.Dockerfile
@@ -1,9 +1,17 @@
+FROM --platform=$BUILDPLATFORM golang:1.13.10-alpine3.10 as builder
+WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver
+ADD . .
+ARG TARGETARCH
+ARG TARGETOS
+ARG LDFLAGS
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "${LDFLAGS}" -o _output/secrets-store-csi.exe ./cmd/secrets-store-csi-driver
+
 FROM mcr.microsoft.com/windows/servercore:1809 as core
 
 FROM mcr.microsoft.com/windows/nanoserver:1809
 LABEL description="Secrets Store CSI Driver"
 
-COPY ./_output/secrets-store-csi.exe /secrets-store-csi.exe
+COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi.exe /secrets-store-csi.exe
 COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
 USER ContainerAdministrator
 ENTRYPOINT ["/secrets-store-csi.exe"]


### PR DESCRIPTION
**What this PR does / why we need it**:
- Updates dockerfile with a builder image
- Updates base image with us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:v2.1.0 as minimal base (https://github.com/kubernetes/kubernetes/tree/master/build/debian-base)
- Uses docker buildx to build cross-platform images


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #196 

**Special notes for your reviewer**: