### PR TITLE
feat: Reuse provider grpc clients

### DIFF
--- a/pkg/csi-common/server.go
+++ b/pkg/csi-common/server.go
@@ -70,6 +70,8 @@ func (s *nonBlockingGRPCServer) ForceStop() {
 }
 
 func (s *nonBlockingGRPCServer) serve(ctx context.Context, endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer) {
+	defer s.wg.Done()
+
 	proto, addr, err := ParseEndpoint(endpoint)
 	if err != nil {
 		klog.Fatal(err.Error())
@@ -117,5 +119,4 @@ func (s *nonBlockingGRPCServer) serve(ctx context.Context, endpoint string, ids 
 
 	<-ctx.Done()
 	server.GracefulStop()
-	s.wg.Done()
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -29,8 +29,8 @@ const (
 	FailedToMount = "FailedToMount"
 	// SecretProviderClassNotFound error
 	SecretProviderClassNotFound = "SecretProviderClassNotFound"
-	// FailedToCreateProviderGRPCClient error
-	FailedToCreateProviderGRPCClient = "FailedToCreateProviderGRPCClient"
+	// FailedToLookupProviderGRPCClient error
+	FailedToLookupProviderGRPCClient = "FailedToLookupProviderGRPCClient"
 	// GRPCProviderError error
 	GRPCProviderError = "GRPCProviderError"
 	// FailedToRotate error

--- a/pkg/secrets-store/provider_client_test.go
+++ b/pkg/secrets-store/provider_client_test.go
@@ -67,6 +67,7 @@ func TestMountContent(t *testing.T) {
 			if err != nil {
 				t.Fatalf("expected err to be nil, got: %+v", err)
 			}
+			defer client.Close()
 			serverEndpoint := fmt.Sprintf("%s/%s.sock", test.socketPath, test.providerName)
 			defer os.Remove(serverEndpoint)
 
@@ -173,6 +174,7 @@ func TestMountContentError(t *testing.T) {
 			if err != nil {
 				t.Fatalf("expected err to be nil, got: %+v", err)
 			}
+			defer client.Close()
 			serverEndpoint := fmt.Sprintf("%s/%s.sock", test.socketPath, test.providerName)
 			defer os.Remove(serverEndpoint)
 

--- a/pkg/secrets-store/utils_test.go
+++ b/pkg/secrets-store/utils_test.go
@@ -45,7 +45,7 @@ func TestGetProviderPath(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		testNodeServer, err := newNodeServer(NewFakeDriver(), tc.providerVolumePath, "", "", "test-node", &mount.FakeMounter{}, fake.NewFakeClientWithScheme(nil), NewStatsReporter())
+		testNodeServer, err := newNodeServer(NewFakeDriver(), tc.providerVolumePath, "", "test-node", &mount.FakeMounter{}, nil, fake.NewFakeClientWithScheme(nil), NewStatsReporter())
 		assert.NoError(t, err)
 		assert.NotNil(t, testNodeServer)
 

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -34,7 +34,7 @@ const (
 func TestSanity(t *testing.T) {
 	driver := secretsstore.GetDriver()
 	go func() {
-		driver.Run(context.Background(), "secrets-store.csi.k8s.io", "somenodeid", endpoint, providerVolumePath, "provider1=0.0.2,provider2=0.0.4", "", nil)
+		driver.Run(context.Background(), "secrets-store.csi.k8s.io", "somenodeid", endpoint, providerVolumePath, "provider1=0.0.2,provider2=0.0.4", nil, nil)
 	}()
 
 	tmpPath := filepath.Join(os.TempDir(), "csi")


### PR DESCRIPTION
Create the provider GRPC clients during process initialization instead
of on-demand. The Dial() call is non-blocking and if the connection is
disrupted grpc should re-establish the connection. By configuring RPCs
to retry through a service configuration, this will ensure that when a
plugin is restarted the connection will be re-dialed and the RPC
retried.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #300

**Special notes for your reviewer**: