### PR TITLE
helm: make all images configurable

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/README.md
+++ b/manifest_staging/charts/secrets-store-csi-driver/README.md
@@ -31,6 +31,12 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `linux.nodeSelector` | Node Selector for the daemonset on linux nodes | `{}` |
 | `linux.tolerations` | Tolerations for the daemonset on linux nodes | `[]` |
 | `linux.metricsAddr` | The address the metric endpoint binds to | `:8080` |
+| `linux.registrarImage.repository` | Linux node-driver-registrar image repository | `quay.io/k8scsi/csi-node-driver-registrar` |
+| `linux.registrarImage.pullPolicy` | Linux node-driver-registrar image pull policy | `Always` |
+| `linux.registrarImage.tag` | Linux node-driver-registrar image tag | `v1.2.0` |
+| `linux.livenessProbeImage.repository` | Linux liveness-probe image repository | `quay.io/k8scsi/livenessprobe` |
+| `linux.livenessProbeImage.pullPolicy` | Linux liveness-probe image pull policy | `Always` |
+| `linux.livenessProbeImage.tag` | Linux liveness-probe image tag | `v2.0.0` |
 | `windows.image.repository` | Windows image repository | `us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver` |
 | `windows.image.pullPolicy` | Windows image pull policy | `IfNotPresent` |
 | `windows.image.tag` | Windows image tag | `v0.0.12` |
@@ -39,6 +45,12 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `windows.nodeSelector` | Node Selector for the daemonset on windows nodes | `{}` |
 | `windows.tolerations` | Tolerations for the daemonset on windows nodes | `[]` |
 | `windows.metricsAddr` | The address the metric endpoint binds to | `:8080` |
+| `windows.registrarImage.repository` | Windows node-driver-registrar image repository | `mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar` |
+| `windows.registrarImage.pullPolicy` | Windows node-driver-registrar image pull policy | `Always` |
+| `windows.registrarImage.tag` | Windows node-driver-registrar image tag | `v1.2.1-alpha.1-windows-1809-amd64` |
+| `windows.livenessProbeImage.repository` | Windows liveness-probe image repository | `mcr.microsoft.com/oss/kubernetes-csi/livenessprobe` |
+| `windows.livenessProbeImage.pullPolicy` | Windows liveness-probe image pull policy | `Always` |
+| `windows.livenessProbeImage.tag` | Windows liveness-probe image tag | `v2.0.1-alpha.1-windows-1809-amd64` |
 | `logLevel.debug` | Enable debug logging | true |
 | `livenessProbe.port` | Liveness probe port | `9808` |
 | `livenessProbe.logLevel` | Liveness probe container logging verbosity level | `2` |

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: secrets-store-csi-driver
       containers:
         - name: node-driver-registrar
-          image: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.2.1-alpha.1-windows-1809-amd64
+          image: "{{ .Values.windows.registrarImage.repository }}:{{ .Values.windows.registrarImage.tag }}"
           args:
             - --v=5
             - "--csi-address=unix://C:\\csi\\csi.sock"
@@ -36,7 +36,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.windows.registrarImage.pullPolicy }}
           volumeMounts:
             - name: plugin-dir
               mountPath: C:\csi
@@ -88,8 +88,8 @@ spec:
               mountPath: C:\k\secrets-store-csi-providers
         {{- if semverCompare ">= v0.0.9-0" .Values.windows.image.tag }}
         - name: liveness-probe
-          image: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.0.1-alpha.1-windows-1809-amd64
-          imagePullPolicy: Always
+          image: "{{ .Values.windows.livenessProbeImage.repository }}:{{ .Values.windows.livenessProbeImage.tag }}"
+          imagePullPolicy: {{ .Values.windows.livenessProbeImage.pullPolicy }}
           args:
           - "--csi-address=unix://C:\\csi\\csi.sock"
           - --probe-timeout=3s

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -18,7 +18,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          image: "{{ .Values.linux.registrarImage.repository }}:{{ .Values.linux.registrarImage.tag }}"
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -38,7 +38,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.linux.registrarImage.pullPolicy }}
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
@@ -90,8 +90,8 @@ spec:
               mountPath: /etc/kubernetes/secrets-store-csi-providers
         {{- if semverCompare ">= v0.0.8-0" .Values.linux.image.tag }}
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.0.0
-          imagePullPolicy: Always
+          image: "{{ .Values.linux.livenessProbeImage.repository }}:{{ .Values.linux.livenessProbeImage.tag }}"
+          imagePullPolicy: {{ .Values.linux.livenessProbeImage.pullPolicy }}
           args:
           - --csi-address=/csi/csi.sock
           - --probe-timeout=3s

--- a/manifest_staging/charts/secrets-store-csi-driver/values.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/values.yaml
@@ -4,6 +4,14 @@ linux:
     repository: us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver
     tag: v0.0.12
     pullPolicy: Always
+  registrarImage:
+    repository: quay.io/k8scsi/csi-node-driver-registrar
+    tag: v1.2.0
+    pullPolicy: Always
+  livenessProbeImage:
+    repository: quay.io/k8scsi/livenessprobe
+    tag: v2.0.0
+    pullPolicy: Always
   kubeletRootDir: /var/lib/kubelet
   nodeSelector: {}
   tolerations: []
@@ -15,6 +23,14 @@ windows:
     repository: us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver
     tag: v0.0.12
     pullPolicy: IfNotPresent
+  registrarImage:
+    repository: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar
+    tag: v1.2.1-alpha.1-windows-1809-amd64
+    pullPolicy: Always
+  livenessProbeImage:
+    repository: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe
+    tag: v2.0.1-alpha.1-windows-1809-amd64
+    pullPolicy: Always
   kubeletRootDir: C:\var\lib\kubelet
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows to configure all the image repositories if needed. For our container platfom only containers from private registries are allowed.

fixes https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/255