### PR TITLE
Update mdbook to 0.4.5 to fix CVE-2020-26297

### DIFF
--- a/docs/book/install-and-build.sh
+++ b/docs/book/install-and-build.sh
@@ -23,7 +23,7 @@ cd "${KUBE_ROOT}" || exit 1
 
 os=$(go env GOOS)
 arch=$(go env GOARCH)
-mdBookVersion="v0.4.3"
+mdBookVersion="v0.4.5"
 
 # translate arch to rust's conventions (if we can)
 if [[ ${arch} == "amd64" ]]; then


### PR DESCRIPTION
See https://blog.rust-lang.org/2021/01/04/mdbook-security-advisory.html for more details.

Thanks!
