### PR TITLE
attributes: pass csi.storage.k8s.io/serviceAccount.name

### DIFF
--- a/pkg/secrets-store/nodeserver.go
+++ b/pkg/secrets-store/nodeserver.go
@@ -51,6 +51,7 @@ const (
 	csipodname                           = "csi.storage.k8s.io/pod.name"
 	csipodnamespace                      = "csi.storage.k8s.io/pod.namespace"
 	csipoduid                            = "csi.storage.k8s.io/pod.uid"
+	csipodsa                             = "csi.storage.k8s.io/serviceAccount.name"
 	providerField                        = "provider"
 	parametersField                      = "parameters"
 	secretProviderClassField             = "secretProviderClass"
@@ -147,6 +148,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	parameters[csipodname] = attrib[csipodname]
 	parameters[csipodnamespace] = attrib[csipodnamespace]
 	parameters[csipoduid] = attrib[csipoduid]
+	parameters[csipodsa] = attrib[csipodsa]
 	podName = parameters[csipodname]
 	podNamespace = parameters[csipodnamespace]
 	podUID = parameters[csipoduid]


### PR DESCRIPTION
**What this PR does / why we need it**:

Passing through the csi.storage.k8s.io/serviceAccount.name parameter will allow plugins who need to obtain K8S SA tokens to perform
workload identity to not need to perform additional get pod K8S API calls.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

See: https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/29

**Special notes for your reviewer**: