### PR TITLE
chore: remove lifecycle prestop command

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -23,15 +23,6 @@ spec:
             - --v=5
             - "--csi-address=unix://C:\\csi\\csi.sock"
             - --kubelet-registration-path={{ .Values.windows.kubeletRootDir }}\plugins\csi-secrets-store\csi.sock
-          lifecycle:
-              preStop:
-                exec:
-                  command:
-                    [
-                      "cmd",
-                      "/c",
-                      "del /f C:\\registration\\secrets-store.csi.k8s.io-reg.sock",
-                    ]
           env:
           - name: KUBE_NODE_NAME
             valueFrom:

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -25,15 +25,6 @@ spec:
             - --v=5
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path={{ .Values.linux.kubeletRootDir }}/plugins/csi-secrets-store/csi.sock
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  [
-                    "/bin/sh",
-                    "-c",
-                    "rm -rf /registration/secrets-store.csi.k8s.io-reg.sock",
-                  ]
           env:
           - name: KUBE_NODE_NAME
             valueFrom:

--- a/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
@@ -19,15 +19,6 @@ spec:
             - --v=5
             - "--csi-address=unix://C:\\csi\\csi.sock"
             - "--kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\csi-secrets-store\\csi.sock"
-          lifecycle:
-              preStop:
-                exec:
-                  command:
-                    [
-                      "cmd",
-                      "/c",
-                      "del /f C:\\registration\\secrets-store.csi.k8s.io-reg.sock",
-                    ]
           env:
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/manifest_staging/deploy/secrets-store-csi-driver.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver.yaml
@@ -20,15 +20,6 @@ spec:
             - --v=5
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-secrets-store/csi.sock
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  [
-                    "/bin/sh",
-                    "-c",
-                    "rm -rf /registration/secrets-store.csi.k8s.io-reg.sock",
-                  ]
           env:
             - name: KUBE_NODE_NAME
               valueFrom:


### PR DESCRIPTION
**What this PR does / why we need it**:
Removing the lifecycle prestop commands for `node-driver-registrar`

- `node-driver-registrar` switched to using a distroless image. So shell is no longer available.
- `node-driver-registrar` cleans up the registration socket as part of shutdown - https://github.com/kubernetes-csi/node-driver-registrar/pull/61

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/kind cleanup