### PR TITLE
doc: add release doc and targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,14 +133,14 @@ e2e-teardown:
 .PHONY: install-driver
 install-driver:
 ifdef TEST_WINDOWS
-		helm install csi-secrets-store charts/secrets-store-csi-driver --namespace default --wait --timeout=15m -v=5 --debug \
+		helm install csi-secrets-store manifest_staging/charts/secrets-store-csi-driver --namespace default --wait --timeout=15m -v=5 --debug \
 			--set windows.image.pullPolicy="IfNotPresent" \
 			--set windows.image.repository=$(REGISTRY)/$(IMAGE_NAME) \
 			--set windows.image.tag=$(IMAGE_VERSION) \
 			--set windows.enabled=true \
 			--set linux.enabled=false
 else
-		helm install csi-secrets-store charts/secrets-store-csi-driver --namespace default --wait --timeout=15m -v=5 --debug \
+		helm install csi-secrets-store manifest_staging/charts/secrets-store-csi-driver --namespace default --wait --timeout=15m -v=5 --debug \
 			--set linux.image.pullPolicy="IfNotPresent" \
 			--set linux.image.repository="e2e/secrets-store-csi" \
 			--set linux.image.tag=$(IMAGE_VERSION) \
@@ -163,6 +163,10 @@ manifests: controller-gen
 
 	# generate rbac-secretproviderclass
 	$(KUSTOMIZE) build config/rbac -o manifest_staging/deploy/rbac-secretproviderclass.yaml
+	cp config/rbac/role.yaml config/rbac/role_binding.yaml config/rbac/serviceaccount.yaml manifest_staging/charts/secrets-store-csi-driver/templates/
+	@sed -i '1s/^/{{ if .Values.rbac.install }}\n/gm; $$s/$$/\n{{ end }}/gm' manifest_staging/charts/secrets-store-csi-driver/templates/role.yaml
+	@sed -i '1s/^/{{ if .Values.rbac.install }}\n/gm; s/namespace: .*/namespace: {{ .Release.Namespace }}/gm; $$s/$$/\n{{ end }}/gm' manifest_staging/charts/secrets-store-csi-driver/templates/role_binding.yaml
+	@sed -i '1s/^/{{ if .Values.rbac.install }}\n/gm; s/namespace: .*/namespace: {{ .Release.Namespace }}/gm; $$s/$$/\n{{ include "sscd.labels" . | indent 2 }}\n{{ end }}/gm' manifest_staging/charts/secrets-store-csi-driver/templates/serviceaccount.yaml
 
 # Run go fmt against code
 fmt:
@@ -193,16 +197,17 @@ KUSTOMIZE=$(shell which kustomize)
 endif
 
 release-manifest:
-	@sed -i "s/version: .*/version: ${NEWVERSION}/" charts/secrets-store-csi-driver/Chart.yaml
-	@sed -i "s/appVersion: .*/appVersion: ${NEWVERSION}/" charts/secrets-store-csi-driver/Chart.yaml
-	@sed -i "s/tag: .*/tag: ${NEWVERSION}/" charts/secrets-store-csi-driver/values.yaml
-	@sed -i "s/image tag | .*/image tag | \`${NEWVERSION}\` |/" charts/secrets-store-csi-driver/README.md
 	$(MAKE) manifests
+	@sed -i "s/version: .*/version: ${NEWVERSION}/" manifest_staging/charts/secrets-store-csi-driver/Chart.yaml
+	@sed -i "s/appVersion: .*/appVersion: ${NEWVERSION}/" manifest_staging/charts/secrets-store-csi-driver/Chart.yaml
+	@sed -i "s/tag: .*/tag: ${NEWVERSION}/" manifest_staging/charts/secrets-store-csi-driver/values.yaml
+	@sed -i "s/image tag | .*/image tag | \`${NEWVERSION}\` |/" manifest_staging/charts/secrets-store-csi-driver/README.md
 
 promote-staging-manifest:
+	$(MAKE) release-manifest
 	@rm -rf deploy
 	@cp -r manifest_staging/deploy .
 	@rm -rf charts/secrets-store-csi-driver
-	@cp -r manifest_staging/charts/secrets-store-csi-driver .
+	@cp -r manifest_staging/charts/secrets-store-csi-driver ./charts
 	@helm package ./charts/secrets-store-csi-driver -d ./charts/
 	@helm repo index ./charts --url https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -43,25 +43,21 @@ Publishing involves creating a release tag and creating a new Release on GitHub.
   
 ## Building and releasing
 
-1. Execute the release-patch target to generate patch. Give the semantic version of the release:
-    ```
-   make release-manifests NEWVERSION=v0.0.12
-    ```
-2. Promote staging manifest to release
+1. Execute the promote-staging-manifest target to generate patch and promote staging manifest to release
     ```
    make promote-staging-manifest NEWVERSION=v0.0.12
     ```
-3. Preview the changes
+2. Preview the changes
     ```bash
    git diff
     ```
-4. Commit the changes and push to remote repository to create a pull request
+3. Commit the changes and push to remote repository to create a pull request
     ```
     git checkout -b release-<NEW VERSION>
     git commit -a -s -m "release: update manifests and helm chart for <NEW VERSION>"
     git push <YOUR FORK>
     ```
-5. Once the PR is merged to master, tag master with release version and push tags to remote repository.
+4. Once the PR is merged to master, tag master with release version and push tags to remote repository.
     - An [OWNER](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/OWNERS) runs git tag and pushes the tag with git push
    ```
    git checkout master

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,77 @@
+# Release Process
+
+## Overview
+
+The release process consists of three phases: versioning, building and publishing
+
+Versioning involves maintaining the following files:
+
+- Makefile - the Makefile contains a `VERSION` variable that defines the version of the project.
+- secrets-store-csi-driver.yaml - the Linux driver deployment yaml that contains the latest release tag image of the project.
+- secrets-store-csi-driver-windows.yaml - the Windows driver deployment yaml that contains the latest release tag image of the project.
+- `deploy/` dir that contains all the secrets-store-csi-driver resources to be deployed to the cluster including the latest release tag image of the project.
+
+The steps below explain how to update these files. In addition, the repository should be tagged with the semantic version identifying the release.
+
+Building involves obtaining a copy of the repository and triggering an automatic build as part of the [prow job](https://testgrid.k8s.io/sig-auth-secrets-store-csi-driver#secrets-store-csi-driver-push-image).
+
+Publishing involves creating a release tag and creating a new Release on GitHub.
+
+## Versioning
+
+1. Update the version to the semantic version of the new release similar to [this](https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/251)
+1. Commit the changes and push to remote repository to create a pull request
+
+    ```
+    git checkout -b bump-version-<NEW VERSION>
+    git commit -m "Bump versions for <NEW VERSION"
+    git push <YOUR FORK>
+    ```
+   
+ 1. Once the PR is merged to master, the [prow job](https://testgrid.k8s.io/sig-auth-secrets-store-csi-driver#secrets-store-csi-driver-push-image) is triggered to build and push the new version to staging repo (`gcr.io/k8s-staging-csi-secrets-store/driver`)
+ 1. Once the prow job completes, follow the [instructions](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#image-promoter) to promote the image to production repo
+    - Run generate script to append the new image to promoter manifest
+    ```bash
+    k8s.gcr.io/images/k8s-staging-csi-secrets-store/generate.sh > k8s.gcr.io/images/k8s-staging-csi-secrets-store/images.yaml
+    ```
+    - Preview the changes
+    ```bash
+    git diff
+    ```
+    - Commit the changes and push to remote repository to create a pull request
+  1. Once the image promoter PR is merged, the image will be promoted to prod repo (`us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver`)
+  
+## Building and releasing
+
+1. Execute the release-patch target to generate patch. Give the semantic version of the release:
+    ```
+   make release-manifests NEWVERSION=v0.0.12
+    ```
+2. Promote staging manifest to release
+    ```
+   make promote-staging-manifest NEWVERSION=v0.0.12
+    ```
+3. Preview the changes
+    ```bash
+   git diff
+    ```
+4. Commit the changes and push to remote repository to create a pull request
+    ```
+    git checkout -b release-<NEW VERSION>
+    git commit -a -s -m "release: update manifests and helm chart for <NEW VERSION>"
+    git push <YOUR FORK>
+    ```
+5. Once the PR is merged to master, tag master with release version and push tags to remote repository.
+    - An [OWNER](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/OWNERS) runs git tag and pushes the tag with git push
+   ```
+   git checkout master
+   git pull origin master
+   git tag -a <NEW VERSION> -m '<NEW VERSION>'
+   git push origin <NEW VERSION>
+   ```
+
+## Publishing
+
+1. Create a draft release in GitHub and associate it with the tag that was just created
+1. Write the release notes similar to [this](https://github.com/kubernetes-sigs/secrets-store-csi-driver/releases/tag/v0.0.12) and upload all the artifacts from the `deploy/` dir
+1. Publish release

--- a/manifest_staging/charts/secrets-store-csi-driver/Chart.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: secrets-store-csi-driver
+version: 0.0.12
+appVersion: 0.0.12
+kubeVersion: ">=1.15.0-0"
+description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
+icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
+sources:
+  - https://github.com/kubernetes-sigs/secrets-store-csi-driver
+maintainers:
+  - name: Rita Zhang
+    email: ritazh@microsoft.com

--- a/manifest_staging/charts/secrets-store-csi-driver/README.md
+++ b/manifest_staging/charts/secrets-store-csi-driver/README.md
@@ -1,0 +1,42 @@
+# secrets-store-csi-driver
+
+## Installation
+
+Quick start instructions for the setup and configuration of secrets-store-csi-driver using Helm.
+
+### Prerequisites
+
+- [Helm v3.0+](https://helm.sh/docs/intro/quickstart/#install-helm)
+
+### Installing the chart
+
+```bash
+$ helm repo add secrets-store-csi-driver https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
+$ helm install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver
+```
+
+### Configuration
+
+The following table lists the configurable parameters of the csi-secrets-store-provider-azure chart and their default values.
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `nameOverride` | String to partially override secrets-store-csi-driver.fullname template with a string (will prepend the release name) | `""` |
+| `fullnameOverride` | String to fully override secrets-store-csi-driver.fullname template with a string | `""` |
+| `linux.image.repository` | Linux image repository | `us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver` |
+| `linux.image.pullPolicy` | Linux image pull policy | `Always` |
+| `linux.image.tag` | Linux image tag | `v0.0.12` |
+| `linux.enabled` | Install secrets store csi driver on linux nodes | true |
+| `linux.kubeletRootDir` | Configure the kubelet root dir | `/var/lib/kubelet` |
+| `linux.nodeSelector` | Node Selector for the daemonset on linux nodes | `{}` |
+| `windows.image.repository` | Windows image repository | `us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver` |
+| `windows.image.pullPolicy` | Windows image pull policy | `IfNotPresent` |
+| `windows.image.tag` | Windows image tag | `v0.0.12` |
+| `windows.enabled` | Install secrets store csi driver on windows nodes | false |
+| `windows.kubeletRootDir` | Configure the kubelet root dir | `C:\var\lib\kubelet` |
+| `windows.nodeSelector` | Node Selector for the daemonset on windows nodes | `{}` |
+| `logLevel.debug` | Enable debug logging | true |
+| `livenessProbe.port` | Liveness probe port | `9808` |
+| `livenessProbe.logLevel` | Liveness probe container logging verbosity level | `2` |
+| `rbac.install` | Install default rbac roles and bindings | true |
+| `minimumProviderVersions` | A comma delimited list of key-value pairs of minimum provider versions with driver | `""` |

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/NOTES.txt
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/NOTES.txt
@@ -1,0 +1,8 @@
+The Secrets Store CSI Driver is getting deployed to your cluster.
+
+To verify that Secrets Store CSI Driver has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "sscd.name" . }}"
+
+Now you can follow these steps https://github.com/kubernetes-sigs/secrets-store-csi-driver#use-the-secrets-store-csi-driver
+to create a SecretProviderClass resource, and a deployment using the SecretProviderClass.

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/_helpers.tpl
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sscd.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sscd.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Standard labels for helm resources
+*/}}
+{{- define "sscd.labels" -}}
+labels:
+  heritage: "{{ .Release.Service }}"
+  release: "{{ .Release.Name }}"
+  revision: "{{ .Release.Revision }}"
+  chart: "{{ .Chart.Name }}"
+  chartVersion: "{{ .Chart.Version }}"
+  app: {{ template "sscd.name" . }}
+{{- end -}}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/csidriver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/csidriver.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: secrets-store.csi.k8s.io
+spec:
+  podInfoOnMount: true
+  attachRequired: false
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.Version }}
+  # Added in Kubernetes 1.16 with default mode of Persistent. Secrets store csi driver needs Ephermeral to be set.
+  volumeLifecycleModes: 
+  - Ephemeral
+{{ end }}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/role.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/role.yaml
@@ -1,0 +1,58 @@
+{{ if .Values.rbac.install }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secretproviderclasses-role
+rules:
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses/status
+  verbs:
+  - get
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+  - patch
+  - watch
+  - list
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasspodstatuses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasspodstatuses/status
+  verbs:
+  - get
+  - update
+  - patch
+{{ end }}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/role_binding.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/role_binding.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.rbac.install }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: secretproviderclasses-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secretproviderclasses-role
+subjects:
+- kind: ServiceAccount
+  name: secrets-store-csi-driver
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -1,0 +1,122 @@
+{{- if .Values.windows.enabled}}
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: {{ template "sscd.fullname" . }}-windows
+  namespace: {{ .Release.Namespace }}
+{{ include "sscd.labels" . | indent 2 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "sscd.name" . }}
+  template:
+    metadata:
+{{ include "sscd.labels" . | indent 6 }}
+    spec:
+      serviceAccountName: secrets-store-csi-driver
+      containers:
+        - name: node-driver-registrar
+          image: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.2.1-alpha.1-windows-1809-amd64
+          args:
+            - --v=5
+            - "--csi-address=unix://C:\\csi\\csi.sock"
+            - --kubelet-registration-path={{ .Values.windows.kubeletRootDir }}\plugins\csi-secrets-store\csi.sock
+          lifecycle:
+              preStop:
+                exec:
+                  command:
+                    [
+                      "cmd",
+                      "/c",
+                      "del /f C:\\registration\\secrets-store.csi.k8s.io-reg.sock",
+                    ]
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: C:\csi
+            - name: registration-dir
+              mountPath: C:\registration
+        - name: secrets-store
+          image: "{{ .Values.windows.image.repository }}:{{ .Values.windows.image.tag }}"
+          args:
+            - "--debug={{ .Values.logLevel.debug }}"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+            - "--provider-volume=C:\\k\\secrets-store-csi-providers"
+            {{- if and (semverCompare ">= v0.0.9-0" .Values.windows.image.tag) .Values.minimumProviderVersions }}
+            - "--min-provider-version={{ .Values.minimumProviderVersions }}"
+            {{- end }}
+          env:
+            - name: CSI_ENDPOINT
+              value: unix://C:\\csi\\csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          imagePullPolicy: {{ .Values.windows.image.pullPolicy }}
+          securityContext:
+            privileged: true
+          {{- if semverCompare ">= v0.0.9-0" .Values.windows.image.tag }}
+          ports:
+            - containerPort: {{ .Values.livenessProbe.port }}
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+              failureThreshold: 5
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 30
+              timeoutSeconds: 10
+              periodSeconds: 15
+          {{- end }}
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: C:\csi
+            - name: mountpoint-dir
+              mountPath: {{ .Values.windows.kubeletRootDir }}\pods
+              mountPropagation: Bidirectional
+            - name: providers-dir
+              mountPath: C:\k\secrets-store-csi-providers
+        {{- if semverCompare ">= v0.0.9-0" .Values.windows.image.tag }}
+        - name: liveness-probe
+          image: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.0.1-alpha.1-windows-1809-amd64
+          imagePullPolicy: Always
+          args:
+          - "--csi-address=unix://C:\\csi\\csi.sock"
+          - --probe-timeout=3s
+          - --health-port={{ .Values.livenessProbe.port }}
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: C:\csi
+        {{- end }}
+      volumes:
+        - name: mountpoint-dir
+          hostPath:
+            path: {{ .Values.windows.kubeletRootDir }}\pods\
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: {{ .Values.windows.kubeletRootDir }}\plugins_registry\
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: {{ .Values.windows.kubeletRootDir }}\plugins\csi-secrets-store\
+            type: DirectoryOrCreate
+        - name: providers-dir
+          hostPath:
+            path: C:\k\secrets-store-csi-providers\
+            type: DirectoryOrCreate
+      nodeSelector:
+        kubernetes.io/os: windows
+{{- if .Values.windows.nodeSelector }}
+{{- toYaml .Values.windows.nodeSelector | nindent 8 }}
+{{- end }}
+{{- end -}}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.linux.enabled}}
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: {{ template "sscd.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{ include "sscd.labels" . | indent 2 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "sscd.name" . }}
+  template:
+    metadata:
+{{ include "sscd.labels" . | indent 6 }}
+    spec:
+      serviceAccountName: secrets-store-csi-driver
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path={{ .Values.linux.kubeletRootDir }}/plugins/csi-secrets-store/csi.sock
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  [
+                    "/bin/sh",
+                    "-c",
+                    "rm -rf /registration/secrets-store.csi.k8s.io-reg.sock",
+                  ]
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: secrets-store
+          image: "{{ .Values.linux.image.repository }}:{{ .Values.linux.image.tag }}"
+          args:
+            - "--debug={{ .Values.logLevel.debug }}"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+            - "--provider-volume=/etc/kubernetes/secrets-store-csi-providers"
+            {{- if and (semverCompare ">= v0.0.8-0" .Values.linux.image.tag) .Values.minimumProviderVersions }}
+            - "--min-provider-version={{ .Values.minimumProviderVersions }}"
+            {{- end }}
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          imagePullPolicy: {{ .Values.linux.image.pullPolicy }}
+          securityContext:
+            privileged: true
+          {{- if semverCompare ">= v0.0.8-0" .Values.linux.image.tag }}
+          ports:
+            - containerPort: {{ .Values.livenessProbe.port }}
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+              failureThreshold: 5
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 30
+              timeoutSeconds: 10
+              periodSeconds: 15
+          {{- end }}
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: mountpoint-dir
+              mountPath: {{ .Values.linux.kubeletRootDir }}/pods
+              mountPropagation: Bidirectional
+            - name: providers-dir
+              mountPath: /etc/kubernetes/secrets-store-csi-providers
+        {{- if semverCompare ">= v0.0.8-0" .Values.linux.image.tag }}
+        - name: liveness-probe
+          image: quay.io/k8scsi/livenessprobe:v2.0.0
+          imagePullPolicy: Always
+          args:
+          - --csi-address=/csi/csi.sock
+          - --probe-timeout=3s
+          - --health-port={{ .Values.livenessProbe.port }}
+          - -v={{ .Values.livenessProbe.logLevel }}
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+        {{- end }}
+      volumes:
+        - name: mountpoint-dir
+          hostPath:
+            path: {{ .Values.linux.kubeletRootDir }}/pods
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: {{ .Values.linux.kubeletRootDir }}/plugins_registry/
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: {{ .Values.linux.kubeletRootDir }}/plugins/csi-secrets-store/
+            type: DirectoryOrCreate
+        - name: providers-dir
+          hostPath:
+            path: /etc/kubernetes/secrets-store-csi-providers
+            type: DirectoryOrCreate
+      nodeSelector:
+        kubernetes.io/os: linux
+{{- if .Values.linux.nodeSelector }}
+{{- toYaml .Values.linux.nodeSelector | nindent 8 }}
+{{- end }}
+{{- end -}}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -1,0 +1,101 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: secretproviderclasses.secrets-store.csi.x-k8s.io
+spec:
+  group: secrets-store.csi.x-k8s.io
+  names:
+    kind: SecretProviderClass
+    listKind: SecretProviderClassList
+    plural: secretproviderclasses
+    singular: secretproviderclass
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: SecretProviderClass is the Schema for the secretproviderclasses
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SecretProviderClassSpec defines the desired state of SecretProviderClass
+          properties:
+            parameters:
+              additionalProperties:
+                type: string
+              description: Configuration for specific provider
+              type: object
+            provider:
+              description: Configuration for provider name
+              type: string
+            secretObjects:
+              items:
+                description: SecretObject defines the desired state of synced K8s
+                  secret objects
+                properties:
+                  data:
+                    items:
+                      description: SecretObjectData defines the desired state of synced
+                        K8s secret object data
+                      properties:
+                        key:
+                          description: data field to populate
+                          type: string
+                        objectName:
+                          description: name of the object to sync
+                          type: string
+                      type: object
+                    type: array
+                  secretName:
+                    description: name of the K8s secret object
+                    type: string
+                  type:
+                    description: type of K8s secret object
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          description: SecretProviderClassStatus defines the observed state of SecretProviderClass
+          properties:
+            byPod:
+              items:
+                description: ByPodStatus defines the state of SecretProviderClass
+                  as seen by an individual controller
+                properties:
+                  id:
+                    description: id of the pod that wrote the status
+                    type: string
+                  namespace:
+                    description: namespace of the pod that wrote the status
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
@@ -1,0 +1,61 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io
+spec:
+  group: secrets-store.csi.x-k8s.io
+  names:
+    kind: SecretProviderClassPodStatus
+    listKind: SecretProviderClassPodStatusList
+    plural: secretproviderclasspodstatuses
+    singular: secretproviderclasspodstatus
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: SecretProviderClassPodStatus is the Schema for the secretproviderclassespodstatus
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        status:
+          description: SecretProviderClassPodStatusStatus defines the observed state
+            of SecretProviderClassPodStatus
+          properties:
+            mounted:
+              type: boolean
+            podName:
+              type: string
+            podUID:
+              type: string
+            secretProviderClassName:
+              type: string
+            targetPath:
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/serviceaccount.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{ if .Values.rbac.install }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secrets-store-csi-driver
+  namespace: {{ .Release.Namespace }}
+{{ include "sscd.labels" . | indent 2 }}
+{{ end }}

--- a/manifest_staging/charts/secrets-store-csi-driver/values.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/values.yaml
@@ -1,0 +1,33 @@
+linux:
+  enabled: true
+  image:
+    repository: us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver
+    tag: v0.0.12
+    pullPolicy: Always
+  kubeletRootDir: /var/lib/kubelet
+  nodeSelector: {}
+
+windows:
+  enabled: false
+  image:
+    repository: us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver
+    tag: v0.0.12
+    pullPolicy: IfNotPresent
+  kubeletRootDir: C:\var\lib\kubelet
+  nodeSelector: {}
+
+logLevel:
+  debug: true
+
+livenessProbe:
+  port: 9808
+  logLevel: 2
+
+## Install Default RBAC roles and bindings
+rbac:
+  install: true
+
+## Minimum Provider Versions (optional)
+## A comma delimited list of key-value pairs of minimum provider versions
+## e.g. provider1=0.0.2,provider2=0.0.3
+minimumProviderVersions:

--- a/manifest_staging/deploy/csidriver-1.15.yaml
+++ b/manifest_staging/deploy/csidriver-1.15.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: secrets-store.csi.k8s.io
+spec:
+  podInfoOnMount: true
+  attachRequired: false

--- a/manifest_staging/deploy/csidriver.yaml
+++ b/manifest_staging/deploy/csidriver.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: secrets-store.csi.k8s.io
+spec:
+  podInfoOnMount: true
+  attachRequired: false
+  volumeLifecycleModes:
+  - Ephemeral

--- a/manifest_staging/deploy/rbac-secretproviderclass.yaml
+++ b/manifest_staging/deploy/rbac-secretproviderclass.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secrets-store-csi-driver
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: secretproviderclasses-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secretproviderclasses-role
+subjects:
+- kind: ServiceAccount
+  name: secrets-store-csi-driver
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secretproviderclasses-role
+rules:
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses/status
+  verbs:
+  - get
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+  - patch
+  - list
+  - watch
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasspodstatuses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasspodstatuses/status
+  verbs:
+  - get
+  - update
+  - patch

--- a/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
@@ -1,0 +1,109 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-secrets-store-windows
+spec:
+  selector:
+    matchLabels:
+      app: csi-secrets-store
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store
+    spec:
+      serviceAccountName: secrets-store-csi-driver
+      containers:
+        - name: node-driver-registrar
+          image: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.2.1-alpha.1-windows-1809-amd64
+          args:
+            - --v=5
+            - "--csi-address=unix://C:\\csi\\csi.sock"
+            - "--kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\csi-secrets-store\\csi.sock"
+          lifecycle:
+              preStop:
+                exec:
+                  command:
+                    [
+                      "cmd",
+                      "/c",
+                      "del /f C:\\registration\\secrets-store.csi.k8s.io-reg.sock",
+                    ]
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: C:\csi
+            - name: registration-dir
+              mountPath: C:\registration
+        - name: secrets-store
+          image: us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver:v0.0.12
+          args:
+            - "--debug=true"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+            - "--provider-volume=C:\\k\\secrets-store-csi-providers"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix://C:\\csi\\csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+              failureThreshold: 5
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 30
+              timeoutSeconds: 10
+              periodSeconds: 15
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: C:\csi
+            - name: mountpoint-dir
+              mountPath: "C:\\var\\lib\\kubelet\\pods"
+              mountPropagation: Bidirectional
+            - name: providers-dir
+              mountPath: C:\k\secrets-store-csi-providers
+        - name: liveness-probe
+          image: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.0.1-alpha.1-windows-1809-amd64
+          imagePullPolicy: IfNotPresent
+          args:
+          - "--csi-address=unix://C:\\csi\\csi.sock"
+          - --probe-timeout=3s
+          - --health-port=9808
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: C:\csi
+      volumes:
+        - name: mountpoint-dir
+          hostPath:
+            path: C:\var\lib\kubelet\pods\
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: C:\var\lib\kubelet\plugins_registry\
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: C:\var\lib\kubelet\plugins\csi-secrets-store\
+            type: DirectoryOrCreate
+        - name: providers-dir
+          hostPath:
+            path: C:\k\secrets-store-csi-providers\
+            type: DirectoryOrCreate
+      nodeSelector:
+        kubernetes.io/os: windows

--- a/manifest_staging/deploy/secrets-store-csi-driver.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver.yaml
@@ -1,0 +1,111 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-secrets-store
+spec:
+  selector:
+    matchLabels:
+      app: csi-secrets-store
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store
+    spec:
+      serviceAccountName: secrets-store-csi-driver
+      hostNetwork: true
+      containers:
+        - name: node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-secrets-store/csi.sock
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  [
+                    "/bin/sh",
+                    "-c",
+                    "rm -rf /registration/secrets-store.csi.k8s.io-reg.sock",
+                  ]
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: secrets-store
+          image: us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver:v0.0.12
+          args:
+            - "--debug=true"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+            - "--provider-volume=/etc/kubernetes/secrets-store-csi-providers"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          ports:
+            - containerPort: 9808
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+              failureThreshold: 5
+              httpGet:
+                path: /healthz
+                port: healthz
+              initialDelaySeconds: 30
+              timeoutSeconds: 10
+              periodSeconds: 15
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+            - name: providers-dir
+              mountPath: /etc/kubernetes/secrets-store-csi-providers
+        - name: liveness-probe
+          image: quay.io/k8scsi/livenessprobe:v2.0.0
+          imagePullPolicy: Always
+          args:
+          - --csi-address=/csi/csi.sock
+          - --probe-timeout=3s
+          - --health-port=9808
+          - -v=2
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+      volumes:
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi-secrets-store/
+            type: DirectoryOrCreate
+        - name: providers-dir
+          hostPath:
+            path: /etc/kubernetes/secrets-store-csi-providers
+            type: DirectoryOrCreate
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -1,0 +1,101 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: secretproviderclasses.secrets-store.csi.x-k8s.io
+spec:
+  group: secrets-store.csi.x-k8s.io
+  names:
+    kind: SecretProviderClass
+    listKind: SecretProviderClassList
+    plural: secretproviderclasses
+    singular: secretproviderclass
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: SecretProviderClass is the Schema for the secretproviderclasses
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SecretProviderClassSpec defines the desired state of SecretProviderClass
+          properties:
+            parameters:
+              additionalProperties:
+                type: string
+              description: Configuration for specific provider
+              type: object
+            provider:
+              description: Configuration for provider name
+              type: string
+            secretObjects:
+              items:
+                description: SecretObject defines the desired state of synced K8s
+                  secret objects
+                properties:
+                  data:
+                    items:
+                      description: SecretObjectData defines the desired state of synced
+                        K8s secret object data
+                      properties:
+                        key:
+                          description: data field to populate
+                          type: string
+                        objectName:
+                          description: name of the object to sync
+                          type: string
+                      type: object
+                    type: array
+                  secretName:
+                    description: name of the K8s secret object
+                    type: string
+                  type:
+                    description: type of K8s secret object
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          description: SecretProviderClassStatus defines the observed state of SecretProviderClass
+          properties:
+            byPod:
+              items:
+                description: ByPodStatus defines the state of SecretProviderClass
+                  as seen by an individual controller
+                properties:
+                  id:
+                    description: id of the pod that wrote the status
+                    type: string
+                  namespace:
+                    description: namespace of the pod that wrote the status
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+++ b/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
@@ -1,0 +1,61 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io
+spec:
+  group: secrets-store.csi.x-k8s.io
+  names:
+    kind: SecretProviderClassPodStatus
+    listKind: SecretProviderClassPodStatusList
+    plural: secretproviderclasspodstatuses
+    singular: secretproviderclasspodstatus
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: SecretProviderClassPodStatus is the Schema for the secretproviderclassespodstatus
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        status:
+          description: SecretProviderClassPodStatusStatus defines the observed state
+            of SecretProviderClassPodStatus
+          properties:
+            mounted:
+              type: boolean
+            podName:
+              type: string
+            podUID:
+              type: string
+            secretProviderClassName:
+              type: string
+            targetPath:
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds docs for release process, some helper targets to run as part of generating the helm charts and release manifests.
- Adds `manifest_staging` dir to stage deployment manifest changes required for next release. There is no charts dir here, as new flags for helm charts can be added by wrapping them in conditionals similar to [this](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml#L54-L56). The helm charts are always used to test PRs and master.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #201 

**Special notes for your reviewer**:

/kind documentation