### PR TITLE
test: update test for secret with multiple owner references

### DIFF
--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -105,12 +105,13 @@ setup() {
   wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
 
   envsubst < $BATS_TESTS_DIR/nginx-deployment-synck8s-azure.yaml | kubectl apply -f -
+  envsubst < $BATS_TESTS_DIR/nginx-deployment-two-synck8s-azure.yaml | kubectl apply -f -
 
   cmd="kubectl wait --for=condition=Ready --timeout=60s pod -l app=nginx"
   wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
 }
 
-@test "Sync with K8s secrets - read secret from pod, read K8s secret, read env var, check secret ownerReferences" {
+@test "Sync with K8s secrets - read secret from pod, read K8s secret, read env var, check secret ownerReferences with multiple owners" {
   POD=$(kubectl get pod -l app=nginx -o jsonpath="{.items[0].metadata.name}")
 
   result=$(kubectl exec $POD -- $EXEC_COMMAND /mnt/secrets-store/secretalias)
@@ -130,19 +131,26 @@ setup() {
   [[ "${result//$'\r'}" == "${LABEL_VALUE}" ]]
 
   result=$(kubectl get secret foosecret -o json | jq '.metadata.ownerReferences | length')
-  [[ "$result" -eq 2 ]]
+  [[ "$result" -eq 4 ]]
 }
 
-@test "Sync with K8s secrets - delete deployment, check secret deleted" {
+@test "Sync with K8s secrets - delete deployment, check owner ref updated, check secret deleted" {
   run kubectl delete -f $BATS_TESTS_DIR/nginx-deployment-synck8s-azure.yaml
   assert_success
 
-  run kubectl delete -f $BATS_TESTS_DIR/azure_synck8s_v1alpha1_secretproviderclass.yaml
+  sleep 20
+  result=$(kubectl get secret foosecret -o json | jq '.metadata.ownerReferences | length')
+  [[ "$result" -eq 2 ]]
+
+  run kubectl delete -f $BATS_TESTS_DIR/nginx-deployment-two-synck8s-azure.yaml
   assert_success
 
   sleep 20
   result=$(kubectl get secret | grep foosecret | wc -l)
   [[ "$result" -eq 0 ]]
+
+  run kubectl delete -f $BATS_TESTS_DIR/azure_synck8s_v1alpha1_secretproviderclass.yaml
+  assert_success
 }
 
 @test "Test Namespaced scope SecretProviderClass - create deployment" {

--- a/test/bats/tests/azure/nginx-deployment-two-synck8s-azure.yaml
+++ b/test/bats/tests/azure/nginx-deployment-two-synck8s-azure.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-two
+  labels:
+    app: nginx
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: $CONTAINER_IMAGE
+        name: nginx
+        env:
+        - name: SECRET_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: foosecret
+              key: username
+        volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/mnt/secrets-store"
+          readOnly: true
+      volumes:
+        - name: secrets-store-inline
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "azure-sync"
+            nodePublishSecretRef:
+              name: secrets-store-creds

--- a/test/bats/tests/vault/nginx-deployment-two-synck8s.yaml
+++ b/test/bats/tests/vault/nginx-deployment-two-synck8s.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-two
+  labels:
+    app: nginx
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        env:
+        - name: SECRET_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: foosecret
+              key: username
+        volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/mnt/secrets-store"
+          readOnly: true
+      volumes:
+        - name: secrets-store-inline
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "vault-foo-sync"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Updates test for single secret with multiple owners
  - Checks when the first owner is deleted, the secret still exists and the deleted owners are removed from the `ownerReferences`
  - When the last owner is deleted, the secret is subsequently deleted as part of the cascading deletion.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: