### PR TITLE
helm: move tolerations block inside OS conditional in helm chart

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -120,8 +120,8 @@ spec:
 {{- if .Values.windows.nodeSelector }}
 {{- toYaml .Values.windows.nodeSelector | nindent 8 }}
 {{- end }}
-{{- end -}}
 {{- with .Values.windows.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- end -}}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -123,8 +123,8 @@ spec:
 {{- if .Values.linux.nodeSelector }}
 {{- toYaml .Values.linux.nodeSelector | nindent 8 }}
 {{- end }}
-{{- end -}}
 {{- with .Values.linux.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduced in a previous PR, the tolerations block should be inside the `{{- if .Values.linux/windows.enabled}}` conditional in the Daemon Set yaml; it is currently outside.
This could cause issues if the `enabled` flag of a specific OS is false, but there are tolerations defined for it.

**Special notes for your reviewer**:
Detected while testing with `secrets-store-csi-driver-provider-azure`