### PR TITLE
helm chart best practices

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/templates/_helpers.tpl
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/_helpers.tpl
@@ -25,10 +25,10 @@ Standard labels for helm resources
 */}}
 {{- define "sscd.labels" -}}
 labels:
-  heritage: "{{ .Release.Service }}"
-  release: "{{ .Release.Name }}"
-  revision: "{{ .Release.Revision }}"
-  chart: "{{ .Chart.Name }}"
-  chartVersion: "{{ .Chart.Version }}"
+  app.kubernetes.io/instance: "{{ .Release.Name }}"
+  app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+  app.kubernetes.io/name: "{{ template "sscd.name" . }}"
+  app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
   app: {{ template "sscd.name" . }}
+  helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- end -}}


### PR DESCRIPTION
Co-authored-by: Sean Nguyen <sean.nguyen@rackspace.com>

**What this PR does / why we need it**:
This PR is #240 with just the label changes. The crds are still kept in `templates` dir to support helm2 and helm3. In the future, we could move the crds to `crds` dir for helm3 and add `templates/crds.yaml` with

```
{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
  {{ $.Files.Get $path }}
---
{{- end }}
```

This would then need to be wrapped in a `installCRDs` conditional check, that users can set to true if running using helm2. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #226, Fixes Azure/secrets-store-csi-driver-provider-azure#121

**Special notes for your reviewer**:
- Tested upgrade
  - Installed charts using `charts/secrets-store-csi-driver`
  - Upgraded using `manifest_staging/charts/secrets-store-csi-driver`

Thank you @snooyen for the changes in PR #240  🎉 