### PR TITLE
fix: handle pod termination during reconcile

### DIFF
--- a/pkg/rotation/reconciler_test.go
+++ b/pkg/rotation/reconciler_test.go
@@ -596,6 +596,17 @@ func TestReconcileNoError(t *testing.T) {
 	// 2 normal events - one for successfully updating the mounted contents and
 	// second for successfully rotating the K8s secret
 	g.Expect(len(fakeRecorder.Events)).To(BeNumerically("==", 2))
+
+	// test with pod being terminated
+	podToAdd.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	kubeClient = fake.NewSimpleClientset(podToAdd, secretToAdd)
+	testReconciler, err = newTestReconciler(scheme, kubeClient, crdClient, ctrlClient, 60*time.Second, socketPath)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = testReconciler.store.Run(wait.NeverStop)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	err = testReconciler.reconcile(context.TODO(), secretProviderClassPodStatusToProcess)
+	g.Expect(err).NotTo(HaveOccurred())
 }
 
 func TestPatchSecret(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Checks if the pod is terminating while inside the reconcile or rotation loop. If the pod is terminating, then return.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: