### PR TITLE
feat: use common port for all metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/kubernetes-csi/csi-lib-utils v0.7.1
 	github.com/kubernetes-csi/csi-test/v4 v4.0.2
 	github.com/onsi/gomega v1.10.1
-	github.com/prometheus/client_golang v1.8.0 // indirect
+	github.com/prometheus/client_golang v1.8.0
 	github.com/stretchr/testify v1.6.1
 	go.opentelemetry.io/otel v0.13.0
 	go.opentelemetry.io/otel/exporters/metric/prometheus v0.13.0

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	metricsBackend = flag.String("metrics-backend", "Prometheus", "Backend used for metrics")
-	prometheusPort = flag.Int("prometheus-port", 8888, "Prometheus port for metrics backend")
+	_              = flag.Int("prometheus-port", 8888, "Prometheus port for metrics backend [DEPRECATED]. Use --metrics-addr instead.")
 )
 
 const prometheusExporter = "prometheus"

--- a/pkg/metrics/prometheus_exporter.go
+++ b/pkg/metrics/prometheus_exporter.go
@@ -14,28 +14,18 @@ limitations under the License.
 package metrics
 
 import (
-	"fmt"
-	"net/http"
+	otProm "go.opentelemetry.io/otel/exporters/metric/prometheus"
 
-	"go.opentelemetry.io/otel/exporters/metric/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 func initPrometheusExporter() error {
-	/*
-		Prometheus exporter for opentelemetry is under active development
-		Defining the buckets is due to change in future release - https://github.com/open-telemetry/opentelemetry-go/issues/689
-	*/
-	pusher, err := prometheus.InstallNewPipeline(prometheus.Config{
+	_, err := otProm.InstallNewPipeline(otProm.Config{
+		Registry: metrics.Registry.(*prometheus.Registry), // using the controller-runtime prometheus metrics registry
 		DefaultHistogramBoundaries: []float64{
 			0.1, 0.2, 0.3, 0.4, 0.5, 1, 1.5, 2, 2.5, 3.0, 5.0, 10.0, 15.0, 30.0,
 		}})
-	if err != nil {
-		return err
-	}
-	http.HandleFunc("/", pusher.ServeHTTP)
-	go func() {
-		_ = http.ListenAndServe(fmt.Sprintf(":%v", *prometheusPort), nil)
-	}()
 
-	return nil
+	return err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Use controller-runtime prom registry to init exporter. This will publish `controller-runtime` and `driver` metrics to the same url `http://localhost:<metrics addr>/metrics`

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #411 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
