### PR TITLE
roles: split secret sync a separate role: secretprovidersyncing-role

### DIFF
--- a/config/rbac-syncsecret/kustomization.yaml
+++ b/config/rbac-syncsecret/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- role.yaml
+- role_binding.yaml

--- a/config/rbac-syncsecret/role.yaml
+++ b/config/rbac-syncsecret/role.yaml
@@ -1,0 +1,20 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: secretprovidersyncing-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/rbac-syncsecret/role_binding.yaml
+++ b/config/rbac-syncsecret/role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: secretprovidersyncing-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secretprovidersyncing-role
+subjects:
+- kind: ServiceAccount
+  name: secrets-store-csi-driver
+  namespace: default

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,18 +7,6 @@ metadata:
   name: secretproviderclasses-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - secrets-store.csi.x-k8s.io
   resources:
   - secretproviderclasses

--- a/controllers/secretproviderclasspodstatus_controller.go
+++ b/controllers/secretproviderclasspodstatus_controller.go
@@ -60,7 +60,6 @@ type SecretProviderClassPodStatusReconciler struct {
 // +kubebuilder:rbac:groups=secrets-store.csi.x-k8s.io,resources=secretproviderclasspodstatuses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=secrets-store.csi.x-k8s.io,resources=secretproviderclasspodstatuses/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=secrets-store.csi.x-k8s.io,resources=secretproviderclasses,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 func (r *SecretProviderClassPodStatusReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()

--- a/controllers/syncsecret/syncsecret.go
+++ b/controllers/syncsecret/syncsecret.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package syncsecret holds the RBAC permission annotations for the controller
+// to sync k8s secrets so that they can be built and applied separately.
+package syncsecret
+
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete

--- a/manifest_staging/charts/secrets-store-csi-driver/README.md
+++ b/manifest_staging/charts/secrets-store-csi-driver/README.md
@@ -57,4 +57,5 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `livenessProbe.port` | Liveness probe port | `9808` |
 | `livenessProbe.logLevel` | Liveness probe container logging verbosity level | `2` |
 | `rbac.install` | Install default rbac roles and bindings | true |
+| `syncSecret.enabled` | Enable rbac roles and bindings required for syncing to Kubernetes native secrets (the default will change to false after v0.0.14) | true |
 | `minimumProviderVersions` | A comma delimited list of key-value pairs of minimum provider versions with driver | `""` |

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/role-syncsecret.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/role-syncsecret.yaml
@@ -1,0 +1,22 @@
+{{ if .Values.syncSecret.enabled }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: secretprovidersyncing-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{ end }}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/role-syncsecret_binding.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/role-syncsecret_binding.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.syncSecret.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: secretprovidersyncing-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secretprovidersyncing-role
+subjects:
+- kind: ServiceAccount
+  name: secrets-store-csi-driver
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/role.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/role.yaml
@@ -8,18 +8,6 @@ metadata:
   name: secretproviderclasses-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - secrets-store.csi.x-k8s.io
   resources:
   - secretproviderclasses

--- a/manifest_staging/charts/secrets-store-csi-driver/values.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/values.yaml
@@ -49,6 +49,11 @@ livenessProbe:
 rbac:
   install: true
 
+## Install RBAC roles and bindings required for K8S Secrets syncing. Change this
+## to false after v0.0.14
+syncSecret:
+  enabled: true
+
 ## Minimum Provider Versions (optional)
 ## A comma delimited list of key-value pairs of minimum provider versions
 ## e.g. provider1=0.0.2,provider2=0.0.3

--- a/manifest_staging/deploy/rbac-secretproviderclass.yaml
+++ b/manifest_staging/deploy/rbac-secretproviderclass.yaml
@@ -11,18 +11,6 @@ metadata:
   name: secretproviderclasses-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - secrets-store.csi.x-k8s.io
   resources:
   - secretproviderclasses

--- a/manifest_staging/deploy/rbac-secretprovidersyncing.yaml
+++ b/manifest_staging/deploy/rbac-secretprovidersyncing.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: secretprovidersyncing-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: secretprovidersyncing-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secretprovidersyncing-role
+subjects:
+- kind: ServiceAccount
+  name: secrets-store-csi-driver
+  namespace: default


### PR DESCRIPTION
**What this PR does / why we need it**:

Addresses #243, allowing users to choose to not grant as many privileges to the CSI driver and help prevent against accidentally
persisting secrets to K8S's datastore which may not be appropriate in
some environments.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #243

**Special notes for your reviewer**:

This _only_ modifies the permissions installed, which would just lead to repeated error messages in the reconciler whenever it attempts to sync a secret. I could also change the controller to accept a flag and skip secret syncing which may lead to a better error message. Let me know what you think!