### PR TITLE
feat: allow kubelet root dir to be configurable

### DIFF
--- a/charts/secrets-store-csi-driver/README.md
+++ b/charts/secrets-store-csi-driver/README.md
@@ -27,10 +27,12 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `linux.image.pullPolicy` | Linux image pull policy | `Always` |
 | `linux.image.tag` | Linux image tag | `v0.0.10` |
 | `linux.enabled` | Install secrets store csi driver on linux nodes | true |
+| `linux.kubeletRootDir` | Configure the kubelet root dir | `/var/lib/kubelet` |
 | `windows.image.repository` | Windows image repository | `mcr.microsoft.com/k8s/csi/secrets-store/driver` |
 | `windows.image.pullPolicy` | Windows image pull policy | `IfNotPresent` |
 | `windows.image.tag` | Windows image tag | `v0.0.10` |
 | `windows.enabled` | Install secrets store csi driver on windows nodes | false |
+| `windows.kubeletRootDir` | Configure the kubelet root dir | `C:\var\lib\kubelet` |
 | `logLevel.debug` | Enable debug logging | true |
 | `livenessProbe.port` | Liveness probe port | `9808` |
 | `rbac.install` | Install default rbac roles and bindings | true |

--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -22,7 +22,7 @@ spec:
           args:
             - --v=5
             - "--csi-address=unix://C:\\csi\\csi.sock"
-            - "--kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\csi-secrets-store\\csi.sock"
+            - --kubelet-registration-path={{ .Values.windows.kubeletRootDir }}\plugins\csi-secrets-store\csi.sock
           lifecycle:
               preStop:
                 exec:
@@ -83,7 +83,7 @@ spec:
             - name: plugin-dir
               mountPath: C:\csi
             - name: mountpoint-dir
-              mountPath: "C:\\var\\lib\\kubelet\\pods"
+              mountPath: {{ .Values.windows.kubeletRootDir }}\pods
               mountPropagation: Bidirectional
             - name: providers-dir
               mountPath: C:\k\secrets-store-csi-providers
@@ -102,15 +102,15 @@ spec:
       volumes:
         - name: mountpoint-dir
           hostPath:
-            path: C:\var\lib\kubelet\pods\
+            path: {{ .Values.windows.kubeletRootDir }}\pods\
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
-            path: C:\var\lib\kubelet\plugins_registry\
+            path: {{ .Values.windows.kubeletRootDir }}\plugins_registry\
             type: Directory
         - name: plugin-dir
           hostPath:
-            path: C:\var\lib\kubelet\plugins\csi-secrets-store\
+            path: {{ .Values.windows.kubeletRootDir }}\plugins\csi-secrets-store\
             type: DirectoryOrCreate
         - name: providers-dir
           hostPath:

--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -24,7 +24,7 @@ spec:
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
-            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-secrets-store/csi.sock
+            - --kubelet-registration-path={{ .Values.linux.kubeletRootDir }}/plugins/csi-secrets-store/csi.sock
           lifecycle:
             preStop:
               exec:
@@ -85,7 +85,7 @@ spec:
             - name: plugin-dir
               mountPath: /csi
             - name: mountpoint-dir
-              mountPath: /var/lib/kubelet/pods
+              mountPath: {{ .Values.linux.kubeletRootDir }}/pods
               mountPropagation: Bidirectional
             - name: providers-dir
               mountPath: /etc/kubernetes/secrets-store-csi-providers
@@ -104,15 +104,15 @@ spec:
       volumes:
         - name: mountpoint-dir
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: {{ .Values.linux.kubeletRootDir }}/pods
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/
+            path: {{ .Values.linux.kubeletRootDir }}/plugins_registry/
             type: Directory
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/csi-secrets-store/
+            path: {{ .Values.linux.kubeletRootDir }}/plugins/csi-secrets-store/
             type: DirectoryOrCreate
         - name: providers-dir
           hostPath:

--- a/charts/secrets-store-csi-driver/values.yaml
+++ b/charts/secrets-store-csi-driver/values.yaml
@@ -4,6 +4,7 @@ linux:
     repository: docker.io/deislabs/secrets-store-csi
     tag: v0.0.10
     pullPolicy: Always
+  kubeletRootDir: /var/lib/kubelet
 
 windows:
   enabled: false
@@ -11,6 +12,7 @@ windows:
     repository: mcr.microsoft.com/k8s/csi/secrets-store/driver
     tag: v0.0.10
     pullPolicy: IfNotPresent
+  kubeletRootDir: C:\var\lib\kubelet
 
 logLevel:
   debug: true

--- a/pkg/secrets-store/nodeserver.go
+++ b/pkg/secrets-store/nodeserver.go
@@ -284,7 +284,7 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 		return &csi.NodeUnpublishVolumeResponse{}, nil
 	}
 
-	podUID = getPodUIDFromTargetPath(runtime.GOOS, targetPath)
+	podUID = getPodUIDFromTargetPath(targetPath)
 	if len(podUID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Cannot get podUID from Target path")
 	}

--- a/pkg/secrets-store/utils.go
+++ b/pkg/secrets-store/utils.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -103,23 +104,13 @@ func getMountedFiles(targetPath string) ([]string, error) {
 }
 
 // getPodUIDFromTargetPath returns podUID from targetPath
-func getPodUIDFromTargetPath(goos string, targetPath string) string {
-	var parts []string
-	if goos == "windows" {
-		if strings.Contains(targetPath, `\var\lib\kubelet\pods`) {
-			parts = strings.Split(targetPath, `\`)
-		} else if strings.Contains(targetPath, `\\var\\lib\\kubelet\\pods`) {
-			parts = strings.Split(targetPath, `\\`)
-		}
-	} else {
-		if strings.Contains(targetPath, `/var/lib/kubelet/pods`) {
-			parts = strings.Split(targetPath, `/`)
-		}
+func getPodUIDFromTargetPath(targetPath string) string {
+	re := regexp.MustCompile(`[\\|\/]+pods[\\|\/]+(.+?)[\\|\/]+volumes`)
+	match := re.FindStringSubmatch(targetPath)
+	if len(match) < 2 {
+		return ""
 	}
-	if len(parts) > 6 {
-		return parts[5]
-	}
-	return ""
+	return match[1]
 }
 
 // ensureMountPoint ensures mount point is valid

--- a/pkg/secrets-store/utils_test.go
+++ b/pkg/secrets-store/utils_test.go
@@ -237,7 +237,6 @@ func TestGetProviderPath(t *testing.T) {
 func TestGetPodUIDFromTargetPath(t *testing.T) {
 	cases := []struct {
 		targetPath     string
-		goos           string
 		expectedPodUID string
 	}{
 		{
@@ -246,12 +245,10 @@ func TestGetPodUIDFromTargetPath(t *testing.T) {
 		},
 		{
 			targetPath:     `c:\var\lib\kubelet\pods\d4fd876f-bdb3-11e9-a369-0a5d188d99c0\volumes`,
-			goos:           "windows",
 			expectedPodUID: "d4fd876f-bdb3-11e9-a369-0a5d188d99c0",
 		},
 		{
 			targetPath:     `c:\\var\\lib\\kubelet\\pods\\d4fd876f-bdb3-11e9-a369-0a5d188d9934\\volumes`,
-			goos:           "windows",
 			expectedPodUID: "d4fd876f-bdb3-11e9-a369-0a5d188d9934",
 		},
 		{
@@ -262,10 +259,18 @@ func TestGetPodUIDFromTargetPath(t *testing.T) {
 			targetPath:     "/var/lib/kubelet/pods",
 			expectedPodUID: "",
 		},
+		{
+			targetPath:     "/opt/new/var/lib/kubelet/pods/456457fc-d980-4191-b5eb-daf70c4ff7c1/volumes/kubernetes.io~csi/secrets-store-inline/mount",
+			expectedPodUID: "456457fc-d980-4191-b5eb-daf70c4ff7c1",
+		},
+		{
+			targetPath:     "data/kubelet/pods/456457fc-d980-4191-b5eb-daf70c4ff7c1/volumes/kubernetes.io~csi/secrets-store-inline/mount",
+			expectedPodUID: "456457fc-d980-4191-b5eb-daf70c4ff7c1",
+		},
 	}
 
 	for _, tc := range cases {
-		actualPodUID := getPodUIDFromTargetPath(tc.goos, tc.targetPath)
+		actualPodUID := getPodUIDFromTargetPath(tc.targetPath)
 		assert.Equal(t, tc.expectedPodUID, actualPodUID)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Makes `kubeletDir` configurable. Default value is `/var/lib/kubelet` for Linux and `C:\var\lib\kubelet` for Windows.
- Change logic to get the podUID from target path.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #206 

**Special notes for your reviewer**: