### PR TITLE
Update and fix e2e-vault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,13 @@ test-style: setup
 sanity-test:
 	go test -v ./test/sanity
 build: setup
-	CGO_ENABLED=0 GOOS=linux go build -a -ldflags ${LDFLAGS} -o _output/secrets-store-csi ./cmd/secrets-store-csi-driver
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags $(LDFLAGS) -o _output/secrets-store-csi ./cmd/secrets-store-csi-driver
 build-windows: setup
-	CGO_ENABLED=0 GOOS=windows go build -a -ldflags ${LDFLAGS} -o _output/secrets-store-csi.exe ./cmd/secrets-store-csi-driver
+	CGO_ENABLED=0 GOOS=windows go build -a -ldflags $(LDFLAGS) -o _output/secrets-store-csi.exe ./cmd/secrets-store-csi-driver
 image:
-	docker buildx build --no-cache --build-arg LDFLAGS=${LDFLAGS} -t $(IMAGE_TAG) -f docker/Dockerfile --platform="linux/amd64" --output "type=docker,push=false" .
+	docker buildx build --no-cache --build-arg LDFLAGS=$(LDFLAGS) -t $(IMAGE_TAG) -f docker/Dockerfile --platform="linux/amd64" --output "type=docker,push=false" .
 image-windows:
-	docker buildx build --no-cache --build-arg LDFLAGS=${LDFLAGS} -t $(IMAGE_TAG) -f docker/windows.Dockerfile --platform="windows/amd64" --output "type=docker,push=false" .
+	docker buildx build --no-cache --build-arg LDFLAGS=$(LDFLAGS) -t $(IMAGE_TAG) -f docker/windows.Dockerfile --platform="windows/amd64" --output "type=docker,push=false" .
 clean:
 	-rm -rf _output
 setup: clean
@@ -68,22 +68,22 @@ endif
 mod:
 	@go mod tidy
 
-KIND_VERSION ?= 0.6.0
-KUBERNETES_VERSION ?= 1.15.3
-VAULT_VERSION ?= 1.2.2
+KIND_VERSION ?= 0.8.1
+KUBERNETES_VERSION ?= 1.15.11
+VAULT_VERSION ?= 1.4.2
 
 # USED for windows CI tests
 .PHONY: e2e-test
 e2e-test: e2e-bootstrap
 	make e2e-azure
-	
+
 .PHONY: e2e-bootstrap
 e2e-bootstrap: install-helm
 	apt-get update && apt-get install bats && apt-get install gettext-base -y
 	# Download and install Vault
-	curl -LO https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && unzip vault_${VAULT_VERSION}_linux_amd64.zip && chmod +x vault && mv vault /usr/local/bin/
+	vault -v | grep -q v$(VAULT_VERSION) || (curl -LO https://releases.hashicorp.com/vault/$(VAULT_VERSION)/vault_$(VAULT_VERSION)_linux_amd64.zip && unzip vault_$(VAULT_VERSION)_linux_amd64.zip && chmod +x vault && mv vault /usr/local/bin/)
 ifndef TEST_WINDOWS
-	curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl && chmod +x ./kubectl && mv kubectl /usr/local/bin/
+	curl -LO https://storage.googleapis.com/kubernetes-release/release/v$(KUBERNETES_VERSION)/bin/linux/amd64/kubectl && chmod +x ./kubectl && mv kubectl /usr/local/bin/
 	make setup-kind
 endif
 	docker pull $(IMAGE_TAG) || make e2e-container
@@ -91,9 +91,10 @@ endif
 .PHONY: setup-kind
 setup-kind:
 	# Download and install kind
-	curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 --output kind && chmod +x kind && mv kind /usr/local/bin/
+	kind --version | grep -q $(KIND_VERSION) || (curl -L https://github.com/kubernetes-sigs/kind/releases/download/v$(KIND_VERSION)/kind-linux-amd64 --output kind && chmod +x kind && mv kind /usr/local/bin/)
 	# Create kind cluster
-	kind create cluster --config kind-config.yaml --image kindest/node:v${KUBERNETES_VERSION}
+	kind delete cluster || true
+	kind create cluster --config kind-config.yaml --image kindest/node:v$(KUBERNETES_VERSION)
 
 .PHONY: e2e-container
 e2e-container:
@@ -101,14 +102,14 @@ e2e-container:
 	docker buildx create --use --name=container-builder
 ifdef TEST_WINDOWS
 		az acr login --name $(REGISTRY_NAME)
-		docker buildx build --no-cache --build-arg LDFLAGS=${LDFLAGS} -t $(IMAGE_TAG)-linux-amd64 -f docker/Dockerfile --platform="linux/amd64" --push .
-		docker buildx build --no-cache --build-arg LDFLAGS=${LDFLAGS} -t $(IMAGE_TAG)-windows-1809-amd64 -f docker/windows.Dockerfile --platform="windows/amd64" --push .
+		docker buildx build --no-cache --build-arg LDFLAGS=$(LDFLAGS) -t $(IMAGE_TAG)-linux-amd64 -f docker/Dockerfile --platform="linux/amd64" --push .
+		docker buildx build --no-cache --build-arg LDFLAGS=$(LDFLAGS) -t $(IMAGE_TAG)-windows-1809-amd64 -f docker/windows.Dockerfile --platform="windows/amd64" --push .
 		docker manifest create $(IMAGE_TAG) $(IMAGE_TAG)-linux-amd64 $(IMAGE_TAG)-windows-1809-amd64
 		docker manifest inspect $(IMAGE_TAG)
 		docker manifest push --purge $(IMAGE_TAG)
 else
 		REGISTRY="e2e" make image
-		kind load docker-image --name kind e2e/secrets-store-csi:${IMAGE_VERSION}
+		kind load docker-image --name kind e2e/secrets-store-csi:$(IMAGE_VERSION)
 endif
 
 .PHONY: install-helm

--- a/test/bats/tests/vault.yaml
+++ b/test/bats/tests/vault.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: vault
-        image: registry.hub.docker.com/library/vault:1.1.1
+        image: registry.hub.docker.com/library/vault:1.4.2
         imagePullPolicy: Always
         args: ['server', '-dev']
         securityContext:


### PR DESCRIPTION
**What this PR does / why we need it**:

* Update latest tools for e2e. Install commands if it does not exist. It makes it more convenient for running locally.
* Fix wrong usage of arithmetic binary operators usage in bats it made wrong assets.
```shell
$ result=$(kubectl exec -it nginx-secrets-store-inline cat /mnt/secrets-store/foo1)
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl kubectl exec [POD] -- [COMMAND] instead.

$ [[ "$result" -eq "hello1" ]]; echo $?
0

$ [[ "$result" -eq "hello" ]]; echo $?
0 # wrong
```

* Update latest usage of `kubectl exec` to dismiss the deprecated warning.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

As a long-term improvement, I'm thinking to replace bats based e2e with `onsi/ginkgo` to avoid using bash that is hard to notice.