### PR TITLE
chore: update golangci-lint to v1.30.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 4m
+  timeout: 5m
   skip-dirs:
   skip-files:
 

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ test: test-style
 	go vet $(GO_FILES)
 test-style: setup
 	@echo "==> Running static validations and linters <=="
-	# Setting deadline to 5m as deafult is 1m
-	golangci-lint run --deadline=5m
+	# Setting timeout to 5m as deafult is 1m
+	golangci-lint run --timeout=5m
 sanity-test:
 	go test -v ./test/sanity
 build: setup

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ setup: clean
 	$Q go env
 
 ifndef HAS_GOLANGCI
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin v1.19.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.30.0
 endif
 
 .PHONY: mod


### PR DESCRIPTION
**What this PR does / why we need it**:
`make test` never exit

**Which issue(s) this PR fixes**:
Fixes #281