### PR TITLE
chore: best-effort cleanup socket

### DIFF
--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -75,7 +75,7 @@ func RunNodePublishServer(endpoint string, d *CSIDriver, ns csi.NodeServer) {
 	ids := NewDefaultIdentityServer(d)
 
 	s := NewNonBlockingGRPCServer()
-	s.Start(endpoint, ids, nil, ns)
+	s.Start(context.Background(), endpoint, ids, nil, ns)
 	s.Wait()
 }
 
@@ -83,7 +83,7 @@ func RunControllerPublishServer(endpoint string, d *CSIDriver, cs csi.Controller
 	ids := NewDefaultIdentityServer(d)
 
 	s := NewNonBlockingGRPCServer()
-	s.Start(endpoint, ids, cs, nil)
+	s.Start(context.Background(), endpoint, ids, cs, nil)
 	s.Wait()
 }
 
@@ -91,7 +91,7 @@ func RunControllerandNodePublishServer(endpoint string, d *CSIDriver, cs csi.Con
 	ids := NewDefaultIdentityServer(d)
 
 	s := NewNonBlockingGRPCServer()
-	s.Start(endpoint, ids, cs, ns)
+	s.Start(context.Background(), endpoint, ids, cs, ns)
 	s.Wait()
 }
 

--- a/pkg/secrets-store/secrets-store.go
+++ b/pkg/secrets-store/secrets-store.go
@@ -17,6 +17,7 @@ limitations under the License.
 package secretsstore
 
 import (
+	"context"
 	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -93,7 +94,7 @@ func newIdentityServer(d *csicommon.CSIDriver) *identityServer {
 }
 
 // Run starts the CSI plugin
-func (s *SecretsStore) Run(driverName, nodeID, endpoint, providerVolumePath, minProviderVersions, grpcSupportedProviders string, client client.Client) {
+func (s *SecretsStore) Run(ctx context.Context, driverName, nodeID, endpoint, providerVolumePath, minProviderVersions, grpcSupportedProviders string, client client.Client) {
 	klog.Infof("Driver: %v ", driverName)
 	klog.Infof("Version: %s", vendorVersion)
 	klog.Infof("Provider Volume Path: %s", providerVolumePath)
@@ -123,6 +124,6 @@ func (s *SecretsStore) Run(driverName, nodeID, endpoint, providerVolumePath, min
 	s.ids = newIdentityServer(s.driver)
 
 	server := csicommon.NewNonBlockingGRPCServer()
-	server.Start(endpoint, s.ids, s.cs, s.ns)
+	server.Start(ctx, endpoint, s.ids, s.cs, s.ns)
 	server.Wait()
 }

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package sanity
 
 import (
+	"context"
 	"testing"
 
 	"github.com/kubernetes-csi/csi-test/pkg/sanity"
@@ -32,7 +33,7 @@ const (
 func TestSanity(t *testing.T) {
 	driver := secretsstore.GetDriver()
 	go func() {
-		driver.Run("secrets-store.csi.k8s.io", "somenodeid", endpoint, providerVolumePath, "provider1=0.0.2,provider2=0.0.4", "", nil)
+		driver.Run(context.Background(), "secrets-store.csi.k8s.io", "somenodeid", endpoint, providerVolumePath, "provider1=0.0.2,provider2=0.0.4", "", nil)
 	}()
 
 	config := &sanity.Config{


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleanup missing `Close()` on the unix socket which can lead to the file persistent. This is best effort, if the process does not exist gracefully the socket file could remain.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #367

**Special notes for your reviewer**:
I think this is all that's missing unless I'm misunderstanding #367

The wait group on `NonBlockingGRPCServer` was never actually done. Updated `Start` to pass in a parent cancelable context so that `Start` and `Wait` _could_ finish.