### PR TITLE
bug: Make SecretProviderClass Namespaced scoped

### DIFF
--- a/test/bats/tests/nginx-deployment-synck8s-azure-namespace.yaml
+++ b/test/bats/tests/nginx-deployment-synck8s-azure-namespace.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: $CONTAINER_IMAGE
+        name: nginx
+        env:
+        - name: SECRET_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: foosecret
+              key: username
+        volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/mnt/secrets-store"
+          readOnly: true
+      volumes:
+        - name: secrets-store-inline
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "azure-sync"
+              secretProviderClassNamespace: "ns1"
+            nodePublishSecretRef:
+              name: secrets-store-creds


### PR DESCRIPTION
**What this PR does / why we need it**:

-  match SecretProviderClass in the same namespace as the pod.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #60 

**Special notes for your reviewer**: