### PR TITLE
test: check pod ready status before getting name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ test: test-style
 	go vet $(GO_FILES)
 test-style: setup
 	@echo "==> Running static validations and linters <=="
-	golangci-lint run
+	# Setting deadline to 5m as deafult is 1m
+	golangci-lint run --deadline=5m
 sanity-test:
 	go test -v ./test/sanity
 build: setup

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -41,9 +41,10 @@ setup() {
   run kubectl apply -f $PROVIDER_YAML --namespace $NAMESPACE	
   assert_success	
 
-  AZURE_PROVIDER_POD=$(kubectl get pod --namespace $NAMESPACE -l app=csi-secrets-store-provider-azure -o jsonpath="{.items[0].metadata.name}")	
-  cmd="kubectl wait --for=condition=Ready --timeout=60s pod/$AZURE_PROVIDER_POD --namespace $NAMESPACE"
+  cmd="kubectl wait --for=condition=Ready --timeout=60s pod -l app=csi-secrets-store-provider-azure --namespace $NAMESPACE"
   wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
+
+  AZURE_PROVIDER_POD=$(kubectl get pod --namespace $NAMESPACE -l app=csi-secrets-store-provider-azure -o jsonpath="{.items[0].metadata.name}")	
 
   run kubectl get pod/$AZURE_PROVIDER_POD --namespace $NAMESPACE
   assert_success

--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -15,9 +15,10 @@ export CONTAINER_IMAGE=nginx
   run kubectl apply -f $PROVIDER_YAML --namespace $NAMESPACE
   assert_success
 
-  VAULT_PROVIDER_POD=$(kubectl get pod --namespace $NAMESPACE -l app=csi-secrets-store-provider-vault -o jsonpath="{.items[0].metadata.name}")
-  cmd="kubectl wait --for=condition=Ready --timeout=60s pod/$VAULT_PROVIDER_POD --namespace $NAMESPACE"
+  cmd="kubectl wait --for=condition=Ready --timeout=60s pod -l app=csi-secrets-store-provider-vault --namespace $NAMESPACE"
   wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
+
+  VAULT_PROVIDER_POD=$(kubectl get pod --namespace $NAMESPACE -l app=csi-secrets-store-provider-vault -o jsonpath="{.items[0].metadata.name}")
 
   run kubectl get pod/$VAULT_PROVIDER_POD --namespace $NAMESPACE
   assert_success
@@ -49,9 +50,10 @@ EOF
   run kubectl apply -f $BATS_TESTS_DIR/vault.yaml
   assert_success
 
-  VAULT_POD=$(kubectl get pod -l app=vault -o jsonpath="{.items[0].metadata.name}")
-  cmd="kubectl wait --for=condition=Ready --timeout=60s pod/$VAULT_POD"
+  cmd="kubectl wait --for=condition=Ready --timeout=60s pod -l app=vault"
   wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
+
+  VAULT_POD=$(kubectl get pod -l app=vault -o jsonpath="{.items[0].metadata.name}")
 
   run kubectl get pod/$VAULT_POD
   assert_success


### PR DESCRIPTION
**What this PR does / why we need it**:
- Checks if the provider pods are ready before getting the pod name

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Prevents flakes similar to -

```
not ok 1 install azure provider
# (in test file test/bats/azure.bats, line 44)
#   `AZURE_PROVIDER_POD=$(kubectl get pod --namespace $NAMESPACE -l app=csi-secrets-store-provider-azure -o jsonpath="{.items[0].metadata.name}")' failed
# error: error executing jsonpath "{.items[0].metadata.name}": Error executing template: array index out of bounds: index 0, length 0. Printing more information for debugging the template:
# 	template was:
# 		{.items[0].metadata.name}
# 	object given to jsonpath engine was:
# 		map[string]interface {}{"apiVersion":"v1", "items":[]interface {}{}, "kind":"List", "metadata":map[string]interface {}{"resourceVersion":"", "selfLink":""}}
# 
# 
```

where the provider pod is not yet scheduled

/kind flake