### PR TITLE
feat: add unit tests for secrets-store pkg

### DIFF
--- a/pkg/secrets-store/mocks/stats_reporter_mock.go
+++ b/pkg/secrets-store/mocks/stats_reporter_mock.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mocks // import sigs.k8s.io/secrets-store-csi-driver/pkg/secrets-store/mocks
+
+type FakeReporter struct {
+	reportNodePublishCtMetricInvoked        int
+	reportNodeUnPublishCtMetricInvoked      int
+	reportNodePublishErrorCtMetricInvoked   int
+	reportNodeUnPublishErrorCtMetricInvoked int
+	reportSyncK8SecretCtMetricInvoked       int
+	reportSyncK8SecretDurationInvoked       int
+}
+
+func NewFakeReporter() *FakeReporter {
+	return &FakeReporter{}
+}
+
+func (f *FakeReporter) ReportNodePublishCtMetric(provider string) {
+	f.reportNodePublishCtMetricInvoked++
+}
+
+func (f *FakeReporter) ReportNodeUnPublishCtMetric() {
+	f.reportNodeUnPublishCtMetricInvoked++
+}
+
+func (f *FakeReporter) ReportNodePublishErrorCtMetric(provider, errType string) {
+	f.reportNodePublishErrorCtMetricInvoked++
+}
+
+func (f *FakeReporter) ReportNodeUnPublishErrorCtMetric() {
+	f.reportNodeUnPublishErrorCtMetricInvoked++
+}
+
+func (f *FakeReporter) ReportSyncK8SecretCtMetric(provider string, count int) {
+	f.reportSyncK8SecretCtMetricInvoked++
+}
+
+func (f *FakeReporter) ReportSyncK8SecretDuration(duration float64) {
+	f.reportSyncK8SecretDurationInvoked++
+}
+
+func (f *FakeReporter) ReportNodePublishCtMetricInvoked() int {
+	return f.reportNodePublishCtMetricInvoked
+}
+func (f *FakeReporter) ReportNodeUnPublishCtMetricInvoked() int {
+	return f.reportNodeUnPublishCtMetricInvoked
+}
+func (f *FakeReporter) ReportNodePublishErrorCtMetricInvoked() int {
+	return f.reportNodePublishErrorCtMetricInvoked
+}
+func (f *FakeReporter) ReportNodeUnPublishErrorCtMetricInvoked() int {
+	return f.reportNodeUnPublishErrorCtMetricInvoked
+}
+func (f *FakeReporter) ReportSyncK8SecretCtMetricInvoked() int {
+	return f.reportSyncK8SecretCtMetricInvoked
+}
+func (f *FakeReporter) ReportSyncK8SecretDurationInvoked() int {
+	return f.reportSyncK8SecretDurationInvoked
+}

--- a/pkg/secrets-store/nodeserver.go
+++ b/pkg/secrets-store/nodeserver.go
@@ -77,10 +77,10 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 				log.Infof("unmounting target path %s as node publish volume failed", targetPath)
 				ns.mounter.Unmount(targetPath)
 			}
-			ns.reporter.reportNodePublishErrorCtMetric(providerName, errorReason)
+			ns.reporter.ReportNodePublishErrorCtMetric(providerName, errorReason)
 			return
 		}
-		ns.reporter.reportNodePublishCtMetric(providerName)
+		ns.reporter.ReportNodePublishCtMetric(providerName)
 	}()
 
 	// Check arguments
@@ -206,10 +206,10 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 
 	defer func() {
 		if err != nil {
-			ns.reporter.reportNodeUnPublishErrorCtMetric()
+			ns.reporter.ReportNodeUnPublishErrorCtMetric()
 			return
 		}
-		ns.reporter.reportNodeUnPublishCtMetric()
+		ns.reporter.ReportNodeUnPublishCtMetric()
 	}()
 
 	// Check arguments

--- a/pkg/secrets-store/nodeserver_test.go
+++ b/pkg/secrets-store/nodeserver_test.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -36,9 +38,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
+	"sigs.k8s.io/secrets-store-csi-driver/pkg/secrets-store/mocks"
 )
 
-func testNodeServer(mountPoints []mount.MountPoint, client client.Client, grpcSupportProviders string) (*nodeServer, error) {
+func testNodeServer(mountPoints []mount.MountPoint, client client.Client, grpcSupportProviders string, reporter StatsReporter, providerBinaryName string) (*nodeServer, error) {
 	tmpDir, err := ioutil.TempDir("", "ut")
 	if err != nil {
 		return nil, err
@@ -49,11 +52,24 @@ func testNodeServer(mountPoints []mount.MountPoint, client client.Client, grpcSu
 			return nil, err
 		}
 	}
-	return newNodeServer(NewFakeDriver(), tmpDir, "", grpcSupportProviders, "testnode", mount.NewFakeMounter(mountPoints), client)
+	if providerBinaryName != "" {
+		dirPath := fmt.Sprintf("%s/%s", tmpDir, providerBinaryName)
+		filePath := fmt.Sprintf("%s/provider-%s", dirPath, providerBinaryName)
+		err = os.MkdirAll(dirPath, 0755)
+		if err != nil {
+			return nil, err
+		}
+		f, err := os.Create(filePath)
+		defer f.Close()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return newNodeServer(NewFakeDriver(), tmpDir, "", grpcSupportProviders, "testnode", mount.NewFakeMounter(mountPoints), client, reporter)
 }
 
-func getTestTargetPath(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "ut")
+func getTestTargetPath(pattern string, t *testing.T) string {
+	dir, err := ioutil.TempDir("", fmt.Sprintf("ut%s", pattern))
 	if err != nil {
 		t.Fatalf("expected err to be nil, got: %+v", err)
 	}
@@ -63,16 +79,21 @@ func getTestTargetPath(t *testing.T) string {
 func TestNodePublishVolume(t *testing.T) {
 	tests := []struct {
 		name                 string
+		providerBinaryName   string
 		nodePublishVolReq    csi.NodePublishVolumeRequest
 		mountPoints          []mount.MountPoint
 		initObjects          []runtime.Object
 		grpcSupportProviders string
+		RPCCode              codes.Code
+		wantsRPCCode         bool
 		expectedErr          bool
 		shouldRetryRemount   bool
 	}{
 		{
 			name:               "volume capabilities nil",
 			nodePublishVolReq:  csi.NodePublishVolumeRequest{},
+			RPCCode:            codes.InvalidArgument,
+			wantsRPCCode:       true,
 			expectedErr:        true,
 			shouldRetryRemount: true,
 		},
@@ -81,6 +102,8 @@ func TestNodePublishVolume(t *testing.T) {
 			nodePublishVolReq: csi.NodePublishVolumeRequest{
 				VolumeCapability: &csi.VolumeCapability{},
 			},
+			RPCCode:            codes.InvalidArgument,
+			wantsRPCCode:       true,
 			expectedErr:        true,
 			shouldRetryRemount: true,
 		},
@@ -90,6 +113,8 @@ func TestNodePublishVolume(t *testing.T) {
 				VolumeCapability: &csi.VolumeCapability{},
 				VolumeId:         "testvolid1",
 			},
+			RPCCode:            codes.InvalidArgument,
+			wantsRPCCode:       true,
 			expectedErr:        true,
 			shouldRetryRemount: true,
 		},
@@ -98,8 +123,10 @@ func TestNodePublishVolume(t *testing.T) {
 			nodePublishVolReq: csi.NodePublishVolumeRequest{
 				VolumeCapability: &csi.VolumeCapability{},
 				VolumeId:         "testvolid1",
-				TargetPath:       getTestTargetPath(t),
+				TargetPath:       getTestTargetPath("", t),
 			},
+			RPCCode:            codes.InvalidArgument,
+			wantsRPCCode:       true,
 			expectedErr:        true,
 			shouldRetryRemount: true,
 		},
@@ -108,7 +135,7 @@ func TestNodePublishVolume(t *testing.T) {
 			nodePublishVolReq: csi.NodePublishVolumeRequest{
 				VolumeCapability: &csi.VolumeCapability{},
 				VolumeId:         "testvolid1",
-				TargetPath:       getTestTargetPath(t),
+				TargetPath:       getTestTargetPath("", t),
 				VolumeContext:    map[string]string{"secretProviderClass": "provider1"},
 			},
 			expectedErr:        true,
@@ -119,7 +146,7 @@ func TestNodePublishVolume(t *testing.T) {
 			nodePublishVolReq: csi.NodePublishVolumeRequest{
 				VolumeCapability: &csi.VolumeCapability{},
 				VolumeId:         "testvolid1",
-				TargetPath:       getTestTargetPath(t),
+				TargetPath:       getTestTargetPath("", t),
 				VolumeContext:    map[string]string{"secretProviderClass": "provider1", csipodname: "pod1", csipodnamespace: "default"},
 			},
 			initObjects: []runtime.Object{
@@ -138,7 +165,7 @@ func TestNodePublishVolume(t *testing.T) {
 			nodePublishVolReq: csi.NodePublishVolumeRequest{
 				VolumeCapability: &csi.VolumeCapability{},
 				VolumeId:         "testvolid1",
-				TargetPath:       getTestTargetPath(t),
+				TargetPath:       getTestTargetPath("", t),
 				VolumeContext:    map[string]string{"secretProviderClass": "provider1", csipodname: "pod1", csipodnamespace: "default"},
 			},
 			initObjects: []runtime.Object{
@@ -157,7 +184,7 @@ func TestNodePublishVolume(t *testing.T) {
 			nodePublishVolReq: csi.NodePublishVolumeRequest{
 				VolumeCapability: &csi.VolumeCapability{},
 				VolumeId:         "testvolid1",
-				TargetPath:       getTestTargetPath(t),
+				TargetPath:       getTestTargetPath("", t),
 				VolumeContext:    map[string]string{"secretProviderClass": "provider1", csipodname: "pod1", csipodnamespace: "default"},
 			},
 			initObjects: []runtime.Object{
@@ -179,7 +206,7 @@ func TestNodePublishVolume(t *testing.T) {
 			nodePublishVolReq: csi.NodePublishVolumeRequest{
 				VolumeCapability: &csi.VolumeCapability{},
 				VolumeId:         "testvolid1",
-				TargetPath:       getTestTargetPath(t),
+				TargetPath:       getTestTargetPath("", t),
 				VolumeContext:    map[string]string{"secretProviderClass": "provider1", csipodname: "pod1", csipodnamespace: "default"},
 			},
 			initObjects: []runtime.Object{
@@ -198,11 +225,11 @@ func TestNodePublishVolume(t *testing.T) {
 			shouldRetryRemount: true,
 		},
 		{
-			name: "failed to invoke provider, unmounted to force retry",
+			name: "failed to find provider binary, unmounted to force retry",
 			nodePublishVolReq: csi.NodePublishVolumeRequest{
 				VolumeCapability: &csi.VolumeCapability{},
 				VolumeId:         "testvolid1",
-				TargetPath:       getTestTargetPath(t),
+				TargetPath:       getTestTargetPath("", t),
 				VolumeContext:    map[string]string{"secretProviderClass": "provider1", csipodname: "pod1", csipodnamespace: "default", csipoduid: "poduid1"},
 				Readonly:         true,
 			},
@@ -226,7 +253,7 @@ func TestNodePublishVolume(t *testing.T) {
 			nodePublishVolReq: csi.NodePublishVolumeRequest{
 				VolumeCapability: &csi.VolumeCapability{},
 				VolumeId:         "testvolid1",
-				TargetPath:       getTestTargetPath(t),
+				TargetPath:       getTestTargetPath("", t),
 				VolumeContext:    map[string]string{"secretProviderClass": "provider1", csipodname: "pod1", csipodnamespace: "default", csipoduid: "poduid1"},
 				Readonly:         true,
 			},
@@ -244,6 +271,31 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 			mountPoints:        []mount.MountPoint{},
 			expectedErr:        false,
+			shouldRetryRemount: true,
+		},
+		{
+			name:               "Failed to execute provider binary",
+			providerBinaryName: "provider1",
+			nodePublishVolReq: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{},
+				VolumeId:         "testvolid1",
+				TargetPath:       getTestTargetPath("", t),
+				VolumeContext:    map[string]string{"secretProviderClass": "provider1", csipodname: "pod1", csipodnamespace: "default", csipoduid: "poduid1"},
+				Readonly:         true,
+			},
+			initObjects: []runtime.Object{
+				&v1alpha1.SecretProviderClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "provider1",
+						Namespace: "default",
+					},
+					Spec: v1alpha1.SecretProviderClassSpec{
+						Provider:   "provider1",
+						Parameters: map[string]string{"parameter1": "value1"},
+					},
+				},
+			},
+			expectedErr:        true,
 			shouldRetryRemount: true,
 		},
 	}
@@ -267,10 +319,13 @@ func TestNodePublishVolume(t *testing.T) {
 				}
 				test.mountPoints = append(test.mountPoints, mount.MountPoint{Path: absFile})
 			}
-			ns, err := testNodeServer(test.mountPoints, fake.NewFakeClientWithScheme(s, test.initObjects...), test.grpcSupportProviders)
+			r := mocks.NewFakeReporter()
+			ns, err := testNodeServer(test.mountPoints, fake.NewFakeClientWithScheme(s, test.initObjects...), test.grpcSupportProviders, r, test.providerBinaryName)
 			if err != nil {
 				t.Fatalf("expected error to be nil, got: %+v", err)
 			}
+			// Removes provider volume dir that was created by testNodeServer
+			defer os.RemoveAll(ns.providerVolumePath)
 
 			numberOfAttempts := 1
 			// to ensure the remount is tried after previous failure and still fails
@@ -279,10 +334,28 @@ func TestNodePublishVolume(t *testing.T) {
 			}
 
 			for numberOfAttempts > 0 {
+				// How many times 'total_node_publish' and 'total_node_publish_error' counters have been incremented so far
+				c, cErr := r.ReportNodePublishCtMetricInvoked(), r.ReportNodePublishErrorCtMetricInvoked()
+
 				_, err = ns.NodePublishVolume(context.TODO(), &test.nodePublishVolReq)
 				if test.expectedErr && err == nil || !test.expectedErr && err != nil {
 					t.Fatalf("expected err: %v, got: %+v", test.expectedErr, err)
 				}
+
+				// For the error cases where it is expected that the error will contain an RPC code
+				gRPCStatus, ok := status.FromError(err)
+				if test.wantsRPCCode && (!ok || test.RPCCode != gRPCStatus.Code()) {
+					t.Fatalf("expected RPC status code: %v, got: %v\n", test.RPCCode, gRPCStatus.Code())
+				}
+
+				// Check that the correct counter has been incremented
+				if err != nil && r.ReportNodePublishErrorCtMetricInvoked() <= cErr {
+					t.Fatalf("expected 'total_node_publish_error' counter to be incremented, but it was not")
+				}
+				if err == nil && r.ReportNodePublishCtMetricInvoked() <= c {
+					t.Fatalf("expected 'total_node_publish' counter to be incremented, but it was not")
+				}
+
 				mnts, err := ns.mounter.List()
 				if err != nil {
 					t.Fatalf("expected err to be nil, got: %v", err)
@@ -319,13 +392,13 @@ func TestMountSecretsStoreObjectContent(t *testing.T) {
 		{
 			name:        "permission not set",
 			attributes:  "{}",
-			targetPath:  getTestTargetPath(t),
+			targetPath:  getTestTargetPath("", t),
 			expectedErr: true,
 		},
 		{
 			name:                "provider binary not found",
 			attributes:          "{}",
-			targetPath:          getTestTargetPath(t),
+			targetPath:          getTestTargetPath("", t),
 			permission:          fmt.Sprint(permission),
 			expectedErrorReason: internalerrors.ProviderBinaryNotFound,
 			expectedErr:         true,
@@ -333,7 +406,7 @@ func TestMountSecretsStoreObjectContent(t *testing.T) {
 		{
 			name:                 "failed to create provider grpc client",
 			attributes:           "{}",
-			targetPath:           getTestTargetPath(t),
+			targetPath:           getTestTargetPath("", t),
 			permission:           fmt.Sprint(permission),
 			grpcSupportProviders: "provider1",
 			expectedErrorReason:  "GRPCProviderError",
@@ -343,7 +416,7 @@ func TestMountSecretsStoreObjectContent(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ns, err := testNodeServer(nil, fake.NewFakeClientWithScheme(nil), test.grpcSupportProviders)
+			ns, err := testNodeServer(nil, fake.NewFakeClientWithScheme(nil), test.grpcSupportProviders, mocks.NewFakeReporter(), "")
 			if err != nil {
 				t.Fatalf("expected error to be nil, got: %+v", err)
 			}
@@ -353,6 +426,120 @@ func TestMountSecretsStoreObjectContent(t *testing.T) {
 			}
 			if test.expectedErr && err == nil || !test.expectedErr && err != nil {
 				t.Fatalf("expected err: %v, got: %+v", test.expectedErr, err)
+			}
+		})
+	}
+}
+
+func TestNodeUnpublishVolume(t *testing.T) {
+	tests := []struct {
+		name                 string
+		grpcSupportProviders string
+		nodeUnpublishVolReq  csi.NodeUnpublishVolumeRequest
+		mountPoints          []mount.MountPoint
+		RPCCode              codes.Code
+		wantsErr             bool
+		wantsRPCCode         bool
+		shouldRetryUnmount   bool
+	}{
+		{
+			name: "Failure: volume id is empty",
+			nodeUnpublishVolReq: csi.NodeUnpublishVolumeRequest{
+				VolumeId: "testvolid1",
+			},
+			wantsErr:           true,
+			wantsRPCCode:       true,
+			RPCCode:            codes.InvalidArgument,
+			shouldRetryUnmount: true,
+		},
+		{
+			name: "Failure: target path is empty",
+			nodeUnpublishVolReq: csi.NodeUnpublishVolumeRequest{
+				VolumeId: "testvolid1",
+			},
+			wantsErr:           true,
+			wantsRPCCode:       true,
+			RPCCode:            codes.InvalidArgument,
+			shouldRetryUnmount: true,
+		},
+		{
+			name: "Failure: target path does not contain valid podUID",
+			nodeUnpublishVolReq: csi.NodeUnpublishVolumeRequest{
+				VolumeId:   "testvolid1",
+				TargetPath: getTestTargetPath("", t),
+			},
+			wantsErr:           true,
+			wantsRPCCode:       true,
+			RPCCode:            codes.InvalidArgument,
+			shouldRetryUnmount: true,
+		},
+		{
+			name: "Success for a mounted volume with a retry",
+			nodeUnpublishVolReq: csi.NodeUnpublishVolumeRequest{
+				VolumeId:   "testvolid1",
+				TargetPath: getTestTargetPath(`\\pods\fakePod\\volumes`, t),
+			},
+			mountPoints:        []mount.MountPoint{},
+			shouldRetryUnmount: true,
+		},
+	}
+	s := scheme.Scheme
+	s.AddKnownTypes(schema.GroupVersion{Group: v1alpha1.GroupVersion.Group, Version: v1alpha1.GroupVersion.Version},
+		&v1alpha1.SecretProviderClass{},
+		&v1alpha1.SecretProviderClassList{},
+	)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.nodeUnpublishVolReq.TargetPath != "" {
+				defer os.RemoveAll(test.nodeUnpublishVolReq.TargetPath)
+			}
+			if test.mountPoints != nil {
+				// If file is a symlink, get its absolute path
+				absFile, err := filepath.EvalSymlinks(test.nodeUnpublishVolReq.TargetPath)
+				if err != nil {
+					absFile = test.nodeUnpublishVolReq.TargetPath
+				}
+				test.mountPoints = append(test.mountPoints, mount.MountPoint{Path: absFile})
+			}
+
+			r := mocks.NewFakeReporter()
+			ns, err := testNodeServer(test.mountPoints, fake.NewFakeClientWithScheme(s), test.grpcSupportProviders, r, "")
+			if err != nil {
+				t.Fatalf("expected error to be nil, got: %+v", err)
+			}
+			// Removes provider volume dir that was created by testNodeServer
+			defer os.RemoveAll(ns.providerVolumePath)
+
+			numberOfAttempts := 1
+			// to ensure the remount is tried after previous failure and still fails
+			if test.shouldRetryUnmount {
+				numberOfAttempts = 2
+			}
+
+			for numberOfAttempts > 0 {
+				// How many times 'total_node_unpublish' and 'total_node_unpublish_error' counters have been incremented so far
+				c, cErr := r.ReportNodeUnPublishCtMetricInvoked(), r.ReportNodeUnPublishErrorCtMetricInvoked()
+
+				_, err := ns.NodeUnpublishVolume(context.TODO(), &test.nodeUnpublishVolReq)
+				if test.wantsErr && err == nil || !test.wantsErr && err != nil {
+					t.Fatalf("expected err: %v, got: %+v", test.wantsErr, err)
+				}
+
+				// For the error cases where it is expected that the error will contain an RPC code
+				gRPCStatus, ok := status.FromError(err)
+				if test.wantsRPCCode && (!ok || test.RPCCode != gRPCStatus.Code()) {
+					t.Fatalf("expected RPC status code: %v, got: %v\n", test.RPCCode, gRPCStatus.Code())
+				}
+
+				// Check that the correct counter has been incremented
+				if err != nil && r.ReportNodeUnPublishErrorCtMetricInvoked() <= cErr {
+					t.Fatalf("expected 'total_node_unpublish_error' counter to be incremented, but it was not")
+				}
+				if err == nil && r.ReportNodeUnPublishCtMetricInvoked() <= c {
+					t.Fatalf("expected 'total_node_unpublish' counter to be incremented, but it was not")
+				}
+
+				numberOfAttempts--
 			}
 		})
 	}

--- a/pkg/secrets-store/secrets-store.go
+++ b/pkg/secrets-store/secrets-store.go
@@ -48,7 +48,7 @@ func GetDriver() *SecretsStore {
 	return &SecretsStore{}
 }
 
-func newNodeServer(d *csicommon.CSIDriver, providerVolumePath, minProviderVersions, grpcSupportedProviders, nodeID string, mounter mount.Interface, client client.Client) (*nodeServer, error) {
+func newNodeServer(d *csicommon.CSIDriver, providerVolumePath, minProviderVersions, grpcSupportedProviders, nodeID string, mounter mount.Interface, client client.Client, statsReporter StatsReporter) (*nodeServer, error) {
 	// get a map of provider and compatible version
 	minProviderVersionsMap, err := version.GetMinimumProviderVersions(minProviderVersions)
 	if err != nil {
@@ -72,7 +72,7 @@ func newNodeServer(d *csicommon.CSIDriver, providerVolumePath, minProviderVersio
 		providerVolumePath:     providerVolumePath,
 		minProviderVersions:    minProviderVersionsMap,
 		mounter:                mounter,
-		reporter:               newStatsReporter(),
+		reporter:               statsReporter,
 		nodeID:                 nodeID,
 		client:                 client,
 		grpcSupportedProviders: grpcSupportedProvidersMap,
@@ -121,7 +121,7 @@ func (s *SecretsStore) Run(driverName, nodeID, endpoint, providerVolumePath, min
 	}
 	defer m.Stop()
 
-	ns, err := newNodeServer(s.driver, providerVolumePath, minProviderVersions, grpcSupportedProviders, nodeID, mount.New(""), client)
+	ns, err := newNodeServer(s.driver, providerVolumePath, minProviderVersions, grpcSupportedProviders, nodeID, mount.New(""), client, NewStatsReporter())
 	if err != nil {
 		log.Fatalf("failed to initialize node server, error: %+v", err)
 	}

--- a/pkg/secrets-store/stats_reporter.go
+++ b/pkg/secrets-store/stats_reporter.go
@@ -41,15 +41,15 @@ type reporter struct {
 }
 
 type StatsReporter interface {
-	reportNodePublishCtMetric(provider string)
-	reportNodeUnPublishCtMetric()
-	reportNodePublishErrorCtMetric(provider, errType string)
-	reportNodeUnPublishErrorCtMetric()
-	reportSyncK8SecretCtMetric(provider string, count int)
-	reportSyncK8SecretDuration(duration float64)
+	ReportNodePublishCtMetric(provider string)
+	ReportNodeUnPublishCtMetric()
+	ReportNodePublishErrorCtMetric(provider, errType string)
+	ReportNodeUnPublishErrorCtMetric()
+	ReportSyncK8SecretCtMetric(provider string, count int)
+	ReportSyncK8SecretDuration(duration float64)
 }
 
-func newStatsReporter() StatsReporter {
+func NewStatsReporter() StatsReporter {
 	meter := global.Meter("secretsstore")
 	nodePublishTotal = metric.Must(meter).NewInt64Counter("total_node_publish", metric.WithDescription("Total number of node publish calls"))
 	nodeUnPublishTotal = metric.Must(meter).NewInt64Counter("total_node_unpublish", metric.WithDescription("Total number of node unpublish calls"))
@@ -60,29 +60,29 @@ func newStatsReporter() StatsReporter {
 	return &reporter{meter: meter}
 }
 
-func (r *reporter) reportNodePublishCtMetric(provider string) {
+func (r *reporter) ReportNodePublishCtMetric(provider string) {
 	labels := []core.KeyValue{key.String(providerKey, provider), key.String(osTypeKey, runtimeOS)}
 	nodePublishTotal.Add(context.Background(), 1, labels...)
 }
 
-func (r *reporter) reportNodeUnPublishCtMetric() {
+func (r *reporter) ReportNodeUnPublishCtMetric() {
 	nodeUnPublishTotal.Add(context.Background(), 1, []core.KeyValue{key.String(osTypeKey, runtimeOS)}...)
 }
 
-func (r *reporter) reportNodePublishErrorCtMetric(provider, errType string) {
+func (r *reporter) ReportNodePublishErrorCtMetric(provider, errType string) {
 	labels := []core.KeyValue{key.String(providerKey, provider), key.String(errorKey, errType), key.String(osTypeKey, runtimeOS)}
 	nodePublishErrorTotal.Add(context.Background(), 1, labels...)
 }
 
-func (r *reporter) reportNodeUnPublishErrorCtMetric() {
+func (r *reporter) ReportNodeUnPublishErrorCtMetric() {
 	nodeUnPublishErrorTotal.Add(context.Background(), 1, []core.KeyValue{key.String(osTypeKey, runtimeOS)}...)
 }
 
-func (r *reporter) reportSyncK8SecretCtMetric(provider string, count int) {
+func (r *reporter) ReportSyncK8SecretCtMetric(provider string, count int) {
 	labels := []core.KeyValue{key.String(providerKey, provider), key.String(osTypeKey, runtimeOS)}
 	syncK8sSecretTotal.Add(context.Background(), int64(count), labels...)
 }
 
-func (r *reporter) reportSyncK8SecretDuration(duration float64) {
+func (r *reporter) ReportSyncK8SecretDuration(duration float64) {
 	r.meter.RecordBatch(context.Background(), []core.KeyValue{key.String(osTypeKey, runtimeOS)}, syncK8sSecretDuration.Measurement(duration))
 }

--- a/pkg/secrets-store/utils_test.go
+++ b/pkg/secrets-store/utils_test.go
@@ -45,7 +45,7 @@ func TestGetProviderPath(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		testNodeServer, err := newNodeServer(NewFakeDriver(), tc.providerVolumePath, "", "", "test-node", &mount.FakeMounter{}, fake.NewFakeClientWithScheme(nil))
+		testNodeServer, err := newNodeServer(NewFakeDriver(), tc.providerVolumePath, "", "", "test-node", &mount.FakeMounter{}, fake.NewFakeClientWithScheme(nil), NewStatsReporter())
 		assert.NoError(t, err)
 		assert.NotNil(t, testNodeServer)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds more tests for NodePublishVolume and NodeUnpublishVolume functions

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

Fixes #132 

**Special notes for your reviewer**:
I think it would be great if it was possible to also test success scenario for NodePublishVolume. At the moment the code that executes the provider binary with args runs directly in the NodePublishVolume function, but maybe if could be factored out?