### PR TITLE
feat: set secrets-store default container for log

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
     {{- if .Values.windows.podAnnotations }}
       annotations:
+        kubectl.kubernetes.io/default-logs-container: secrets-store
 {{ toYaml .Values.windows.podAnnotations | indent 8 }}
     {{- end }}
 {{ include "sscd.labels" . | indent 6 }}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
     {{- if .Values.linux.podAnnotations }}
       annotations:
+        kubectl.kubernetes.io/default-logs-container: secrets-store
 {{ toYaml .Values.linux.podAnnotations | indent 8 }}
     {{- end }}
 {{ include "sscd.labels" . | indent 6 }}

--- a/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         app: csi-secrets-store
+      annotations:
+        kubectl.kubernetes.io/default-logs-container: secrets-store
     spec:
       serviceAccountName: secrets-store-csi-driver
       containers:

--- a/manifest_staging/deploy/secrets-store-csi-driver.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver.yaml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         app: csi-secrets-store
+      annotations:
+        kubectl.kubernetes.io/default-logs-container: secrets-store
     spec:
       serviceAccountName: secrets-store-csi-driver
       containers:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Sets `secrets-store` container as default container for log

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
