### PR TITLE
Fix vault bats tests for running against v0.0.6 of the provider

### DIFF
--- a/test/bats/tests/vault/vault_synck8s_v1alpha1_secretproviderclass.yaml
+++ b/test/bats/tests/vault/vault_synck8s_v1alpha1_secretproviderclass.yaml
@@ -10,9 +10,9 @@ spec:
     labels:                                   
       environment: "test"
     data: 
-    - objectName: foo
+    - objectName: bar
       key: pwd
-    - objectName: foo1
+    - objectName: bar1
       key: username
   parameters:
     roleName: "example-role"
@@ -21,10 +21,10 @@ spec:
     objects:  |
       array:
         - |
-          objectPath: "/foo"
+          objectPath: "v1/secret/foo"
           objectName: "bar"
           objectVersion: ""
         - |
-          objectPath: "/foo1"
-          objectName: "bar"
+          objectPath: "v1/secret/foo1"
+          objectName: "bar1"
           objectVersion: ""

--- a/test/bats/tests/vault/vault_v1alpha1_multiple_secretproviderclass.yaml
+++ b/test/bats/tests/vault/vault_v1alpha1_multiple_secretproviderclass.yaml
@@ -8,9 +8,9 @@ spec:
   - secretName: foosecret-0
     type: Opaque
     data: 
-    - objectName: foo
+    - objectName: bar
       key: pwd
-    - objectName: foo1
+    - objectName: bar1
       key: username
   parameters:
     roleName: "example-role"
@@ -19,12 +19,12 @@ spec:
     objects:  |
       array:
         - |
-          objectPath: "/foo"
+          objectPath: "v1/secret/foo"
           objectName: "bar"
           objectVersion: ""
         - |
-          objectPath: "/foo1"
-          objectName: "bar"
+          objectPath: "v1/secret/foo1"
+          objectName: "bar1"
           objectVersion: ""
 ---
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
@@ -37,9 +37,9 @@ spec:
   - secretName: foosecret-1
     type: Opaque
     data: 
-    - objectName: foo
+    - objectName: bar
       key: pwd
-    - objectName: foo1
+    - objectName: bar1
       key: username
   parameters:
     roleName: "example-role"
@@ -48,10 +48,10 @@ spec:
     objects:  |
       array:
         - |
-          objectPath: "/foo"
+          objectPath: "v1/secret/foo"
           objectName: "bar"
           objectVersion: ""
         - |
-          objectPath: "/foo1"
-          objectName: "bar"
+          objectPath: "v1/secret/foo1"
+          objectName: "bar1"
           objectVersion: ""

--- a/test/bats/tests/vault/vault_v1alpha1_secretproviderclass.yaml
+++ b/test/bats/tests/vault/vault_v1alpha1_secretproviderclass.yaml
@@ -11,10 +11,10 @@ spec:
     objects:  |
       array:
         - |
-          objectPath: "/foo"
+          objectPath: "v1/secret/foo"
           objectName: "bar"
           objectVersion: ""
         - |
-          objectPath: "/foo1"
-          objectName: "bar"
+          objectPath: "v1/secret/foo1"
+          objectName: "bar1"
           objectVersion: ""

--- a/test/bats/tests/vault/vault_v1alpha1_secretproviderclass_ns.yaml
+++ b/test/bats/tests/vault/vault_v1alpha1_secretproviderclass_ns.yaml
@@ -9,9 +9,9 @@ spec:
   - secretName: foosecret
     type: Opaque
     data: 
-    - objectName: foo
+    - objectName: bar
       key: pwd
-    - objectName: foo1
+    - objectName: bar1
       key: username
   parameters:
     roleName: "example-role"
@@ -20,12 +20,12 @@ spec:
     objects:  |
       array:
         - |
-          objectPath: "/foo"
+          objectPath: "v1/secret/foo"
           objectName: "bar"
           objectVersion: ""
         - |
-          objectPath: "/foo1"
-          objectName: "bar"
+          objectPath: "v1/secret/foo1"
+          objectName: "bar1"
           objectVersion: ""
 ---
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
@@ -39,9 +39,9 @@ spec:
   - secretName: foosecret
     type: Opaque
     data: 
-    - objectName: foo
+    - objectName: bar
       key: pwd
-    - objectName: foo1
+    - objectName: bar1
       key: username
   parameters:
     roleName: "example-role"
@@ -50,10 +50,10 @@ spec:
     objects:  |
       array:
         - |
-          objectPath: "/foo"
+          objectPath: "v1/secret/foo"
           objectName: "bar"
           objectVersion: ""
         - |
-          objectPath: "/foo1"
-          objectName: "bar"
+          objectPath: "v1/secret/foo1"
+          objectName: "bar1"
           objectVersion: ""


### PR DESCRIPTION
**What this PR does / why we need it**:

v0.0.5 of the vault provider introduced a breaking change which the integration tests here were never updated for. This PR fixes the tests so they should pass for v0.0.6, and allow us to merge https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/pull/53 safely.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

Apologies for the conflicts with #245 but I've tried to keep the diff to a minimum to make it easier to port over to that PR.