### PR TITLE
fix: skip pods in succeeded or failed phase

### DIFF
--- a/controllers/secretproviderclasspodstatus_controller.go
+++ b/controllers/secretproviderclasspodstatus_controller.go
@@ -219,9 +219,11 @@ func (r *SecretProviderClassPodStatusReconciler) Reconcile(req ctrl.Request) (ct
 		}
 		return ctrl.Result{}, err
 	}
-	// pod is being terminated so don't reconcile
-	if !pod.GetDeletionTimestamp().IsZero() {
-		klog.InfoS("pod is being terminated, skipping reconcile", "pod", klog.KObj(pod))
+	// skip reconcile if the pod is being terminated
+	// or the pod is in succeeded state (for jobs that complete aren't gc yet)
+	// or the pod is in a failed state (all containers get terminated)
+	if !pod.GetDeletionTimestamp().IsZero() || pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+		klog.V(5).InfoS("pod is being terminated, skipping reconcile", "pod", klog.KObj(pod))
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/rotation/reconciler_test.go
+++ b/pkg/rotation/reconciler_test.go
@@ -607,6 +607,18 @@ func TestReconcileNoError(t *testing.T) {
 
 	err = testReconciler.reconcile(context.TODO(), secretProviderClassPodStatusToProcess)
 	g.Expect(err).NotTo(HaveOccurred())
+
+	// test with pod being in succeeded phase
+	podToAdd.DeletionTimestamp = nil
+	podToAdd.Status.Phase = v1.PodSucceeded
+	kubeClient = fake.NewSimpleClientset(podToAdd, secretToAdd)
+	testReconciler, err = newTestReconciler(scheme, kubeClient, crdClient, ctrlClient, 60*time.Second, socketPath)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = testReconciler.store.Run(wait.NeverStop)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	err = testReconciler.reconcile(context.TODO(), secretProviderClassPodStatusToProcess)
+	g.Expect(err).NotTo(HaveOccurred())
 }
 
 func TestPatchSecret(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
We already check for pods in terminating state and skip them:
https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/9e70aa690aeb2fc8dc6bbfcf8ce6879f8b12c65b/pkg/rotation/reconciler.go#L182-L187

However, for pods generated as part of cronjob, they are set to `Completed` state but aren't garbage collected until much later based on `.spec.successfulJobsHistoryLimit` or `.spec.failedJobsHistoryLimit`. The `.status.Phase` for the completed pods are set to `Succeeded` and for failed pods it's `Failed`.

```json
	// PodSucceeded means that all containers in the pod have voluntarily terminated
	// with a container exit code of 0, and the system is not going to restart any of these containers.
	PodSucceeded PodPhase = "Succeeded"
	// PodFailed means that all containers in the pod have terminated, and at least one container has
	// terminated in a failure (exited with a non-zero exit code or was stopped by the system).
	PodFailed PodPhase = "Failed"
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #385 

**Special notes for your reviewer**: