### PR TITLE
chore: remove unused PodUID field in secretproviderclasspodstatus

### DIFF
--- a/apis/v1alpha1/secretproviderclasspodstatus_types.go
+++ b/apis/v1alpha1/secretproviderclasspodstatus_types.go
@@ -28,7 +28,6 @@ const (
 // SecretProviderClassPodStatusStatus defines the observed state of SecretProviderClassPodStatus
 type SecretProviderClassPodStatusStatus struct {
 	PodName                 string                      `json:"podName,omitempty"`
-	PodUID                  string                      `json:"podUID,omitempty"`
 	SecretProviderClassName string                      `json:"secretProviderClassName,omitempty"`
 	Mounted                 bool                        `json:"mounted,omitempty"`
 	TargetPath              string                      `json:"targetPath,omitempty"`

--- a/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+++ b/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
@@ -53,8 +53,6 @@ spec:
                 type: array
               podName:
                 type: string
-              podUID:
-                type: string
               secretProviderClassName:
                 type: string
               targetPath:

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
@@ -53,8 +53,6 @@ spec:
                 type: array
               podName:
                 type: string
-              podUID:
-                type: string
               secretProviderClassName:
                 type: string
               targetPath:

--- a/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+++ b/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
@@ -53,8 +53,6 @@ spec:
                 type: array
               podName:
                 type: string
-              podUID:
-                type: string
               secretProviderClassName:
                 type: string
               targetPath:


### PR DESCRIPTION
**What this PR does / why we need it**:
- `PodUID` field is not used in `SecretProviderClassPodStatus`
- No deprecation notice required as this field was never exposed for use

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/kind cleanup