### PR TITLE
feat: add gosec linter and fix warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,11 +6,15 @@ run:
 linters:
   disable-all: true
   enable:
+    - deadcode
     - gofmt
     - goimports
     - gosimple
     - golint
     - govet
+    - gosec
     - ineffassign
     - misspell
     - unused
+    - structcheck
+    - varcheck

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -38,5 +38,6 @@ const (
 	// PodNotFound error
 	PodNotFound = "PodNotFound"
 	// NodePublishSecretRefNotFound error
+	// #nosec G101 (Ref: https://github.com/securego/gosec/issues/295)
 	NodePublishSecretRefNotFound = "NodePublishSecretRefNotFound"
 )

--- a/pkg/secrets-store/nodeserver.go
+++ b/pkg/secrets-store/nodeserver.go
@@ -28,6 +28,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	csicommon "sigs.k8s.io/secrets-store-csi-driver/pkg/csi-common"
 	internalerrors "sigs.k8s.io/secrets-store-csi-driver/pkg/errors"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/version"

--- a/pkg/secrets-store/utils.go
+++ b/pkg/secrets-store/utils.go
@@ -31,19 +31,10 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
-)
-
-var (
-	secretProviderClassGvk = schema.GroupVersionKind{
-		Group:   "secrets-store.csi.x-k8s.io",
-		Version: "v1alpha1",
-		Kind:    "SecretProviderClassList",
-	}
 )
 
 // getProviderPath returns the absolute path to the provider binary

--- a/pkg/util/secretutil/secret.go
+++ b/pkg/util/secretutil/secret.go
@@ -19,7 +19,7 @@ package secretutil
 import (
 	"crypto/ecdsa"
 	"crypto/rsa"
-	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -198,7 +198,7 @@ func GetSHAFromSecret(data map[string][]byte) (string, error) {
 
 // generateSHA generates SHA from string
 func generateSHA(data string) (string, error) {
-	hasher := sha1.New()
+	hasher := sha256.New()
 	_, err := io.WriteString(hasher, data)
 	if err != nil {
 		return "", err

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -128,7 +128,7 @@ setup() {
   result=$(kubectl get secret foosecret -o jsonpath="{.data.username}" | base64 -d)
   [[ "${result//$'\r'}" == "${SECRET_VALUE}" ]]
 
-  result=$(kubectl exec -it $POD printenv | grep SECRET_USERNAME) | awk -F"=" '{ print $2}'
+  result=$(kubectl exec $POD printenv | grep SECRET_USERNAME) | awk -F"=" '{ print $2}'
   [[ "${result//$'\r'}" == "${SECRET_VALUE}" ]]
 
   result=$(kubectl get secret foosecret -o jsonpath="{.metadata.labels.environment}")


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds `gosec`, `deadcode`, `structcheck` and `varcheck` linters to golangci config.
- Switch to using sha256 as sha1 is weak

```bash
pkg/util/secretutil/secret.go:22:2: G505: Blocklisted import crypto/sha1: weak cryptographic primitive (gosec)
        "crypto/sha1"
        ^
pkg/util/secretutil/secret.go:201:12: G401: Use of weak cryptographic primitive (gosec)
        hasher := sha1.New()
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #350 

**Special notes for your reviewer**: