### PR TITLE
helm: add support for envs in helm chart

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/README.md
+++ b/manifest_staging/charts/secrets-store-csi-driver/README.md
@@ -37,6 +37,7 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `linux.livenessProbeImage.repository` | Linux liveness-probe image repository | `quay.io/k8scsi/livenessprobe` |
 | `linux.livenessProbeImage.pullPolicy` | Linux liveness-probe image pull policy | `Always` |
 | `linux.livenessProbeImage.tag` | Linux liveness-probe image tag | `v2.0.0` |
+| `linux.env` | Environment variables to be passed for the daemonset on linux nodes  | `[]` |
 | `windows.image.repository` | Windows image repository | `us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver` |
 | `windows.image.pullPolicy` | Windows image pull policy | `IfNotPresent` |
 | `windows.image.tag` | Windows image tag | `v0.0.12` |
@@ -51,6 +52,7 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `windows.livenessProbeImage.repository` | Windows liveness-probe image repository | `mcr.microsoft.com/oss/kubernetes-csi/livenessprobe` |
 | `windows.livenessProbeImage.pullPolicy` | Windows liveness-probe image pull policy | `Always` |
 | `windows.livenessProbeImage.tag` | Windows liveness-probe image tag | `v2.0.1-alpha.1-windows-1809-amd64` |
+| `windows.env` | Environment variables to be passed for the daemonset on windows nodes  | `[]` |
 | `logLevel.debug` | Enable debug logging | true |
 | `livenessProbe.port` | Liveness probe port | `9808` |
 | `livenessProbe.logLevel` | Liveness probe container logging verbosity level | `2` |

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -31,11 +31,11 @@ spec:
                       "del /f C:\\registration\\secrets-store.csi.k8s.io-reg.sock",
                     ]
           env:
-            - name: KUBE_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: spec.nodeName
+          - name: KUBE_NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
           imagePullPolicy: {{ .Values.windows.registrarImage.pullPolicy }}
           volumeMounts:
             - name: plugin-dir
@@ -54,13 +54,16 @@ spec:
             {{- end }}
             - "--metrics-addr={{ .Values.windows.metricsAddr }}"
           env:
-            - name: CSI_ENDPOINT
-              value: unix://C:\\csi\\csi.sock
-            - name: KUBE_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: spec.nodeName
+          {{- with .Values.windows.env }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          - name: CSI_ENDPOINT
+            value: unix://C:\\csi\\csi.sock
+          - name: KUBE_NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
           imagePullPolicy: {{ .Values.windows.image.pullPolicy }}
           securityContext:
             privileged: true

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -33,11 +33,11 @@ spec:
                     "rm -rf /registration/secrets-store.csi.k8s.io-reg.sock",
                   ]
           env:
-            - name: KUBE_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: spec.nodeName
+          - name: KUBE_NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
           imagePullPolicy: {{ .Values.linux.registrarImage.pullPolicy }}
           volumeMounts:
             - name: plugin-dir
@@ -56,13 +56,16 @@ spec:
             {{- end }}
             - "--metrics-addr={{ .Values.linux.metricsAddr }}"
           env:
-            - name: CSI_ENDPOINT
-              value: unix:///csi/csi.sock
-            - name: KUBE_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: spec.nodeName
+          {{- with .Values.linux.env }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+          - name: CSI_ENDPOINT
+            value: unix:///csi/csi.sock
+          - name: KUBE_NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
           imagePullPolicy: {{ .Values.linux.image.pullPolicy }}
           securityContext:
             privileged: true

--- a/manifest_staging/charts/secrets-store-csi-driver/values.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/values.yaml
@@ -16,6 +16,7 @@ linux:
   nodeSelector: {}
   tolerations: []
   metricsAddr: ":8080"
+  env: []
 
 windows:
   enabled: false
@@ -35,6 +36,7 @@ windows:
   nodeSelector: {}
   tolerations: []
   metricsAddr: ":8080"
+  env: []
 
 logLevel:
   debug: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Users can set environment variables to be set/overridden via helm chart

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #246

**Special notes for your reviewer**: