### PR TITLE
[WIP] feat: compute SHA for data and patch if data changed

### DIFF
--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -19,10 +19,13 @@ package controllers
 import (
 	"crypto/ecdsa"
 	"crypto/rsa"
+	"crypto/sha1"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"sort"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -146,4 +149,25 @@ func getMountedFiles(targetPath string) (map[string]string, error) {
 		paths[file.Name()] = targetPath + sep + file.Name()
 	}
 	return paths, nil
+}
+
+// getSHAfromSecret gets SHA for the secret data
+func getSHAfromSecret(data map[string][]byte) (string, error) {
+	values := []string{}
+	for k, v := range data {
+		values = append(values, k+"="+string(v[:]))
+	}
+	sort.Strings(values)
+	return generateSHA(strings.Join(values, ";"))
+}
+
+// generateSHA generates SHA from string
+func generateSHA(data string) (string, error) {
+	hasher := sha1.New()
+	_, err := io.WriteString(hasher, data)
+	if err != nil {
+		return "", err
+	}
+	sha := hasher.Sum(nil)
+	return fmt.Sprintf("%x", sha), nil
 }

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -161,3 +161,41 @@ func TestGetCert(t *testing.T) {
 		assert.Equal(t, tc.expectedPEM, actualPEM)
 	}
 }
+
+func TestGenerateSHAFromSecret(t *testing.T) {
+	cases := []struct {
+		desc             string
+		data1            map[string][]byte
+		data2            map[string][]byte
+		expectedSHAMatch bool
+	}{
+		{
+			desc:             "SHA mismatch as data1 missing key",
+			data1:            map[string][]byte{},
+			data2:            map[string][]byte{"key": []byte("value")},
+			expectedSHAMatch: false,
+		},
+		{
+			desc:             "SHA mismatch as data1 key different",
+			data1:            map[string][]byte{"key": []byte("oldvalue")},
+			data2:            map[string][]byte{"key": []byte("newvalue")},
+			expectedSHAMatch: false,
+		},
+		{
+			desc:             "SHA match",
+			data1:            map[string][]byte{"key": []byte("value")},
+			data2:            map[string][]byte{"key": []byte("value")},
+			expectedSHAMatch: true,
+		},
+	}
+
+	for _, tc := range cases {
+		sha1, err := getSHAfromSecret(tc.data1)
+		assert.NoError(t, err)
+
+		sha2, err := getSHAfromSecret(tc.data2)
+		assert.NoError(t, err)
+
+		assert.Equal(t, tc.expectedSHAMatch, sha1 == sha2)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Generates `SHA` for existing secret data and expected secret data. If the SHA doesn't match, then replace the contents with the expected content. This ensures when pods are deleted by `RollingUpdate` but secret isn't deleted, then the contents are kept up to date. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: