### PR TITLE
set context for provider binary calls

### DIFF
--- a/pkg/secrets-store/nodeserver_test.go
+++ b/pkg/secrets-store/nodeserver_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secretsstore
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"golang.org/x/net/context"
+	"k8s.io/utils/mount"
+)
+
+func testNodeServer(mountPoints []mount.MountPoint) (*nodeServer, error) {
+	return newNodeServer(NewFakeDriver(), "", "", "testnode", mount.NewFakeMounter(mountPoints))
+}
+
+func getTestTargetPath(t *testing.T) string {
+	dir, err := ioutil.TempDir("", "ut")
+	if err != nil {
+		t.Fatalf("expected err to be nil, got: %+v", err)
+	}
+	return dir
+}
+
+func TestNodePublishVolume(t *testing.T) {
+	tests := []struct {
+		name              string
+		nodePublishVolReq csi.NodePublishVolumeRequest
+		mountPoints       []mount.MountPoint
+		expectedErr       bool
+	}{
+		{
+			name:              "volume capabilities nil",
+			nodePublishVolReq: csi.NodePublishVolumeRequest{},
+			expectedErr:       true,
+		},
+		{
+			name: "volume id is empty",
+			nodePublishVolReq: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "target path is empty",
+			nodePublishVolReq: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{},
+				VolumeId:         "testvolid1",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "volume context is not set",
+			nodePublishVolReq: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{},
+				VolumeId:         "testvolid1",
+				TargetPath:       getTestTargetPath(t),
+			},
+			expectedErr: true,
+		},
+		{
+			name: "secret provider class not found",
+			nodePublishVolReq: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{},
+				VolumeId:         "testvolid1",
+				TargetPath:       getTestTargetPath(t),
+				VolumeContext:    map[string]string{"secretProviderClass": "provider1"},
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.nodePublishVolReq.TargetPath != "" {
+				defer os.RemoveAll(test.nodePublishVolReq.TargetPath)
+			}
+			ns, err := testNodeServer(test.mountPoints)
+			if err != nil {
+				t.Fatalf("expected error to be nil, got: %+v", err)
+			}
+
+			_, err = ns.NodePublishVolume(context.TODO(), &test.nodePublishVolReq)
+			if test.expectedErr && err == nil || !test.expectedErr && err != nil {
+				t.Fatalf("expected err: %v, got: %+v", test.expectedErr, err)
+			}
+		})
+	}
+}

--- a/pkg/secrets-store/secrets-store.go
+++ b/pkg/secrets-store/secrets-store.go
@@ -45,7 +45,7 @@ func GetDriver() *SecretsStore {
 	return &SecretsStore{}
 }
 
-func newNodeServer(d *csicommon.CSIDriver, providerVolumePath, minProviderVersions, nodeID string) (*nodeServer, error) {
+func newNodeServer(d *csicommon.CSIDriver, providerVolumePath, minProviderVersions, nodeID string, mounter mount.Interface) (*nodeServer, error) {
 	// get a map of provider and compatible version
 	minProviderVersionsMap, err := version.GetMinimumProviderVersions(minProviderVersions)
 	if err != nil {
@@ -58,7 +58,7 @@ func newNodeServer(d *csicommon.CSIDriver, providerVolumePath, minProviderVersio
 		DefaultNodeServer:   csicommon.NewDefaultNodeServer(d),
 		providerVolumePath:  providerVolumePath,
 		minProviderVersions: minProviderVersionsMap,
-		mounter:             mount.New(""),
+		mounter:             mounter,
 		reporter:            newStatsReporter(),
 		nodeID:              nodeID,
 	}, nil
@@ -104,7 +104,7 @@ func (s *SecretsStore) Run(driverName, nodeID, endpoint, providerVolumePath, min
 		log.Fatalf("failed to initialize metrics exporter, error: %+v", err)
 	}
 	defer m.Stop()
-	ns, err := newNodeServer(s.driver, providerVolumePath, minProviderVersions, nodeID)
+	ns, err := newNodeServer(s.driver, providerVolumePath, minProviderVersions, nodeID, mount.New(""))
 	if err != nil {
 		log.Fatalf("failed to initialize node server, error: %+v", err)
 	}

--- a/pkg/secrets-store/utils_test.go
+++ b/pkg/secrets-store/utils_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/mount"
 )
 
 func TestGetProviderPath(t *testing.T) {
@@ -43,7 +44,7 @@ func TestGetProviderPath(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		testNodeServer, err := newNodeServer(NewFakeDriver(), tc.providerVolumePath, "", "test-node")
+		testNodeServer, err := newNodeServer(NewFakeDriver(), tc.providerVolumePath, "", "test-node", &mount.FakeMounter{})
 		assert.NoError(t, err)
 		assert.NotNil(t, testNodeServer)
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,6 +15,7 @@ package version
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -37,9 +38,9 @@ type providerVersion struct {
 
 // IsProviderCompatible checks if the provider version is compatible with
 // current driver version.
-func IsProviderCompatible(provider string, minProviderVersion string) (bool, error) {
+func IsProviderCompatible(ctx context.Context, provider string, minProviderVersion string) (bool, error) {
 	// get current provider version
-	currProviderVersion, err := getProviderVersion(provider)
+	currProviderVersion, err := getProviderVersion(ctx, provider)
 	if err != nil {
 		return false, err
 	}
@@ -89,8 +90,8 @@ func GetMinimumProviderVersions(minProviderVersions string) (map[string]string, 
 	return providerVersionMap, nil
 }
 
-func getProviderVersion(providerName string) (string, error) {
-	cmd := exec.Command(providerName, "--version")
+func getProviderVersion(ctx context.Context, providerName string) (string, error) {
+	cmd := exec.CommandContext(ctx, providerName, "--version")
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Uses `exec.CommandContext` when calling the provider binary. This ensures if the provider doesn't respond before the context timeout, then command times out and the process is killed. The `NodePublishVolume` will then return an error and also unmount the previously mounted `targetPath`. When `kubelet` retries the mount again with the `targetPath` for the pod, the `NodePublishVolume` will be retried as expected. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #236 

**Special notes for your reviewer**: