### PR TITLE
feat: add managed label to secret created by driver

### DIFF
--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -130,6 +130,9 @@ setup() {
   result=$(kubectl get secret foosecret -o jsonpath="{.metadata.labels.environment}")
   [[ "${result//$'\r'}" == "${LABEL_VALUE}" ]]
 
+  result=$(kubectl get secret foosecret -o jsonpath="{.metadata.labels.secrets-store\.csi\.k8s\.io/managed}")
+  [[ "${result//$'\r'}" == "true" ]]
+
   result=$(kubectl get secret foosecret -o json | jq '.metadata.ownerReferences | length')
   [[ "$result" -eq 4 ]]
 }

--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -190,6 +190,9 @@ EOF
   result=$(kubectl get secret foosecret -o jsonpath="{.metadata.labels.environment}")
   [[ "${result//$'\r'}" == "${LABEL_VALUE}" ]]
 
+  result=$(kubectl get secret foosecret  -o jsonpath="{.metadata.labels.secrets-store\.csi\.k8s\.io/managed}")
+  [[ "${result//$'\r'}" == "true" ]]
+
   result=$(kubectl get secret foosecret -o json | jq '.metadata.ownerReferences | length')
   [[ "$result" -eq 4 ]]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new label to the secrets created by the `secrets-store-csi-driver`. This serves as basic plumbing for enabling filtered watches on the secrets as part of rotation reconciler. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: