### PR TITLE
feat: add pprof profiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,13 @@ override IMAGE_VERSION := $(E2E_IMAGE_VERSION)
 endif
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)
 IMAGE_TAG_LATEST=$(REGISTRY)/$(IMAGE_NAME):latest
-LDFLAGS?='-X sigs.k8s.io/secrets-store-csi-driver/pkg/secrets-store.vendorVersion=$(IMAGE_VERSION) -extldflags "-static"'
+
+BUILD_TIMESTAMP := $$(date +%Y-%m-%d-%H:%M)
+BUILD_COMMIT := $$(git rev-parse --short HEAD)
+
+LDFLAGS?="-X sigs.k8s.io/secrets-store-csi-driver/pkg/version.BuildVersion=$(IMAGE_VERSION) \
+			-X sigs.k8s.io/secrets-store-csi-driver/pkg/version.Vcs=$(BUILD_COMMIT) \
+			-X sigs.k8s.io/secrets-store-csi-driver/pkg/version.BuildTime=$(BUILD_TIMESTAMP) --extldflags "-static""
 GO_FILES=$(shell go list ./... | grep -v /test/sanity)
 
 .PHONY: all build image clean test-style

--- a/pkg/csi-common/driver.go
+++ b/pkg/csi-common/driver.go
@@ -42,12 +42,10 @@ func NewCSIDriver(name string, v string, nodeID string) *CSIDriver {
 		klog.Errorf("Driver name missing")
 		return nil
 	}
-
 	if nodeID == "" {
 		klog.Errorf("NodeID missing")
 		return nil
 	}
-	// TODO version format and validation
 	if len(v) == 0 {
 		klog.Errorf("Version argument missing")
 		return nil

--- a/pkg/rotation/reconciler.go
+++ b/pkg/rotation/reconciler.go
@@ -50,6 +50,7 @@ import (
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/fileutil"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/k8sutil"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/secretutil"
+	"sigs.k8s.io/secrets-store-csi-driver/pkg/version"
 )
 
 const (
@@ -88,6 +89,7 @@ func NewReconciler(s *runtime.Scheme, providerVolumePath, nodeName string, rotat
 	if err != nil {
 		return nil, err
 	}
+	config.UserAgent = version.GetUserAgent("rotation")
 	kubeClient := kubernetes.NewForConfigOrDie(config)
 	crdClient := secretsStoreClient.NewForConfigOrDie(config)
 	c, err := client.New(config, client.Options{Scheme: s, Mapper: nil})

--- a/pkg/secrets-store/secrets-store.go
+++ b/pkg/secrets-store/secrets-store.go
@@ -39,10 +39,6 @@ type SecretsStore struct {
 	ids    *identityServer
 }
 
-var (
-	vendorVersion = "0.0.17"
-)
-
 // GetDriver returns a new secrets store driver
 func GetDriver() *SecretsStore {
 	return &SecretsStore{}
@@ -90,15 +86,14 @@ func newIdentityServer(d *csicommon.CSIDriver) *identityServer {
 // Run starts the CSI plugin
 func (s *SecretsStore) Run(ctx context.Context, driverName, nodeID, endpoint, providerVolumePath, minProviderVersions string, providerClients map[string]*CSIProviderClient, client client.Client) {
 	klog.Infof("Driver: %v ", driverName)
-	klog.Infof("Version: %s", vendorVersion)
+	klog.Infof("Version: %s, BuildTime: %s", version.BuildVersion, version.BuildTime)
 	klog.Infof("Provider Volume Path: %s", providerVolumePath)
-	klog.Infof("Minimum provider versions: %s", minProviderVersions)
 	for p := range providerClients {
 		klog.Infof("GRPC supported provider: %s", p)
 	}
 
 	// Initialize default library driver
-	s.driver = csicommon.NewCSIDriver(driverName, vendorVersion, nodeID)
+	s.driver = csicommon.NewCSIDriver(driverName, version.BuildVersion, nodeID)
 	if s.driver == nil {
 		klog.Fatal("Failed to initialize SecretsStore CSI Driver.")
 	}

--- a/pkg/secrets-store/secrets-store_test.go
+++ b/pkg/secrets-store/secrets-store_test.go
@@ -19,11 +19,12 @@ package secretsstore
 import csicommon "sigs.k8s.io/secrets-store-csi-driver/pkg/csi-common"
 
 const (
-	fakeDriverName = "fake"
-	fakeNodeID     = "fakeNodeID"
+	fakeDriverName    = "fake"
+	fakeNodeID        = "fakeNodeID"
+	fakeVendorVersion = "fakeDriverVersion"
 )
 
 func NewFakeDriver() *csicommon.CSIDriver {
-	driver := csicommon.NewCSIDriver(fakeDriverName, vendorVersion, fakeNodeID)
+	driver := csicommon.NewCSIDriver(fakeDriverName, fakeVendorVersion, fakeNodeID)
 	return driver
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,12 +19,28 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/blang/semver"
 	"k8s.io/klog/v2"
 )
 
+var (
+	// Vcs is the commit hash for the binary build
+	Vcs string
+	// BuildTime is the date for the binary build
+	BuildTime string
+	// BuildVersion is the secrets-store-csi-driver version
+	BuildVersion string
+)
+
+// GetUserAgent returns a user agent of the format: csi-secrets-store/<controller name>/<version> (<goos>/<goarch>) <vcs>/<timestamp>
+func GetUserAgent(controllerName string) string {
+	return fmt.Sprintf("csi-secrets-store/%s/%s (%s/%s) %s/%s", controllerName, BuildVersion, runtime.GOOS, runtime.GOARCH, Vcs, BuildTime)
+}
+
+// TODO (aramase) remove these functions after all providers have switched to using gRPC
 // providerVersion holds current provider version
 type providerVersion struct {
 	// Version is the current provider version

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -19,10 +19,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/kubernetes-csi/csi-test/v4/pkg/sanity"
 
 	secretsstore "sigs.k8s.io/secrets-store-csi-driver/pkg/secrets-store"
+	"sigs.k8s.io/secrets-store-csi-driver/pkg/version"
 )
 
 const (
@@ -47,6 +49,9 @@ func TestSanity(t *testing.T) {
 	config.RemoveTargetPath = func(targetPath string) error {
 		return os.RemoveAll(targetPath)
 	}
+
+	version.BuildVersion = "mock"
+	version.BuildTime = time.Now().String()
 	sanity.Test(t, config)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds pprof profiling
- Uses `6065` as default port to avoid conflicts with other processes running profiling

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Example user agent:
```
➜ _output/secrets-store-csi --enable-pprof
I1130 12:18:21.153207   35656 main.go:85] Starting profiling on port 6065
I1130 12:18:21.153327   35656 main.go:92] user agent: csi-secrets-store/controller/v0.0.17 (darwin/amd64) d19088bd/2020-11-30-12:17
I1130 12:18:21.153339   35656 exporter.go:33] metrics backend: prometheus
```