### PR TITLE
chore: bump driver version to v0.0.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ REGISTRY?=docker.io/deislabs
 REGISTRY_NAME = $(shell echo $(REGISTRY) | sed "s/.azurecr.io//g")
 GIT_COMMIT ?= $(shell git rev-parse HEAD)
 IMAGE_NAME=secrets-store-csi
-IMAGE_VERSION?=v0.0.19-rc.00
+IMAGE_VERSION?=v0.0.19
 E2E_IMAGE_VERSION = v0.1.0-e2e-$(GIT_COMMIT)
 # Use a custom version for E2E tests if we are testing in CI
 ifdef CI

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -14,7 +14,7 @@
 
 REGISTRY?=docker.io/deislabs
 IMAGE_NAME=driver
-IMAGE_VERSION?=v0.0.19-rc.00
+IMAGE_VERSION?=v0.0.19
 BUILD_TIMESTAMP := $(shell date +%Y-%m-%d-%H:%M)
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
