### PR TITLE
chore: update to livenessprobe v2.0.0

### DIFF
--- a/charts/secrets-store-csi-driver/README.md
+++ b/charts/secrets-store-csi-driver/README.md
@@ -37,5 +37,6 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `windows.nodeSelector` | Node Selector for the daemonset on windows nodes | `{}` |
 | `logLevel.debug` | Enable debug logging | true |
 | `livenessProbe.port` | Liveness probe port | `9808` |
+| `livenessProbe.logLevel` | Liveness probe container logging verbosity level | `2` |
 | `rbac.install` | Install default rbac roles and bindings | true |
 | `minimumProviderVersions` | A comma delimited list of key-value pairs of minimum provider versions with driver | `""` |

--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -89,12 +89,13 @@ spec:
               mountPath: /etc/kubernetes/secrets-store-csi-providers
         {{- if semverCompare ">= v0.0.8-0" .Values.linux.image.tag }}
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: quay.io/k8scsi/livenessprobe:v2.0.0
           imagePullPolicy: Always
           args:
           - --csi-address=/csi/csi.sock
           - --probe-timeout=3s
           - --health-port={{ .Values.livenessProbe.port }}
+          - -v={{ .Values.livenessProbe.logLevel }}
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi

--- a/charts/secrets-store-csi-driver/values.yaml
+++ b/charts/secrets-store-csi-driver/values.yaml
@@ -21,6 +21,7 @@ logLevel:
 
 livenessProbe:
   port: 9808
+  logLevel: 2
 
 ## Install Default RBAC roles and bindings
 rbac:

--- a/deploy/secrets-store-csi-driver.yaml
+++ b/deploy/secrets-store-csi-driver.yaml
@@ -80,12 +80,13 @@ spec:
             - name: providers-dir
               mountPath: /etc/kubernetes/secrets-store-csi-providers
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: quay.io/k8scsi/livenessprobe:v2.0.0
           imagePullPolicy: Always
           args:
           - --csi-address=/csi/csi.sock
           - --probe-timeout=3s
           - --health-port=9808
+          - -v=2
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi


### PR DESCRIPTION
**What this PR does / why we need it**:
- Updates `livenessprobe` container version to `v2.0.0`
- Set log verbosity to 2 for `livenessprobe` container as the frequent health check logs have been set at log level 5 in `v2.0.0`

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #247 

**Special notes for your reviewer**: