### PR TITLE
chore: update e2e helm install for grpc supported provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,13 +138,15 @@ ifdef TEST_WINDOWS
 			--set windows.image.repository=$(REGISTRY)/$(IMAGE_NAME) \
 			--set windows.image.tag=$(IMAGE_VERSION) \
 			--set windows.enabled=true \
-			--set linux.enabled=false
+			--set linux.enabled=false \
+			--set grpcSupportedProviders=azure
 else
 		helm install csi-secrets-store manifest_staging/charts/secrets-store-csi-driver --namespace default --wait --timeout=15m -v=5 --debug \
 			--set linux.image.pullPolicy="IfNotPresent" \
 			--set linux.image.repository="e2e/secrets-store-csi" \
 			--set linux.image.tag=$(IMAGE_VERSION) \
-			--set linux.image.pullPolicy="IfNotPresent"
+			--set linux.image.pullPolicy="IfNotPresent" \
+			--set grpcSupportedProviders=azure
 endif
 
 .PHONY: e2e-azure


### PR DESCRIPTION
**What this PR does / why we need it**:
- The new release for `azure` provider now only supports gRPC for communication. Updating the e2e helm install to include the provider.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: