### PR TITLE
feat: add preserveUnknownFields=false marker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ export GOPATH GOBIN GO111MODULE DOCKER_CLI_EXPERIMENTAL
 HAS_GOLANGCI := $(shell command -v golangci-lint;)
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: SecretProviderClassList
     plural: secretproviderclasses
     singular: secretproviderclass
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+++ b/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: SecretProviderClassPodStatusList
     plural: secretproviderclasspodstatuses
     singular: secretproviderclasspodstatus
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: SecretProviderClassList
     plural: secretproviderclasses
     singular: secretproviderclass
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: SecretProviderClassPodStatusList
     plural: secretproviderclasspodstatuses
     singular: secretproviderclasspodstatus
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: SecretProviderClassList
     plural: secretproviderclasses
     singular: secretproviderclass
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+++ b/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: SecretProviderClassPodStatusList
     plural: secretproviderclasspodstatuses
     singular: secretproviderclasspodstatus
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/test/bats/tests/vault/vault_v1alpha1_secretproviderclass_ns.yaml
+++ b/test/bats/tests/vault/vault_v1alpha1_secretproviderclass_ns.yaml
@@ -2,9 +2,9 @@ apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:
   name: vault-foo-sync
+  namespace: default
 spec:
   provider: invalidprovider
-  namespace: default
   secretObjects:
   - secretName: foosecret
     type: Opaque


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds `preserveUnknownFields=false` marker for CRD generation. This is required for `kubectl explain`.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #214 

**Special notes for your reviewer**:
```
➜ kubectl explain secretproviderclass                                                                                              
KIND:     SecretProviderClass
VERSION:  secrets-store.csi.x-k8s.io/v1alpha1

DESCRIPTION:
     SecretProviderClass is the Schema for the secretproviderclasses API

FIELDS:
   apiVersion   <string>
     APIVersion defines the versioned schema of this representation of an
     object. Servers should convert recognized schemas to the latest internal
     value, and may reject unrecognized values. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources

   kind <string>
     Kind is a string value representing the REST resource this object
     represents. Servers may infer this from the endpoint the client submits
     requests to. Cannot be updated. In CamelCase. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds

   metadata     <Object>
     Standard object's metadata. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

   spec <Object>
     SecretProviderClassSpec defines the desired state of SecretProviderClass

   status       <Object>
     SecretProviderClassStatus defines the observed state of SecretProviderClass
```

/kind feature
/milestone v0.0.13