### PR TITLE
deploy: set namespace as kube-system

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ kubectl apply -f deploy/rbac-secretproviderclass.yaml # update the namespace of 
 kubectl apply -f deploy/csidriver.yaml
 kubectl apply -f deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
 kubectl apply -f deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
-kubectl apply -f deploy/secrets-store-csi-driver.yaml --namespace $NAMESPACE
+kubectl apply -f deploy/secrets-store-csi-driver.yaml
 
 # If using the driver to sync secrets-store content as Kubernetes Secrets, deploy the additional RBAC permissions
 # required to enable this feature
@@ -119,13 +119,13 @@ kubectl apply -f deploy/rbac-secretprovidersyncing.yaml
 kubectl apply -f deploy/csidriver-1.15.yaml
 
 # [OPTIONAL] To deploy driver on windows nodes
-kubectl apply -f deploy/secrets-store-csi-driver-windows.yaml --namespace $NAMESPACE
+kubectl apply -f deploy/secrets-store-csi-driver-windows.yaml
 ```
 
 To validate the installer is running as expected, run the following commands:
 
 ```bash
-kubectl get po --namespace $NAMESPACE
+kubectl get po --namespace=kube-system
 ```
 
 You should see the Secrets Store CSI driver pods running on each agent node:
@@ -141,6 +141,17 @@ You should see the following CRDs deployed:
 kubectl get crd
 NAME                                               
 secretproviderclasses.secrets-store.csi.x-k8s.io    
+```
+
+**Note**: v0.0.17 and earlier installed the driver to the `default` namespace.
+Newer versions of the driver will install the driver to the `kube-system`
+namespace. After applying the new YAML files to your cluster run the following
+to clean up old resources:
+
+```bash
+kubectl delete daemonset csi-secrets-store --namespace=default
+kubectl delete daemonset csi-secrets-store-windows --namespace=default
+kubectl delete serviceaccount secrets-store-csi-driver --namespace=default
 ```
 
 </details>

--- a/config/rbac-syncsecret/role_binding.yaml
+++ b/config/rbac-syncsecret/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: secrets-store-csi-driver
-  namespace: default
+  namespace: kube-system

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: secrets-store-csi-driver
-  namespace: default
+  namespace: kube-system

--- a/config/rbac/serviceaccount.yaml
+++ b/config/rbac/serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: secrets-store-csi-driver
-  namespace: default
+  namespace: kube-system

--- a/manifest_staging/deploy/rbac-secretproviderclass.yaml
+++ b/manifest_staging/deploy/rbac-secretproviderclass.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: secrets-store-csi-driver
-  namespace: default
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -65,4 +65,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: secrets-store-csi-driver
-  namespace: default
+  namespace: kube-system

--- a/manifest_staging/deploy/rbac-secretprovidersyncing.yaml
+++ b/manifest_staging/deploy/rbac-secretprovidersyncing.yaml
@@ -28,4 +28,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: secrets-store-csi-driver
-  namespace: default
+  namespace: kube-system

--- a/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
@@ -2,6 +2,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: csi-secrets-store-windows
+  namespace: kube-system
 spec:
   selector:
     matchLabels:

--- a/manifest_staging/deploy/secrets-store-csi-driver.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver.yaml
@@ -2,6 +2,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: csi-secrets-store
+  namespace: kube-system
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
**What this PR does / why we need it**:

Resolved #375. The CSI driver needs permissions across all namespaces
for secrets syncing and access to the host filesystem. A non-cluster
admin user should not have the ability to update or modify the CSI
driver due to these high level of privileges.

This change would require users upgrading from previous verisons of the
driver to run the following to cleanup old resources:

kubectl delete DaemonSet csi-secrets-store -namespace default
kubectl delete DaemonSet csi-secrets-store-windows -namespace default
kubectl delete ServiceAccount secrets-store-csi-driver -namespace default

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #375 