### PR TITLE
feat: add event recorder for secrets creation and rotation

### DIFF
--- a/cmd/secrets-store-csi-driver/main.go
+++ b/cmd/secrets-store-csi-driver/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"sync"
 	"time"
 
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/metrics"
@@ -98,15 +97,10 @@ func main() {
 		log.Fatalf("failed to start manager, error: %+v", err)
 	}
 
-	reconciler := &controllers.SecretProviderClassPodStatusReconciler{
-		Client: mgr.GetClient(),
-		Mutex:  &sync.Mutex{},
-		Scheme: mgr.GetScheme(),
-		NodeID: *nodeID,
-		Reader: mgr.GetCache(),
-		Writer: mgr.GetClient(),
+	reconciler, err := controllers.New(mgr, *nodeID)
+	if err != nil {
+		log.Fatalf("failed to create secret provider class pod status reconciler, error: %+v", err)
 	}
-
 	if err = reconciler.SetupWithManager(mgr); err != nil {
 		log.Fatalf("failed to create controller, error: %+v", err)
 	}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/role.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/role.yaml
@@ -10,6 +10,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/manifest_staging/deploy/rbac-secretproviderclass.yaml
+++ b/manifest_staging/deploy/rbac-secretproviderclass.yaml
@@ -13,6 +13,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/pkg/k8s/pod.go
+++ b/pkg/k8s/pod.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -35,7 +37,7 @@ func (pl *PodLister) GetWithKey(key string) (*v1.Pod, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("pod not found in informer cache")
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: v1.GroupName, Resource: "pods"}, key)
 	}
 	pod, ok := p.(*v1.Pod)
 	if !ok {

--- a/pkg/k8s/secret.go
+++ b/pkg/k8s/secret.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -35,7 +37,7 @@ func (sl *SecretLister) GetWithKey(key string) (*v1.Secret, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("secret not found in informer cache")
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: v1.GroupName, Resource: "secrets"}, key)
 	}
 	secret, ok := sec.(*v1.Secret)
 	if !ok {

--- a/pkg/k8s/secretproviderclass.go
+++ b/pkg/k8s/secretproviderclass.go
@@ -19,6 +19,9 @@ package k8s
 import (
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
 
 	"k8s.io/client-go/tools/cache"
@@ -36,7 +39,7 @@ func (spcl *SecretProviderClassLister) GetWithKey(key string) (*v1alpha1.SecretP
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("secret provider class not found in informer cache")
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: v1alpha1.GroupName, Resource: "secretproviderclasses"}, key)
 	}
 	spc, ok := s.(*v1alpha1.SecretProviderClass)
 	if !ok {

--- a/pkg/k8s/secretproviderclasspodstatus.go
+++ b/pkg/k8s/secretproviderclasspodstatus.go
@@ -19,6 +19,9 @@ package k8s
 import (
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
 
 	"k8s.io/client-go/tools/cache"
@@ -36,7 +39,7 @@ func (spcpsl *SecretProviderClassPodStatusLister) GetWithKey(key string) (*v1alp
 		return nil, err
 	}
 	if !exists {
-		return nil, fmt.Errorf("secret provider class pod status not found in informer cache")
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: v1alpha1.GroupName, Resource: "secretproviderclasspodstatuses"}, key)
 	}
 	spcps, ok := s.(*v1alpha1.SecretProviderClassPodStatus)
 	if !ok {

--- a/pkg/k8s/store_test.go
+++ b/pkg/k8s/store_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -48,6 +50,7 @@ func TestGetPod(t *testing.T) {
 	// Get a pod that's not found
 	_, err = testStore.GetPod("pod1", "default")
 	g.Expect(err).To(HaveOccurred())
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
 	// add pod and then perform a get to ensure the correct pod is returned
 	podToCreate := &v1.Pod{
@@ -81,6 +84,11 @@ func TestListSecretProviderClassPodStatus(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	err = testStore.Run(wait.NeverStop)
 	g.Expect(err).NotTo(HaveOccurred())
+
+	// Get a secretproviderclasspodstatus that's not found
+	_, err = testStore.GetSecretProviderClassPodStatus("spcps1")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
 	secretProviderClassPodStatusToAdd := []*v1alpha1.SecretProviderClassPodStatus{
 		{
@@ -126,6 +134,7 @@ func TestGetSecret(t *testing.T) {
 	// Get a secret that's not found
 	_, err = testStore.GetSecret("secret1", "default")
 	g.Expect(err).To(HaveOccurred())
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
 	secretToAdd := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -159,6 +168,7 @@ func TestGetSecretProviderClass(t *testing.T) {
 	// Get a spc that's not found
 	_, err = testStore.GetSecretProviderClass("spc1", "default")
 	g.Expect(err).To(HaveOccurred())
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
 	secretProviderClassToAdd := &v1alpha1.SecretProviderClass{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/secrets-store/nodeserver.go
+++ b/pkg/secrets-store/nodeserver.go
@@ -52,12 +52,13 @@ type nodeServer struct {
 }
 
 const (
-	permission               os.FileMode = 0644
-	csipodname                           = "csi.storage.k8s.io/pod.name"
-	csipodnamespace                      = "csi.storage.k8s.io/pod.namespace"
-	csipoduid                            = "csi.storage.k8s.io/pod.uid"
-	csipodsa                             = "csi.storage.k8s.io/serviceAccount.name"
-	secretProviderClassField             = "secretProviderClass"
+	permission os.FileMode = 0644
+
+	csipodname               = "csi.storage.k8s.io/pod.name"
+	csipodnamespace          = "csi.storage.k8s.io/pod.namespace"
+	csipoduid                = "csi.storage.k8s.io/pod.uid"
+	csipodsa                 = "csi.storage.k8s.io/serviceAccount.name"
+	secretProviderClassField = "secretProviderClass"
 )
 
 func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (npvr *csi.NodePublishVolumeResponse, err error) {

--- a/pkg/secrets-store/secrets-store.go
+++ b/pkg/secrets-store/secrets-store.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/utils/mount"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	csicommon "sigs.k8s.io/secrets-store-csi-driver/pkg/csi-common"
 	version "sigs.k8s.io/secrets-store-csi-driver/pkg/version"
 

--- a/pkg/util/secretutil/secret_test.go
+++ b/pkg/util/secretutil/secret_test.go
@@ -345,3 +345,43 @@ func createTestFile(tmpDir, fileName string) (string, error) {
 	}
 	return "", nil
 }
+
+func TestGenerateSHAFromSecret(t *testing.T) {
+	tests := []struct {
+		name             string
+		data1            map[string][]byte
+		data2            map[string][]byte
+		expectedSHAMatch bool
+	}{
+		{
+			name:             "SHA mismatch as data1 missing key",
+			data1:            map[string][]byte{},
+			data2:            map[string][]byte{"key": []byte("value")},
+			expectedSHAMatch: false,
+		},
+		{
+			name:             "SHA mismatch as data1 key different",
+			data1:            map[string][]byte{"key": []byte("oldvalue")},
+			data2:            map[string][]byte{"key": []byte("newvalue")},
+			expectedSHAMatch: false,
+		},
+		{
+			name:             "SHA match for multiple data keys in different order",
+			data1:            map[string][]byte{"key1": []byte("value1"), "key2": []byte("value2")},
+			data2:            map[string][]byte{"key2": []byte("value2"), "key1": []byte("value1")},
+			expectedSHAMatch: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sha1, err := GetSHAFromSecret(test.data1)
+			assert.NoError(t, err)
+
+			sha2, err := GetSHAFromSecret(test.data2)
+			assert.NoError(t, err)
+
+			assert.Equal(t, test.expectedSHAMatch, sha1 == sha2)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds event recorder to generate events for secret creation failure/ when mounted contents are rotated
- Adds SHA check to determine if updating secret is required
- 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #307 

**Special notes for your reviewer**:
```bash
  Normal  MountRotationComplete   8s    csi-secrets-store-rotation  successfully rotated mounted contents for spc default/azure
  Normal  SecretRotationComplete  8s    csi-secrets-store-rotation  successfully rotated K8s secret foosecret
```