### PR TITLE
GCP plugin: integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ else
 			--set linux.image.repository="e2e/secrets-store-csi" \
 			--set linux.image.tag=$(IMAGE_VERSION) \
 			--set linux.image.pullPolicy="IfNotPresent" \
-			--set grpcSupportedProviders=azure \
+			--set grpcSupportedProviders="azure;gcp" \
 			--set enableSecretRotation=true \
 			--set rotationPollInterval=30s
 endif
@@ -162,6 +162,10 @@ e2e-azure: install-driver
 .PHONY: e2e-vault
 e2e-vault: install-driver
 	bats -t test/bats/vault.bats
+
+.PHONY: e2e-gcp
+e2e-gcp: install-driver
+	bats -t test/bats/gcp.bats
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen

--- a/test/bats/gcp.bats
+++ b/test/bats/gcp.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+
+load helpers
+
+BATS_TESTS_DIR=test/bats/tests/gcp
+WAIT_TIME=60
+SLEEP_TIME=1
+NAMESPACE=default
+PROVIDER_NAMESPACE=kube-system
+PROVIDER_YAML=https://raw.githubusercontent.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/main/deploy/provider-gcp-plugin.yaml
+CONTAINER_IMAGE=nginx
+EXEC_COMMAND="cat"
+BASE64_FLAGS="-w 0"
+
+export CONTAINER_IMAGE=$CONTAINER_IMAGE
+export RESOURCE_NAME=${RESOURCE_NAME:-"projects/735463103342/secrets/test-secret-a/versions/latest"}
+export FILE_NAME=${FILE_NAME:-"secret"}
+export SECRET_VALUE=${SECRET_VALUE:-"aHVudGVyMg=="}
+
+setup() {
+  if [[ -z "${GCP_SA_JSON}" ]]; then
+    echo "Error: GCP Service Account (GCP_SA_JSON) is not provided" >&2
+    return 1
+  fi
+}
+
+@test "install gcp provider" {	
+  run kubectl apply -f $PROVIDER_YAML --namespace $PROVIDER_NAMESPACE
+  assert_success	
+
+  cmd="kubectl wait --for=condition=Ready --timeout=60s pod -l app=csi-secrets-store-provider-gcp --namespace $PROVIDER_NAMESPACE"
+  wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
+
+  GCP_PROVIDER_POD=$(kubectl get pod --namespace $PROVIDER_NAMESPACE -l app=csi-secrets-store-provider-gcp -o jsonpath="{.items[0].metadata.name}")	
+
+  run kubectl get pod/$GCP_PROVIDER_POD --namespace $PROVIDER_NAMESPACE
+  assert_success
+}
+
+@test "create gcp k8s secret for provider auth" {
+  run kubectl create secret generic secrets-store-creds --namespace $NAMESPACE --from-literal=key.json="${GCP_SA_JSON}"
+  assert_success
+}
+
+@test "secretproviderclasses crd is established" {
+  cmd="kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.x-k8s.io"
+  wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
+
+  run kubectl get crd/secretproviderclasses.secrets-store.csi.x-k8s.io
+  assert_success
+}
+
+@test "deploy gcp secretproviderclass crd" {
+  envsubst < $BATS_TESTS_DIR/gcp_v1alpha1_secretproviderclass.yaml | kubectl apply -f -
+
+  cmd="kubectl get secretproviderclasses.secrets-store.csi.x-k8s.io/gcp -o yaml | grep gcp"
+  wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
+}
+
+@test "CSI inline volume test with pod portability" {
+  envsubst < $BATS_TESTS_DIR/nginx-pod-secrets-store-inline-volume-crd.yaml | kubectl apply -f -
+  
+  cmd="kubectl wait --for=condition=Ready --timeout=60s pod/nginx-secrets-store-inline-crd"
+  wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
+
+  run kubectl get pod/nginx-secrets-store-inline-crd
+  assert_success
+}
+
+@test "CSI inline volume test with pod portability - read gcp kv secret from pod" {
+  result=$(kubectl exec nginx-secrets-store-inline-crd -- $EXEC_COMMAND /mnt/secrets-store/$FILE_NAME)
+  [[ "${result//$'\r'}" == "${SECRET_VALUE}" ]]
+}

--- a/test/bats/tests/gcp/gcp_v1alpha1_secretproviderclass.yaml
+++ b/test/bats/tests/gcp/gcp_v1alpha1_secretproviderclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: gcp
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+      - resourceName: $RESOURCE_NAME
+        fileName: $FILE_NAME

--- a/test/bats/tests/gcp/nginx-pod-secrets-store-inline-volume-crd.yaml
+++ b/test/bats/tests/gcp/nginx-pod-secrets-store-inline-volume-crd.yaml
@@ -1,0 +1,22 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: nginx-secrets-store-inline-crd
+spec:
+  terminationGracePeriodSeconds: 0
+  containers:
+  - image: $CONTAINER_IMAGE
+    name: nginx
+    volumeMounts:
+    - name: secrets-store-inline
+      mountPath: "/mnt/secrets-store"
+      readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "gcp"
+        nodePublishSecretRef:
+          name: secrets-store-creds


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds integration tests for the GCP Secret Manager plugin: https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Starting with a single test case.

Changes to test-infra: https://github.com/kubernetes/test-infra/pull/19512

and uploading of a new secret (`gcp-secrets-store-cred`) to prow