### PR TITLE
Add value parameters 'linux.nodeDriverRegistrarImage' and 'linux.livenessProbeImage'

### DIFF
--- a/charts/secrets-store-csi-driver/README.md
+++ b/charts/secrets-store-csi-driver/README.md
@@ -26,6 +26,10 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `linux.image.repository` | Linux image repository | `us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver` |
 | `linux.image.pullPolicy` | Linux image pull policy | `Always` |
 | `linux.image.tag` | Linux image tag | `v0.0.12` |
+| `linux.nodeDriverRegistrarImage.repository` | Linux image repository | `quay.io/k8scsi/csi-node-driver-registrar` |
+| `linux.nodeDriverRegistrarImage.tag` | Linux image tag | `v1.2.0` |
+| `linux.livenessProbeImage.repository` | Linux image repository | `quay.io/k8scsi/livenessprobe` |
+| `linux.livenessProbeImage.tag` | Linux image tag | `v2.0.0` |
 | `linux.enabled` | Install secrets store csi driver on linux nodes | true |
 | `linux.kubeletRootDir` | Configure the kubelet root dir | `/var/lib/kubelet` |
 | `linux.nodeSelector` | Node Selector for the daemonset on linux nodes | `{}` |

--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -18,7 +18,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          image: "{{ .Values.linux.nodeDriverRegistrarImage.repository }}:{{ .Values.linux.nodeDriverRegistrarImage.tag }}"
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -90,7 +90,7 @@ spec:
               mountPath: /etc/kubernetes/secrets-store-csi-providers
         {{- if semverCompare ">= v0.0.8-0" .Values.linux.image.tag }}
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.0.0
+          image: "{{ .Values.linux.livenessProbeImage.repository }}:{{ .Values.linux.livenessProbeImage.tag }}"
           imagePullPolicy: Always
           args:
           - --csi-address=/csi/csi.sock

--- a/charts/secrets-store-csi-driver/values.yaml
+++ b/charts/secrets-store-csi-driver/values.yaml
@@ -4,6 +4,12 @@ linux:
     repository: us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver
     tag: v0.0.12
     pullPolicy: Always
+  nodeDriverRegistrarImage:
+    repository: "quay.io/k8scsi/csi-node-driver-registrar"
+    tag: "v1.2.0"
+  livenessProbeImage:
+    repository: "quay.io/k8scsi/livenessprobe"
+    tag: "v2.0.0"
   kubeletRootDir: /var/lib/kubelet
   nodeSelector: {}
   metricsAddr: ":8080"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add value parameters **'linux.nodeDriverRegistrarImage'** and **'linux.livenessProbeImage'** to replace hard coded pod.spec.containers.image fields.

Enables the configuration of the source repository and tag for **'liveness-probe'** and **'node-driver-registrar'** containers in Pod workloads created by DaemonSet : secrets-store-csi-driver.

**Example changes - values.yaml :** 
```yaml
linux:
  nodeDriverRegistrarImage:
    repository: "quay.io/k8scsi/csi-node-driver-registrar"
    tag: "v1.2.0"
  livenessProbeImage:
    repository: "quay.io/k8scsi/livenessprobe"
    tag: "v2.0.0"
```