### PR TITLE
chore: regenerate manifests to remove unused rbac permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -25,16 +25,6 @@ rules:
   verbs:
   - get
   - list
-  - update
-  - watch
-- apiGroups:
-  - secrets-store.csi.x-k8s.io
-  resources:
-  - secretproviderclasses/status
-  verbs:
-  - get
-  - patch
-  - update
   - watch
 - apiGroups:
   - secrets-store.csi.x-k8s.io

--- a/controllers/secretproviderclasspodstatus_controller.go
+++ b/controllers/secretproviderclasspodstatus_controller.go
@@ -59,8 +59,7 @@ type SecretProviderClassPodStatusReconciler struct {
 
 // +kubebuilder:rbac:groups=secrets-store.csi.x-k8s.io,resources=secretproviderclasspodstatuses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=secrets-store.csi.x-k8s.io,resources=secretproviderclasspodstatuses/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=secrets-store.csi.x-k8s.io,resources=secretproviderclasses,verbs=get;list;update;watch
-// +kubebuilder:rbac:groups=secrets-store.csi.x-k8s.io,resources=secretproviderclasses/status,verbs=get;patch;update;watch
+// +kubebuilder:rbac:groups=secrets-store.csi.x-k8s.io,resources=secretproviderclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 func (r *SecretProviderClassPodStatusReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/role.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/role.yaml
@@ -1,28 +1,12 @@
 {{ if .Values.rbac.install }}
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   name: secretproviderclasses-role
 rules:
-- apiGroups:
-  - secrets-store.csi.x-k8s.io
-  resources:
-  - secretproviderclasses
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - secrets-store.csi.x-k8s.io
-  resources:
-  - secretproviderclasses/status
-  verbs:
-  - get
-  - patch
-  - update
-  - watch
 - apiGroups:
   - ""
   resources:
@@ -31,10 +15,18 @@ rules:
   - create
   - delete
   - get
-  - update
-  - patch
-  - watch
   - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - secrets-store.csi.x-k8s.io
   resources:
@@ -53,6 +45,6 @@ rules:
   - secretproviderclasspodstatuses/status
   verbs:
   - get
-  - update
   - patch
+  - update
 {{ end }}

--- a/manifest_staging/deploy/rbac-secretproviderclass.yaml
+++ b/manifest_staging/deploy/rbac-secretproviderclass.yaml
@@ -5,41 +5,11 @@ metadata:
   namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: secretproviderclasses-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: secretproviderclasses-role
-subjects:
-- kind: ServiceAccount
-  name: secrets-store-csi-driver
-  namespace: default
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   name: secretproviderclasses-role
 rules:
-- apiGroups:
-  - secrets-store.csi.x-k8s.io
-  resources:
-  - secretproviderclasses
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - secrets-store.csi.x-k8s.io
-  resources:
-  - secretproviderclasses/status
-  verbs:
-  - get
-  - patch
-  - update
-  - watch
 - apiGroups:
   - ""
   resources:
@@ -48,8 +18,16 @@ rules:
   - create
   - delete
   - get
-  - update
+  - list
   - patch
+  - update
+  - watch
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses
+  verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -70,5 +48,18 @@ rules:
   - secretproviderclasspodstatuses/status
   verbs:
   - get
-  - update
   - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: secretproviderclasses-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secretproviderclasses-role
+subjects:
+- kind: ServiceAccount
+  name: secrets-store-csi-driver
+  namespace: default


### PR DESCRIPTION
**What this PR does / why we need it**:
- Run `make manifests` to generate rbac changes and remove permissions no longer required

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: