### PR TITLE
helm: chart best practices

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/templates/_helpers.tpl
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/_helpers.tpl
@@ -25,10 +25,10 @@ Standard labels for helm resources
 */}}
 {{- define "sscd.labels" -}}
 labels:
-  heritage: "{{ .Release.Service }}"
-  release: "{{ .Release.Name }}"
-  revision: "{{ .Release.Revision }}"
-  chart: "{{ .Chart.Name }}"
-  chartVersion: "{{ .Chart.Version }}"
+  app.kubernetes.io/instance: "{{ .Release.Name }}"
+  app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+  app.kubernetes.io/name: "{{ template "sscd.name" . }}"
+  app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
   app: {{ template "sscd.name" . }}
+  helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Updates Helm chart resources to use recommended/standard labels.  
- Prevents undesired restarts of the secrets-store-csi-driver daemonset when running `helm upgrade --install` due to changing `revision` label.
- ~~Moves SecretProviderClass CRDs to `crds` directory.  Prevents issues when installing on a cluster with pre-existing SecretProviderClass CRDS. (e.g.```Error: UPGRADE FAILED: rendered manifests contain a new resource that already exists. Unable to continue with update: existing resource conflict: namespace: , name: secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io, existing_kind: apiextensions.k8s.io/v1beta1, Kind=CustomResourceDefinition, new_kind: apiextensions.k8s.io/v1beta1, Kind=CustomResourceDefinition```)~~


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #226, Fixes Azure/secrets-store-csi-driver-provider-azure#121

**Special notes for your reviewer**:
- Cannot update daemonset  spec.selector.matchLabels from `app` to `app.kubernetes.io/name` because spec.selector.matchLabels field is immutable.  So the `app` label is maintained for chart backward compatibility with existing releases.
- https://helm.sh/docs/chart_best_practices/labels/#standard-labels
- https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you