### PR TITLE
deploy: add gcp as grpcSupportedProviders by default

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/values.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/values.yaml
@@ -120,7 +120,7 @@ syncSecret:
 minimumProviderVersions:
 
 ## ; delimited list of providers that support grpc for driver-provider [alpha]
-grpcSupportedProviders:
+grpcSupportedProviders: gcp;
 
 ## Enable secret rotation feature [alpha]
 enableSecretRotation: false

--- a/manifest_staging/deploy/secrets-store-csi-driver.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver.yaml
@@ -56,6 +56,7 @@ spec:
             - "--nodeid=$(KUBE_NODE_NAME)"
             - "--provider-volume=/etc/kubernetes/secrets-store-csi-providers"
             - "--metrics-addr=:8095"
+            - "--grpc-supported-providers=gcp;"
             - "--enable-secret-rotation=false"
             - "--rotation-poll-interval=2m"
           env:


### PR DESCRIPTION
**What this PR does / why we need it**:

The gcp plugin only works with `--grpc-supported-providers`, so adding it to the template to set by default.