### PR TITLE
Update e2e tests for gRPC Vault provider release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ else
 			--set linux.image.repository="e2e/secrets-store-csi" \
 			--set linux.image.tag=$(IMAGE_VERSION) \
 			--set linux.image.pullPolicy="IfNotPresent" \
-			--set grpcSupportedProviders="azure;gcp" \
+			--set grpcSupportedProviders="azure;gcp;vault" \
 			--set enableSecretRotation=true \
 			--set rotationPollInterval=30s
 endif

--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -105,7 +105,7 @@ EOF
   assert_success
 
   run kubectl exec $VAULT_POD -- vault write auth/kubernetes/role/example-role \
-    bound_service_account_names=secrets-store-csi-driver \
+    bound_service_account_names=secrets-store-csi-driver-provider-vault \
     bound_service_account_namespaces=$NAMESPACE \
     policies=default,example-readonly \
     ttl=20m


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the tests that got broken with the release of Vault provider [0.0.7](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/releases/tag/0.0.7), and the update of `deploy/` on `master` to use that release - raising this was just dependent on getting the fix in https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/pull/58 merged first.

**Which issue(s) this PR fixes**:
Fixes #429.