### PR TITLE
Set HOME=/root for cloudbuild

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -15,6 +15,9 @@ steps:
     - TAG=$_GIT_TAG
     - BASE_REF=$_PULL_BASE_REF
     - REGISTRY=gcr.io/k8s-staging-csi-secrets-store
+    # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx
+    # setting the home to /root explicitly to make docker buildx work
+    - HOME=/root
     args:
     - manifest
 substitutions:


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets `HOME=/root` in cloud build explicitly to make `buildx` work.

Tested using `cloud-build-local`

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: