### PR TITLE
test: add tests for multiple secret provider class

### DIFF
--- a/test/bats/tests/azure/azure_v1alpha1_multiple_secretproviderclass.yaml
+++ b/test/bats/tests/azure/azure_v1alpha1_multiple_secretproviderclass.yaml
@@ -1,0 +1,55 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: azure-spc-0
+spec:
+  provider: azure
+  secretObjects:
+  - secretName: foosecret-0
+    type: Opaque
+    data: 
+    - objectName: secretalias
+      key: username
+  parameters:
+    usePodIdentity: "false"
+    keyvaultName: "$KEYVAULT_NAME"
+    objects: |
+      array:
+        - |
+          objectName: $SECRET_NAME
+          objectType: secret
+          objectVersion: $SECRET_VERSION
+          objectAlias: secretalias
+        - |
+          objectName: $KEY_NAME
+          objectType: key
+          objectVersion: $KEY_VERSION
+    tenantId: "$TENANT_ID"
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: azure-spc-1
+spec:
+  provider: azure
+  secretObjects:
+  - secretName: foosecret-1
+    type: Opaque
+    data: 
+    - objectName: secretalias
+      key: username
+  parameters:
+    usePodIdentity: "false"
+    keyvaultName: "$KEYVAULT_NAME"
+    objects: |
+      array:
+        - |
+          objectName: $SECRET_NAME
+          objectType: secret
+          objectVersion: $SECRET_VERSION
+          objectAlias: secretalias
+        - |
+          objectName: $KEY_NAME
+          objectType: key
+          objectVersion: $KEY_VERSION
+    tenantId: "$TENANT_ID"

--- a/test/bats/tests/azure/nginx-pod-azure-inline-volume-multiple-spc.yaml
+++ b/test/bats/tests/azure/nginx-pod-azure-inline-volume-multiple-spc.yaml
@@ -1,0 +1,43 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: nginx-secrets-store-inline-multiple-crd
+spec:
+  containers:
+  - image: $CONTAINER_IMAGE
+    name: nginx
+    volumeMounts:
+    - name: secrets-store-inline-0
+      mountPath: "/mnt/secrets-store-0"
+      readOnly: true
+    - name: secrets-store-inline-1
+      mountPath: "/mnt/secrets-store-1"
+      readOnly: true
+    env:
+    - name: SECRET_USERNAME_0
+      valueFrom:
+        secretKeyRef:
+          name: foosecret-0
+          key: username
+    - name: SECRET_USERNAME_1
+      valueFrom:
+        secretKeyRef:
+          name: foosecret-1
+          key: username
+  volumes:
+    - name: secrets-store-inline-0
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "azure-spc-0"
+        nodePublishSecretRef:
+          name: secrets-store-creds
+    - name: secrets-store-inline-1
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "azure-spc-1"
+        nodePublishSecretRef:
+          name: secrets-store-creds

--- a/test/bats/tests/vault/nginx-pod-vault-inline-volume-multiple-spc.yaml
+++ b/test/bats/tests/vault/nginx-pod-vault-inline-volume-multiple-spc.yaml
@@ -1,0 +1,39 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: nginx-secrets-store-inline-multiple-crd
+spec:
+  containers:
+  - image: $CONTAINER_IMAGE
+    name: nginx
+    volumeMounts:
+    - name: secrets-store-inline-0
+      mountPath: "/mnt/secrets-store-0"
+      readOnly: true
+    - name: secrets-store-inline-1
+      mountPath: "/mnt/secrets-store-1"
+      readOnly: true
+    env:
+    - name: SECRET_USERNAME_0
+      valueFrom:
+        secretKeyRef:
+          name: foosecret-0
+          key: username
+    - name: SECRET_USERNAME_1
+      valueFrom:
+        secretKeyRef:
+          name: foosecret-1
+          key: username
+  volumes:
+    - name: secrets-store-inline-0
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "vault-foo-sync-0"
+    - name: secrets-store-inline-1
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "vault-foo-sync-1"

--- a/test/bats/tests/vault/vault_v1alpha1_multiple_secretproviderclass.yaml
+++ b/test/bats/tests/vault/vault_v1alpha1_multiple_secretproviderclass.yaml
@@ -1,0 +1,57 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: vault-foo-sync-0
+spec:
+  provider: vault
+  secretObjects:
+  - secretName: foosecret-0
+    type: Opaque
+    data: 
+    - objectName: foo
+      key: pwd
+    - objectName: foo1
+      key: username
+  parameters:
+    roleName: "example-role"
+    vaultAddress: http://${VAULT_SERVICE_IP}:8200
+    vaultSkipTLSVerify: "true"
+    objects:  |
+      array:
+        - |
+          objectPath: "/foo"
+          objectName: "bar"
+          objectVersion: ""
+        - |
+          objectPath: "/foo1"
+          objectName: "bar"
+          objectVersion: ""
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: vault-foo-sync-1
+spec:
+  provider: vault
+  secretObjects:
+  - secretName: foosecret-1
+    type: Opaque
+    data: 
+    - objectName: foo
+      key: pwd
+    - objectName: foo1
+      key: username
+  parameters:
+    roleName: "example-role"
+    vaultAddress: http://${VAULT_SERVICE_IP}:8200
+    vaultSkipTLSVerify: "true"
+    objects:  |
+      array:
+        - |
+          objectPath: "/foo"
+          objectName: "bar"
+          objectVersion: ""
+        - |
+          objectPath: "/foo1"
+          objectName: "bar"
+          objectVersion: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
With the introduction of new reconciler for creating k8s secrets, multiple `SecretProviderClass` for secret objects is handled. Adding e2e tests as part of this PR to CI.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #187 

**Special notes for your reviewer**: