### PR TITLE
release: bump version to v0.0.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ REPO_PATH="$(ORG_PATH)/$(PROJECT_NAME)"
 
 REGISTRY ?= gcr.io/k8s-staging-csi-secrets-store
 IMAGE_NAME ?= driver
-IMAGE_VERSION ?= v0.0.20-rc.00
+IMAGE_VERSION ?= v0.0.20
 E2E_IMAGE_VERSION = v0.1.0-e2e-$(BUILD_COMMIT)
 # Use a custom version for E2E tests if we are testing in CI
 ifdef CI

--- a/docker/BASEIMAGE
+++ b/docker/BASEIMAGE
@@ -1,5 +1,5 @@
-linux/amd64=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.3.0
+linux/amd64=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.4.0
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/1903=mcr.microsoft.com/windows/nanoserver:1903
 windows/amd64/1909=mcr.microsoft.com/windows/nanoserver:1909
-windows/amd64/1909=mcr.microsoft.com/windows/nanoserver:2004
+windows/amd64/2004=mcr.microsoft.com/windows/nanoserver:2004

--- a/docker/BASEIMAGE_CORE
+++ b/docker/BASEIMAGE_CORE
@@ -1,4 +1,4 @@
 windows/amd64/1809=mcr.microsoft.com/windows/servercore:1809
 windows/amd64/1903=mcr.microsoft.com/windows/servercore:1903
 windows/amd64/1909=mcr.microsoft.com/windows/servercore:1909
-windows/amd64/1909=mcr.microsoft.com/windows/servercore:2004
+windows/amd64/2004=mcr.microsoft.com/windows/servercore:2004

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.3.0
+ARG BASEIMAGE=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.4.0
 
 FROM golang:1.13.10-alpine3.10 as builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -14,7 +14,7 @@
 
 REGISTRY?=docker.io/deislabs
 IMAGE_NAME=driver
-IMAGE_VERSION?=v0.0.20-rc.00
+IMAGE_VERSION?=v0.0.20
 BUILD_TIMESTAMP := $(shell date +%Y-%m-%d-%H:%M)
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Bump debian base image to `us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.4.0`

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
