### PR TITLE
Override support for private registry

### DIFF
--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -16,7 +16,8 @@ spec:
       serviceAccountName: secrets-store-csi-driver
       containers:
         - name: node-driver-registrar
-          image: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v1.2.1-alpha.1-windows-1809-amd64
+          image: "{{ .Values.windows.registrar.image.repository }}:{{ .Values.windows.registrar.image.tag }}"
+          imagePullPolicy: {{ .Values.windows.registrar.secretStore.image.pullPolicy }}
           args:
             - --v=5
             - "--csi-address=unix://C:\\csi\\csi.sock"
@@ -35,15 +36,15 @@ spec:
               valueFrom:
                 fieldRef:
                   apiVersion: v1
-                  fieldPath: spec.nodeName
-          imagePullPolicy: Always
+                  fieldPath: spec.nodeName          
           volumeMounts:
             - name: plugin-dir
               mountPath: C:\csi
             - name: registration-dir
               mountPath: C:\registration
         - name: secrets-store
-          image: "{{ .Values.windows.image.repository }}:{{ .Values.windows.image.tag }}"
+          image: "{{ .Values.windows.secretStore.image.repository }}:{{ .Values.windows.secretStore.image.tag }}"
+          imagePullPolicy: {{ .Values.windows.secretStore.image.pullPolicy }}
           args:
             - "--debug={{ .Values.logLevel.debug }}"
             - "--endpoint=$(CSI_ENDPOINT)"
@@ -60,8 +61,7 @@ spec:
               valueFrom:
                 fieldRef:
                   apiVersion: v1
-                  fieldPath: spec.nodeName
-          imagePullPolicy: {{ .Values.windows.image.pullPolicy }}
+                  fieldPath: spec.nodeName          
           securityContext:
             privileged: true
           {{- if semverCompare ">= v0.0.9-0" .Values.windows.image.tag }}
@@ -88,8 +88,8 @@ spec:
               mountPath: C:\k\secrets-store-csi-providers
         {{- if semverCompare ">= v0.0.9-0" .Values.windows.image.tag }}
         - name: liveness-probe
-          image: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.0.1-alpha.1-windows-1809-amd64
-          imagePullPolicy: Always
+          image: "{{ .Values.windows.livenessProbe.image.repository }}:{{ .Values.windows.livenessProbe.image.tag }}"
+          imagePullPolicy: {{ .Values.windows.livenessProbe.image.pullPolicy }}
           args:
           - "--csi-address=unix://C:\\csi\\csi.sock"
           - --probe-timeout=3s

--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: node-driver-registrar
           image: "{{ .Values.windows.registrar.image.repository }}:{{ .Values.windows.registrar.image.tag }}"
-          imagePullPolicy: {{ .Values.windows.registrar.secretStore.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.windows.registrar.image.pullPolicy }}
           args:
             - --v=5
             - "--csi-address=unix://C:\\csi\\csi.sock"
@@ -50,7 +50,7 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
             - "--provider-volume=C:\\k\\secrets-store-csi-providers"
-            {{- if and (semverCompare ">= v0.0.9-0" .Values.windows.image.tag) .Values.minimumProviderVersions }}
+            {{- if and (semverCompare ">= v0.0.9-0" .Values.windows.secretStore.image.tag) .Values.minimumProviderVersions }}
             - "--min-provider-version={{ .Values.minimumProviderVersions }}"
             {{- end }}
             - "--metrics-addr={{ .Values.windows.metricsAddr }}"
@@ -64,7 +64,7 @@ spec:
                   fieldPath: spec.nodeName          
           securityContext:
             privileged: true
-          {{- if semverCompare ">= v0.0.9-0" .Values.windows.image.tag }}
+          {{- if semverCompare ">= v0.0.9-0" .Values.windows.secretStore.image.tag }}
           ports:
             - containerPort: {{ .Values.livenessProbe.port }}
               name: healthz
@@ -86,7 +86,7 @@ spec:
               mountPropagation: Bidirectional
             - name: providers-dir
               mountPath: C:\k\secrets-store-csi-providers
-        {{- if semverCompare ">= v0.0.9-0" .Values.windows.image.tag }}
+        {{- if semverCompare ">= v0.0.9-0" .Values.windows.secretStore.image.tag }}
         - name: liveness-probe
           image: "{{ .Values.windows.livenessProbe.image.repository }}:{{ .Values.windows.livenessProbe.image.tag }}"
           imagePullPolicy: {{ .Values.windows.livenessProbe.image.pullPolicy }}

--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -18,7 +18,8 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          image: "{{ .Values.registrar.image.repository }}:{{ .Values.registrar.image.tag }}"
+          imagePullPolicy: {{ .Values.registrar.image.pullPolicy }}
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -38,7 +39,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          imagePullPolicy: Always
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
@@ -46,6 +46,7 @@ spec:
               mountPath: /registration
         - name: secrets-store
           image: "{{ .Values.linux.image.repository }}:{{ .Values.linux.image.tag }}"
+          imagePullPolicy: {{ .Values.linux.image.pullPolicy }}
           args:
             - "--debug={{ .Values.logLevel.debug }}"
             - "--endpoint=$(CSI_ENDPOINT)"
@@ -62,8 +63,7 @@ spec:
               valueFrom:
                 fieldRef:
                   apiVersion: v1
-                  fieldPath: spec.nodeName
-          imagePullPolicy: {{ .Values.linux.image.pullPolicy }}
+                  fieldPath: spec.nodeName          
           securityContext:
             privileged: true
           {{- if semverCompare ">= v0.0.8-0" .Values.linux.image.tag }}
@@ -90,8 +90,8 @@ spec:
               mountPath: /etc/kubernetes/secrets-store-csi-providers
         {{- if semverCompare ">= v0.0.8-0" .Values.linux.image.tag }}
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.0.0
-          imagePullPolicy: Always
+          image: "{{ .Values.livenessProbe.image.repository }}:{{ .Values.livenessProbe.image.tag }}"
+          imagePullPolicy: {{ .Values.livenessProbe.image.pullPolicy }}
           args:
           - --csi-address=/csi/csi.sock
           - --probe-timeout=3s

--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: node-driver-registrar
           image: "{{ .Values.linux.registrar.image.repository }}:{{ .Values.linux.registrar.image.tag }}"
-          imagePullPolicy: {{ .Values.linux.registrar.secretStore.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.linux.registrar.image.pullPolicy }}
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -52,7 +52,7 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
             - "--provider-volume=/etc/kubernetes/secrets-store-csi-providers"
-            {{- if and (semverCompare ">= v0.0.8-0" .Values.linux.image.tag) .Values.minimumProviderVersions }}
+            {{- if and (semverCompare ">= v0.0.8-0" .Values.linux.secretStore.image.tag) .Values.minimumProviderVersions }}
             - "--min-provider-version={{ .Values.minimumProviderVersions }}"
             {{- end }}
             - "--metrics-addr={{ .Values.linux.metricsAddr }}"
@@ -66,7 +66,7 @@ spec:
                   fieldPath: spec.nodeName          
           securityContext:
             privileged: true
-          {{- if semverCompare ">= v0.0.8-0" .Values.linux.image.tag }}
+          {{- if semverCompare ">= v0.0.8-0" .Values.linux.secretStore.image.tag }}
           ports:
             - containerPort: {{ .Values.livenessProbe.port }}
               name: healthz
@@ -88,7 +88,7 @@ spec:
               mountPropagation: Bidirectional
             - name: providers-dir
               mountPath: /etc/kubernetes/secrets-store-csi-providers
-        {{- if semverCompare ">= v0.0.8-0" .Values.linux.image.tag }}
+        {{- if semverCompare ">= v0.0.8-0" .Values.linux.secretStore.image.tag }}
         - name: liveness-probe
           image: "{{ .Values.linux.livenessProbe.image.repository }}:{{ .Values.linux.livenessProbe.image.tag }}"
           imagePullPolicy: {{ .Values.linux.livenessProbe.image.pullPolicy }}

--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -18,8 +18,8 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: node-driver-registrar
-          image: "{{ .Values.registrar.image.repository }}:{{ .Values.registrar.image.tag }}"
-          imagePullPolicy: {{ .Values.registrar.image.pullPolicy }}
+          image: "{{ .Values.linux.registrar.image.repository }}:{{ .Values.linux.registrar.image.tag }}"
+          imagePullPolicy: {{ .Values.linux.registrar.secretStore.image.pullPolicy }}
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -45,8 +45,8 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: secrets-store
-          image: "{{ .Values.linux.image.repository }}:{{ .Values.linux.image.tag }}"
-          imagePullPolicy: {{ .Values.linux.image.pullPolicy }}
+          image: "{{ .Values.linux.secretStore.image.repository }}:{{ .Values.linux.secretStore.image.tag }}"
+          imagePullPolicy: {{ .Values.linux.secretStore.image.pullPolicy }}
           args:
             - "--debug={{ .Values.logLevel.debug }}"
             - "--endpoint=$(CSI_ENDPOINT)"
@@ -90,8 +90,8 @@ spec:
               mountPath: /etc/kubernetes/secrets-store-csi-providers
         {{- if semverCompare ">= v0.0.8-0" .Values.linux.image.tag }}
         - name: liveness-probe
-          image: "{{ .Values.livenessProbe.image.repository }}:{{ .Values.livenessProbe.image.tag }}"
-          imagePullPolicy: {{ .Values.livenessProbe.image.pullPolicy }}
+          image: "{{ .Values.linux.livenessProbe.image.repository }}:{{ .Values.linux.livenessProbe.image.tag }}"
+          imagePullPolicy: {{ .Values.linux.livenessProbe.image.pullPolicy }}
           args:
           - --csi-address=/csi/csi.sock
           - --probe-timeout=3s

--- a/charts/secrets-store-csi-driver/values.yaml
+++ b/charts/secrets-store-csi-driver/values.yaml
@@ -10,7 +10,7 @@ linux:
       repository: quay.io/k8scsi/csi-node-driver-registrar
       tag: v1.2.0
       pullPolicy: IfNotPresent
-  livelinessProbe:
+  livenessProbe:
     image:
       repository: quay.io/k8scsi/livenessprobe
       tag: v2.0.0
@@ -31,7 +31,7 @@ windows:
       repository: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar
       tag: v1.2.1-alpha.1-windows-1809-amd64
       pullPolicy: IfNotPresent
-  livelinessProbe:
+  livenessProbe:
     image:
       repository: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe
       tag: v2.0.1-alpha.1-windows-1809-amd64

--- a/charts/secrets-store-csi-driver/values.yaml
+++ b/charts/secrets-store-csi-driver/values.yaml
@@ -3,7 +3,7 @@ linux:
   image:
     repository: us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver
     tag: v0.0.12
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   kubeletRootDir: /var/lib/kubelet
   nodeSelector: {}
   metricsAddr: ":8080"
@@ -21,7 +21,17 @@ windows:
 logLevel:
   debug: true
 
+registrar:
+  image:
+    repository: quay.io/k8scsi/csi-node-driver-registrar
+    tag: v1.2.0
+    pullPolicy: IfNotPresent
+
 livenessProbe:
+  image:
+    repository: quay.io/k8scsi/livenessprobe
+    tag: v2.0.0
+    pullPolicy: IfNotPresent
   port: 9808
   logLevel: 2
 

--- a/charts/secrets-store-csi-driver/values.yaml
+++ b/charts/secrets-store-csi-driver/values.yaml
@@ -1,19 +1,41 @@
 linux:
   enabled: true
-  image:
-    repository: us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver
-    tag: v0.0.12
-    pullPolicy: IfNotPresent
+  secretStore:
+    image:
+      repository: us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver
+      tag: v0.0.12
+      pullPolicy: IfNotPresent
+  registrar:
+    image:
+      repository: quay.io/k8scsi/csi-node-driver-registrar
+      tag: v1.2.0
+      pullPolicy: IfNotPresent
+  livelinessProbe:
+    image:
+      repository: quay.io/k8scsi/livenessprobe
+      tag: v2.0.0
+      pullPolicy: IfNotPresent
   kubeletRootDir: /var/lib/kubelet
   nodeSelector: {}
   metricsAddr: ":8080"
 
 windows:
   enabled: false
-  image:
-    repository: us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver
-    tag: v0.0.12
-    pullPolicy: IfNotPresent
+  secretStore:
+    image:
+      repository: us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver
+      tag: v0.0.12
+      pullPolicy: IfNotPresent
+  registrar:
+    image:
+      repository: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar
+      tag: v1.2.1-alpha.1-windows-1809-amd64
+      pullPolicy: IfNotPresent
+  livelinessProbe:
+    image:
+      repository: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe
+      tag: v2.0.1-alpha.1-windows-1809-amd64
+      pullPolicy: IfNotPresent
   kubeletRootDir: C:\var\lib\kubelet
   nodeSelector: {}
   metricsAddr: ":8080"
@@ -21,17 +43,7 @@ windows:
 logLevel:
   debug: true
 
-registrar:
-  image:
-    repository: quay.io/k8scsi/csi-node-driver-registrar
-    tag: v1.2.0
-    pullPolicy: IfNotPresent
-
-livenessProbe:
-  image:
-    repository: quay.io/k8scsi/livenessprobe
-    tag: v2.0.0
-    pullPolicy: IfNotPresent
+livenessProbe:  
   port: 9808
   logLevel: 2
 


### PR DESCRIPTION
**What this PR does / why we need it**: Add support for overriding registrar and livenessProbe images. Needed for installing CSI driver from restricted environments which do not have access to public container registries.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #255 

**Special notes for your reviewer**:
Test:
helm install test charts/secrets-store-csi-driver -n csi-secrets-store \
--set linux.registrar.image.repository="some-registry/secrets-store/driver/csi-node-driver-registrar" \
--set linux.registrar.image.tag="v1.2.0" \
--set linux.secretStore.image.repository="some-registry/secrets-store/driver/secrets-store-csi" \
--set linux.secretStore.image.tag="v0.0.11" \
--set linux.livenessProbe.image.repository="some-registry/secrets-store/driver/livenessprobe" \
--set linux.livenessProbe.image.tag="v1.1.0" \
--dry-run --debug