### PR TITLE
chore: update node selector and make it configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,8 @@ e2e-container:
 	docker buildx create --use --name=container-builder
 ifdef TEST_WINDOWS
 		az acr login --name $(REGISTRY_NAME)
-		docker buildx build --no-cache --build-arg LDFLAGS=${LDFLAGS} -t $(IMAGE_TAG)-linux-amd64 -f Dockerfile --platform="linux/amd64" --push .
-		docker buildx build --no-cache --build-arg LDFLAGS=${LDFLAGS} -t $(IMAGE_TAG)-windows-1809-amd64 -f windows.Dockerfile --platform="windows/amd64" --push .
+		docker buildx build --no-cache --build-arg LDFLAGS=${LDFLAGS} -t $(IMAGE_TAG)-linux-amd64 -f docker/Dockerfile --platform="linux/amd64" --push .
+		docker buildx build --no-cache --build-arg LDFLAGS=${LDFLAGS} -t $(IMAGE_TAG)-windows-1809-amd64 -f docker/windows.Dockerfile --platform="windows/amd64" --push .
 		docker manifest create $(IMAGE_TAG) $(IMAGE_TAG)-linux-amd64 $(IMAGE_TAG)-windows-1809-amd64
 		docker manifest inspect $(IMAGE_TAG)
 		docker manifest push --purge $(IMAGE_TAG)

--- a/charts/secrets-store-csi-driver/README.md
+++ b/charts/secrets-store-csi-driver/README.md
@@ -28,11 +28,13 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `linux.image.tag` | Linux image tag | `v0.0.11` |
 | `linux.enabled` | Install secrets store csi driver on linux nodes | true |
 | `linux.kubeletRootDir` | Configure the kubelet root dir | `/var/lib/kubelet` |
+| `linux.nodeSelector` | Node Selector for the daemonset on linux nodes | `{}` |
 | `windows.image.repository` | Windows image repository | `mcr.microsoft.com/k8s/csi/secrets-store/driver` |
 | `windows.image.pullPolicy` | Windows image pull policy | `IfNotPresent` |
 | `windows.image.tag` | Windows image tag | `v0.0.11` |
 | `windows.enabled` | Install secrets store csi driver on windows nodes | false |
 | `windows.kubeletRootDir` | Configure the kubelet root dir | `C:\var\lib\kubelet` |
+| `windows.nodeSelector` | Node Selector for the daemonset on windows nodes | `{}` |
 | `logLevel.debug` | Enable debug logging | true |
 | `livenessProbe.port` | Liveness probe port | `9808` |
 | `rbac.install` | Install default rbac roles and bindings | true |

--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -13,8 +13,6 @@ spec:
     metadata:
 {{ include "sscd.labels" . | indent 6 }}
     spec:
-      nodeSelector:
-        beta.kubernetes.io/os: windows
       serviceAccountName: secrets-store-csi-driver
       containers:
         - name: node-driver-registrar
@@ -116,4 +114,9 @@ spec:
           hostPath:
             path: C:\k\secrets-store-csi-providers\
             type: DirectoryOrCreate
+      nodeSelector:
+        kubernetes.io/os: windows
+{{- if .Values.windows.nodeSelector }}
+{{- toYaml .Values.windows.nodeSelector | nindent 8 }}
+{{- end }}
 {{- end -}}

--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -13,8 +13,6 @@ spec:
     metadata:
 {{ include "sscd.labels" . | indent 6 }}
     spec:
-      nodeSelector:
-        beta.kubernetes.io/os: linux
       serviceAccountName: secrets-store-csi-driver
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -118,4 +116,9 @@ spec:
           hostPath:
             path: /etc/kubernetes/secrets-store-csi-providers
             type: DirectoryOrCreate
+      nodeSelector:
+        kubernetes.io/os: linux
+{{- if .Values.linux.nodeSelector }}
+{{- toYaml .Values.linux.nodeSelector | nindent 8 }}
+{{- end }}
 {{- end -}}

--- a/charts/secrets-store-csi-driver/values.yaml
+++ b/charts/secrets-store-csi-driver/values.yaml
@@ -5,6 +5,7 @@ linux:
     tag: v0.0.11
     pullPolicy: Always
   kubeletRootDir: /var/lib/kubelet
+  nodeSelector: {}
 
 windows:
   enabled: false
@@ -13,6 +14,7 @@ windows:
     tag: v0.0.11
     pullPolicy: IfNotPresent
   kubeletRootDir: C:\var\lib\kubelet
+  nodeSelector: {}
 
 logLevel:
   debug: true

--- a/deploy/secrets-store-csi-driver-windows.yaml
+++ b/deploy/secrets-store-csi-driver-windows.yaml
@@ -11,8 +11,6 @@ spec:
       labels:
         app: csi-secrets-store
     spec:
-      nodeSelector:
-        beta.kubernetes.io/os: windows
       serviceAccountName: secrets-store-csi-driver
       containers:
         - name: node-driver-registrar
@@ -107,3 +105,5 @@ spec:
           hostPath:
             path: C:\k\secrets-store-csi-providers\
             type: DirectoryOrCreate
+      nodeSelector:
+        kubernetes.io/os: windows

--- a/deploy/secrets-store-csi-driver.yaml
+++ b/deploy/secrets-store-csi-driver.yaml
@@ -11,8 +11,6 @@ spec:
       labels:
         app: csi-secrets-store
     spec:
-      nodeSelector:
-        beta.kubernetes.io/os: linux
       serviceAccountName: secrets-store-csi-driver
       hostNetwork: true
       containers:
@@ -108,3 +106,5 @@ spec:
           hostPath:
             path: /etc/kubernetes/secrets-store-csi-providers
             type: DirectoryOrCreate
+      nodeSelector:
+        kubernetes.io/os: linux


### PR DESCRIPTION
**What this PR does / why we need it**:
- Update `nodeSelector` labels to `kubernetes.io/os`
- Make `nodeSelector` configurable in helm charts

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #231 

**Special notes for your reviewer**:

/kind cleanup