### PR TITLE
ci: remove az cli req

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,6 @@ e2e-container:
 	docker buildx rm container-builder || true
 	docker buildx create --use --name=container-builder
 ifdef TEST_WINDOWS
-		az acr login --name $(REGISTRY_NAME)
 		docker buildx build --no-cache --build-arg LDFLAGS=$(LDFLAGS) -t $(IMAGE_TAG)-linux-amd64 -f docker/Dockerfile --platform="linux/amd64" --push .
 		docker buildx build --no-cache --build-arg LDFLAGS=$(LDFLAGS) -t $(IMAGE_TAG)-windows-1809-amd64 -f docker/windows.Dockerfile --platform="windows/amd64" --push .
 		docker manifest create $(IMAGE_TAG) $(IMAGE_TAG)-linux-amd64 $(IMAGE_TAG)-windows-1809-amd64


### PR DESCRIPTION
**What this PR does / why we need it**:
`az` cli has been removed from kubetest image as part of this PR - https://github.com/kubernetes/test-infra/pull/18403. Checking to see if we can remove the dependency on `az login` 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: