### PR TITLE
feat: add filtered watch for reconcile

### DIFF
--- a/cmd/secrets-store-csi-driver/main.go
+++ b/cmd/secrets-store-csi-driver/main.go
@@ -37,8 +37,6 @@ import (
 	"k8s.io/klog/v2"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
 	"sigs.k8s.io/secrets-store-csi-driver/controllers"
@@ -170,16 +168,8 @@ func main() {
 		go rec.Run(ctx.Done())
 	}
 
-	ccfg, err := config.GetConfig()
-	if err != nil {
-		klog.Fatalf("failed to initialize driver, error getting config: %+v", err)
-	}
-	c, err := client.New(ccfg, client.Options{Scheme: scheme, Mapper: nil})
-	if err != nil {
-		klog.Fatalf("failed to initialize driver, error creating client: %+v", err)
-	}
 	driver := secretsstore.GetDriver()
-	driver.Run(ctx, *driverName, *nodeID, *endpoint, *providerVolumePath, providerClients, c)
+	driver.Run(ctx, *driverName, *nodeID, *endpoint, *providerVolumePath, providerClients, mgr.GetClient())
 }
 
 // withShutdownSignal returns a copy of the parent context that will close if

--- a/controllers/secretproviderclasspodstatus_controller.go
+++ b/controllers/secretproviderclasspodstatus_controller.go
@@ -364,26 +364,23 @@ func (r *SecretProviderClassPodStatusReconciler) SetupWithManager(mgr ctrl.Manag
 func (r *SecretProviderClassPodStatusReconciler) belongsToNodePredicate() predicate.Funcs {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return r.processIfBelongsToNode(e.ObjectNew, e.MetaNew)
+			return r.processIfBelongsToNode(e.ObjectNew)
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
-			return r.processIfBelongsToNode(e.Object, e.Meta)
+			return r.processIfBelongsToNode(e.Object)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return false
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
-			return r.processIfBelongsToNode(e.Object, e.Meta)
+			return r.processIfBelongsToNode(e.Object)
 		},
 	}
 }
 
 // processIfBelongsToNode determines if the secretproviderclasspodstatus belongs to the node based on the
 // internal.secrets-store.csi.k8s.io/node-name: <node name> label. If belongs to node, then the spcps is processed.
-func (r *SecretProviderClassPodStatusReconciler) processIfBelongsToNode(obj runtime.Object, objMeta metav1.Object) bool {
-	if _, ok := obj.(*v1alpha1.SecretProviderClassPodStatus); !ok {
-		return false
-	}
+func (r *SecretProviderClassPodStatusReconciler) processIfBelongsToNode(objMeta metav1.Object) bool {
 	node, ok := objMeta.GetLabels()[v1alpha1.InternalNodeLabel]
 	if !ok {
 		return false

--- a/controllers/secretproviderclasspodstatus_controller.go
+++ b/controllers/secretproviderclasspodstatus_controller.go
@@ -55,6 +55,7 @@ import (
 
 const (
 	SecretManagedLabel         = "secrets-store.csi.k8s.io/managed"
+	SecretUsedLabel            = "secrets-store.csi.k8s.io/used"
 	secretCreationFailedReason = "FailedToCreateSecret"
 )
 
@@ -123,7 +124,7 @@ func (r *SecretProviderClassPodStatusReconciler) Patcher(ctx context.Context) er
 		spc := &v1alpha1.SecretProviderClass{}
 		namespace := spcPodStatuses[i].Namespace
 
-		if val, exists := spcMap[spcPodStatuses[i].Namespace+"/"+spcName]; exists {
+		if val, exists := spcMap[namespace+"/"+spcName]; exists {
 			spc = &val
 		} else {
 			if err := r.reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: spcName}, spc); err != nil {
@@ -165,7 +166,7 @@ func (r *SecretProviderClassPodStatusReconciler) Patcher(ctx context.Context) er
 		}
 
 		for _, secret := range spc.Spec.SecretObjects {
-			key := types.NamespacedName{Name: secret.SecretName, Namespace: spcPodStatuses[i].Namespace}
+			key := types.NamespacedName{Name: secret.SecretName, Namespace: namespace}
 			val, exists := secretOwnerMap[key]
 			if exists {
 				secretOwnerMap[key] = append(val, ownerRefs...)

--- a/controllers/secretproviderclasspodstatus_controller.go
+++ b/controllers/secretproviderclasspodstatus_controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -40,7 +41,6 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -54,7 +54,7 @@ import (
 )
 
 const (
-	secretManagedLabel         = "secrets-store.csi.k8s.io/managed"
+	SecretManagedLabel         = "secrets-store.csi.k8s.io/managed"
 	secretCreationFailedReason = "FailedToCreateSecret"
 )
 
@@ -110,7 +110,7 @@ func (r *SecretProviderClassPodStatusReconciler) Patcher(ctx context.Context) er
 
 	spcPodStatusList := &v1alpha1.SecretProviderClassPodStatusList{}
 	spcMap := make(map[string]v1alpha1.SecretProviderClass)
-	secretOwnerMap := make(map[types.NamespacedName][]*v1alpha1.SecretProviderClassPodStatus)
+	secretOwnerMap := make(map[types.NamespacedName][]metav1.OwnerReference)
 	// get a list of all spc pod status that belong to the node
 	err := r.reader.List(ctx, spcPodStatusList, r.ListOptionsLabelSelector())
 	if err != nil {
@@ -121,21 +121,56 @@ func (r *SecretProviderClassPodStatusReconciler) Patcher(ctx context.Context) er
 	for i := range spcPodStatuses {
 		spcName := spcPodStatuses[i].Status.SecretProviderClassName
 		spc := &v1alpha1.SecretProviderClass{}
+		namespace := spcPodStatuses[i].Namespace
+
 		if val, exists := spcMap[spcPodStatuses[i].Namespace+"/"+spcName]; exists {
 			spc = &val
 		} else {
-			if err := r.reader.Get(ctx, client.ObjectKey{Namespace: spcPodStatuses[i].Namespace, Name: spcName}, spc); err != nil {
+			if err := r.reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: spcName}, spc); err != nil {
 				return fmt.Errorf("failed to get spc %s, err: %+v", spcName, err)
 			}
-			spcMap[spcPodStatuses[i].Namespace+"/"+spcName] = *spc
+			spcMap[namespace+"/"+spcName] = *spc
 		}
+		// get the pod and check if the pod has a owner reference
+		pod := &v1.Pod{}
+		err = r.reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: spcPodStatuses[i].Status.PodName}, pod)
+		if err != nil {
+			return fmt.Errorf("failed to fetch pod during patching, err: %+v", err)
+		}
+		var ownerRefs []metav1.OwnerReference
+		for _, ownerRef := range pod.GetOwnerReferences() {
+			ownerRefs = append(ownerRefs, metav1.OwnerReference{
+				APIVersion: ownerRef.APIVersion,
+				Kind:       ownerRef.Kind,
+				UID:        ownerRef.UID,
+				Name:       ownerRef.Name,
+			})
+		}
+		// If a pod has no owner references, then it's a static pod and
+		// doesn't belong to a replicaset. In this case, use the spcps as
+		// owner reference just like we do it today
+		if len(ownerRefs) == 0 {
+			// Create a new owner ref.
+			gvk, err := apiutil.GVKForObject(&spcPodStatuses[i], r.scheme)
+			if err != nil {
+				return err
+			}
+			ref := metav1.OwnerReference{
+				APIVersion: gvk.GroupVersion().String(),
+				Kind:       gvk.Kind,
+				UID:        spcPodStatuses[i].GetUID(),
+				Name:       spcPodStatuses[i].GetName(),
+			}
+			ownerRefs = append(ownerRefs, ref)
+		}
+
 		for _, secret := range spc.Spec.SecretObjects {
 			key := types.NamespacedName{Name: secret.SecretName, Namespace: spcPodStatuses[i].Namespace}
 			val, exists := secretOwnerMap[key]
 			if exists {
-				secretOwnerMap[key] = append(val, &spcPodStatuses[i])
+				secretOwnerMap[key] = append(val, ownerRefs...)
 			} else {
-				secretOwnerMap[key] = []*v1alpha1.SecretProviderClassPodStatus{&spcPodStatuses[i]}
+				secretOwnerMap[key] = ownerRefs
 			}
 		}
 	}
@@ -282,7 +317,7 @@ func (r *SecretProviderClassPodStatusReconciler) Reconcile(ctx context.Context, 
 			// Set secrets-store.csi.k8s.io/managed=true label on the secret that's created and managed
 			// by the secrets-store-csi-driver. This label will be used to perform a filtered list watch
 			// only on secrets created and managed by the driver
-			labelsMap[secretManagedLabel] = "true"
+			labelsMap[SecretManagedLabel] = "true"
 
 			createFn := func() (bool, error) {
 				if err := r.createK8sSecret(ctx, secretName, req.Namespace, datamap, labelsMap, secretType); err != nil {
@@ -384,7 +419,7 @@ func (r *SecretProviderClassPodStatusReconciler) createK8sSecret(ctx context.Con
 }
 
 // patchSecretWithOwnerRef patches the secret owner reference with the spc pod status
-func (r *SecretProviderClassPodStatusReconciler) patchSecretWithOwnerRef(ctx context.Context, name, namespace string, spcPodStatus ...*v1alpha1.SecretProviderClassPodStatus) error {
+func (r *SecretProviderClassPodStatusReconciler) patchSecretWithOwnerRef(ctx context.Context, name, namespace string, ownerRefs ...metav1.OwnerReference) error {
 	secret := &corev1.Secret{}
 	secretKey := types.NamespacedName{
 		Namespace: namespace,
@@ -401,23 +436,23 @@ func (r *SecretProviderClassPodStatusReconciler) patchSecretWithOwnerRef(ctx con
 	patch := client.MergeFromWithOptions(secret.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	needsPatch := false
 
+	secretOwnerRefs := secret.GetOwnerReferences()
 	secretOwnerMap := make(map[string]types.UID)
-	for _, or := range secret.GetOwnerReferences() {
+	for _, or := range secretOwnerRefs {
 		secretOwnerMap[or.Name] = or.UID
 	}
 
-	for i := range spcPodStatus {
-		if _, exists := secretOwnerMap[spcPodStatus[i].Name]; exists {
+	for i := range ownerRefs {
+		if _, exists := secretOwnerMap[ownerRefs[i].Name]; exists {
 			continue
 		}
 		needsPatch = true
-		err := controllerutil.SetOwnerReference(spcPodStatus[i], secret, r.scheme)
-		if err != nil {
-			return err
-		}
+		klog.Infof("Adding %s/%s as owner ref for %s/%s", ownerRefs[i].APIVersion, ownerRefs[i].Name, namespace, name)
+		secretOwnerRefs = append(secretOwnerRefs, ownerRefs[i])
 	}
 
 	if needsPatch {
+		secret.SetOwnerReferences(secretOwnerRefs)
 		return r.writer.Patch(ctx, secret, patch)
 	}
 	return nil

--- a/pkg/cache/README.md
+++ b/pkg/cache/README.md
@@ -1,0 +1,7 @@
+# sigs.k8s.io/controller-runtime/pkg/cache
+
+The cache package has been forked from [`sigs.k8s.io/controller-runtime@a8c19c49e49cfba2aa486ff322cbe5222d6da533 (v0.8.2)`](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.8.2).
+
+This fork has been modified to add the ability to perform filtered `ListWatch` based on the field or label selectors.
+
+The original code for the cache package can be found at [https://github.com/kubernetes-sigs/controller-runtime/tree/v0.8.2/pkg/cache](https://github.com/kubernetes-sigs/controller-runtime/tree/v0.8.2/pkg/cache). We'll switch to using the default cache package in controller-runtime after this [Enable filtered list watches as watches](https://github.com/kubernetes-sigs/controller-runtime/issues/244) is implemented.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"time"
+
+	"sigs.k8s.io/secrets-store-csi-driver/pkg/cache/internal"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	crcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+var log = ctrl.Log.WithName("object-cache")
+
+var defaultResyncTime = 10 * time.Hour
+
+// Options are the optional arguments for creating a new InformersMap object
+type Options struct {
+	crcache.Options
+	FieldSelectorByResource map[string]string
+	LabelSelectorByResource map[string]string
+}
+
+// New initializes and returns a new Cache.
+func New(config *rest.Config, opts Options) (crcache.Cache, error) {
+	opts, err := defaultOpts(config, opts)
+	if err != nil {
+		return nil, err
+	}
+	im := internal.NewInformersMap(config, opts.Scheme, opts.Mapper, *opts.Resync, opts.Namespace, opts.FieldSelectorByResource, opts.LabelSelectorByResource)
+	return &informerCache{InformersMap: im}, nil
+}
+
+func Builder(opts Options) crcache.NewCacheFunc {
+	return func(config *rest.Config, cropts crcache.Options) (crcache.Cache, error) {
+		opts.Options = cropts
+		return New(config, opts)
+	}
+}
+
+func defaultOpts(config *rest.Config, opts Options) (Options, error) {
+	// Use the default Kubernetes Scheme if unset
+	if opts.Scheme == nil {
+		opts.Scheme = scheme.Scheme
+	}
+
+	// Construct a new Mapper if unset
+	if opts.Mapper == nil {
+		var err error
+		opts.Mapper, err = apiutil.NewDiscoveryRESTMapper(config)
+		if err != nil {
+			log.WithName("setup").Error(err, "Failed to get API Group-Resources")
+			return opts, fmt.Errorf("could not create RESTMapper from config")
+		}
+	}
+
+	// Default the resync period to 10 hours if unset
+	if opts.Resync == nil {
+		opts.Resync = &defaultResyncTime
+	}
+	return opts, nil
+}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -22,6 +22,7 @@ import (
 
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/cache/internal"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -31,14 +32,19 @@ import (
 
 var log = ctrl.Log.WithName("object-cache")
 
-var defaultResyncTime = 10 * time.Hour
-
 // Options are the optional arguments for creating a new InformersMap object
 type Options struct {
 	crcache.Options
-	FieldSelectorByResource map[string]string
-	LabelSelectorByResource map[string]string
+	// FieldSelectorByResource restricts the cache's ListWatch to the resources with desired field
+	// Default watches resources with any field
+	FieldSelectorByResource map[schema.GroupResource]string
+
+	// LabelSelectorByResource restricts the cache's ListWatch to the resources with desired label
+	// Default watches resources with any label
+	LabelSelectorByResource map[schema.GroupResource]string
 }
+
+var defaultResyncTime = 10 * time.Hour
 
 // New initializes and returns a new Cache.
 func New(config *rest.Config, opts Options) (crcache.Cache, error) {

--- a/pkg/cache/doc.go
+++ b/pkg/cache/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cache provides object caches that act as caching client.Reader
+// instances and help drive Kubernetes-object-based event handlers.
+package cache

--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"strings"
 
+	crcache "sigs.k8s.io/controller-runtime/pkg/cache"
+
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/cache/internal"
 
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -29,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
-	crcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
@@ -53,7 +54,7 @@ type informerCache struct {
 }
 
 // Get implements Reader
-func (ip *informerCache) Get(ctx context.Context, key client.ObjectKey, out runtime.Object) error {
+func (ip *informerCache) Get(ctx context.Context, key client.ObjectKey, out client.Object) error {
 	gvk, err := apiutil.GVKForObject(out, ip.Scheme)
 	if err != nil {
 		return err
@@ -71,7 +72,7 @@ func (ip *informerCache) Get(ctx context.Context, key client.ObjectKey, out runt
 }
 
 // List implements Reader
-func (ip *informerCache) List(ctx context.Context, out runtime.Object, opts ...client.ListOption) error {
+func (ip *informerCache) List(ctx context.Context, out client.ObjectList, opts ...client.ListOption) error {
 
 	gvk, cacheTypeObj, err := ip.objectTypeForListObject(out)
 	if err != nil {
@@ -93,7 +94,7 @@ func (ip *informerCache) List(ctx context.Context, out runtime.Object, opts ...c
 // objectTypeForListObject tries to find the runtime.Object and associated GVK
 // for a single object corresponding to the passed-in list type. We need them
 // because they are used as cache map key.
-func (ip *informerCache) objectTypeForListObject(list runtime.Object) (*schema.GroupVersionKind, runtime.Object, error) {
+func (ip *informerCache) objectTypeForListObject(list client.ObjectList) (*schema.GroupVersionKind, runtime.Object, error) {
 	gvk, err := apiutil.GVKForObject(list, ip.Scheme)
 	if err != nil {
 		return nil, nil, err
@@ -148,7 +149,7 @@ func (ip *informerCache) GetInformerForKind(ctx context.Context, gvk schema.Grou
 }
 
 // GetInformer returns the informer for the obj
-func (ip *informerCache) GetInformer(ctx context.Context, obj runtime.Object) (crcache.Informer, error) {
+func (ip *informerCache) GetInformer(ctx context.Context, obj client.Object) (crcache.Informer, error) {
 	gvk, err := apiutil.GVKForObject(obj, ip.Scheme)
 	if err != nil {
 		return nil, err
@@ -172,7 +173,7 @@ func (ip *informerCache) NeedLeaderElection() bool {
 // to List. For one-to-one compatibility with "normal" field selectors, only return one value.
 // The values may be anything.  They will automatically be prefixed with the namespace of the
 // given object, if present.  The objects passed are guaranteed to be objects of the correct type.
-func (ip *informerCache) IndexField(ctx context.Context, obj runtime.Object, field string, extractValue client.IndexerFunc) error {
+func (ip *informerCache) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
 	informer, err := ip.GetInformer(ctx, obj)
 	if err != nil {
 		return err
@@ -183,7 +184,7 @@ func (ip *informerCache) IndexField(ctx context.Context, obj runtime.Object, fie
 func indexByField(indexer crcache.Informer, field string, extractor client.IndexerFunc) error {
 	indexFunc := func(objRaw interface{}) ([]string, error) {
 		// TODO(directxman12): check if this is the correct type?
-		obj, isObj := objRaw.(runtime.Object)
+		obj, isObj := objRaw.(client.Object)
 		if !isObj {
 			return nil, fmt.Errorf("object of type %T is not an Object", objRaw)
 		}

--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"sigs.k8s.io/secrets-store-csi-driver/pkg/cache/internal"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+	crcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+var (
+	_ crcache.Informers = &informerCache{}
+	_ client.Reader     = &informerCache{}
+	_ crcache.Cache     = &informerCache{}
+)
+
+// ErrCacheNotStarted is returned when trying to read from the cache that wasn't started.
+type ErrCacheNotStarted struct{}
+
+func (*ErrCacheNotStarted) Error() string {
+	return "the cache is not started, can not read objects"
+}
+
+// informerCache is a Kubernetes Object cache populated from InformersMap.  informerCache wraps an InformersMap.
+type informerCache struct {
+	*internal.InformersMap
+}
+
+// Get implements Reader
+func (ip *informerCache) Get(ctx context.Context, key client.ObjectKey, out runtime.Object) error {
+	gvk, err := apiutil.GVKForObject(out, ip.Scheme)
+	if err != nil {
+		return err
+	}
+
+	started, cache, err := ip.InformersMap.Get(ctx, gvk, out)
+	if err != nil {
+		return err
+	}
+
+	if !started {
+		return &ErrCacheNotStarted{}
+	}
+	return cache.Reader.Get(ctx, key, out)
+}
+
+// List implements Reader
+func (ip *informerCache) List(ctx context.Context, out runtime.Object, opts ...client.ListOption) error {
+
+	gvk, cacheTypeObj, err := ip.objectTypeForListObject(out)
+	if err != nil {
+		return err
+	}
+
+	started, cache, err := ip.InformersMap.Get(ctx, *gvk, cacheTypeObj)
+	if err != nil {
+		return err
+	}
+
+	if !started {
+		return &ErrCacheNotStarted{}
+	}
+
+	return cache.Reader.List(ctx, out, opts...)
+}
+
+// objectTypeForListObject tries to find the runtime.Object and associated GVK
+// for a single object corresponding to the passed-in list type. We need them
+// because they are used as cache map key.
+func (ip *informerCache) objectTypeForListObject(list runtime.Object) (*schema.GroupVersionKind, runtime.Object, error) {
+	gvk, err := apiutil.GVKForObject(list, ip.Scheme)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if !strings.HasSuffix(gvk.Kind, "List") {
+		return nil, nil, fmt.Errorf("non-list type %T (kind %q) passed as output", list, gvk)
+	}
+	// we need the non-list GVK, so chop off the "List" from the end of the kind
+	gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
+	_, isUnstructured := list.(*unstructured.UnstructuredList)
+	var cacheTypeObj runtime.Object
+	if isUnstructured {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(gvk)
+		cacheTypeObj = u
+	} else {
+		itemsPtr, err := apimeta.GetItemsPtr(list)
+		if err != nil {
+			return nil, nil, err
+		}
+		// http://knowyourmeme.com/memes/this-is-fine
+		elemType := reflect.Indirect(reflect.ValueOf(itemsPtr)).Type().Elem()
+		if elemType.Kind() != reflect.Ptr {
+			elemType = reflect.PtrTo(elemType)
+		}
+
+		cacheTypeValue := reflect.Zero(elemType)
+		var ok bool
+		cacheTypeObj, ok = cacheTypeValue.Interface().(runtime.Object)
+		if !ok {
+			return nil, nil, fmt.Errorf("cannot get cache for %T, its element %T is not a runtime.Object", list, cacheTypeValue.Interface())
+		}
+	}
+
+	return &gvk, cacheTypeObj, nil
+}
+
+// GetInformerForKind returns the informer for the GroupVersionKind
+func (ip *informerCache) GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (crcache.Informer, error) {
+	// Map the gvk to an object
+	obj, err := ip.Scheme.New(gvk)
+	if err != nil {
+		return nil, err
+	}
+
+	_, i, err := ip.InformersMap.Get(ctx, gvk, obj)
+	if err != nil {
+		return nil, err
+	}
+	return i.Informer, err
+}
+
+// GetInformer returns the informer for the obj
+func (ip *informerCache) GetInformer(ctx context.Context, obj runtime.Object) (crcache.Informer, error) {
+	gvk, err := apiutil.GVKForObject(obj, ip.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	_, i, err := ip.InformersMap.Get(ctx, gvk, obj)
+	if err != nil {
+		return nil, err
+	}
+	return i.Informer, err
+}
+
+// NeedLeaderElection implements the LeaderElectionRunnable interface
+// to indicate that this can be started without requiring the leader lock
+func (ip *informerCache) NeedLeaderElection() bool {
+	return false
+}
+
+// IndexField adds an indexer to the underlying cache, using extraction function to get
+// value(s) from the given field.  This index can then be used by passing a field selector
+// to List. For one-to-one compatibility with "normal" field selectors, only return one value.
+// The values may be anything.  They will automatically be prefixed with the namespace of the
+// given object, if present.  The objects passed are guaranteed to be objects of the correct type.
+func (ip *informerCache) IndexField(ctx context.Context, obj runtime.Object, field string, extractValue client.IndexerFunc) error {
+	informer, err := ip.GetInformer(ctx, obj)
+	if err != nil {
+		return err
+	}
+	return indexByField(informer, field, extractValue)
+}
+
+func indexByField(indexer crcache.Informer, field string, extractor client.IndexerFunc) error {
+	indexFunc := func(objRaw interface{}) ([]string, error) {
+		// TODO(directxman12): check if this is the correct type?
+		obj, isObj := objRaw.(runtime.Object)
+		if !isObj {
+			return nil, fmt.Errorf("object of type %T is not an Object", objRaw)
+		}
+		meta, err := apimeta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		ns := meta.GetNamespace()
+
+		rawVals := extractor(obj)
+		var vals []string
+		if ns == "" {
+			// if we're not doubling the keys for the namespaced case, just re-use what was returned to us
+			vals = rawVals
+		} else {
+			// if we need to add non-namespaced versions too, double the length
+			vals = make([]string, len(rawVals)*2)
+		}
+		for i, rawVal := range rawVals {
+			// save a namespaced variant, so that we can ask
+			// "what are all the object matching a given index *in a given namespace*"
+			vals[i] = internal.KeyToNamespacedKey(ns, rawVal)
+			if ns != "" {
+				// if we have a namespace, also inject a special index key for listing
+				// regardless of the object namespace
+				vals[i+len(rawVals)] = internal.KeyToNamespacedKey("", rawVal)
+			}
+		}
+
+		return vals, nil
+	}
+
+	return indexer.AddIndexers(cache.Indexers{internal.FieldIndexName(field): indexFunc})
+}

--- a/pkg/cache/internal/cache_reader.go
+++ b/pkg/cache/internal/cache_reader.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CacheReader is a client.Reader
+var _ client.Reader = &CacheReader{}
+
+// CacheReader wraps a cache.Index to implement the client.CacheReader interface for a single type
+type CacheReader struct {
+	// indexer is the underlying indexer wrapped by this cache.
+	indexer cache.Indexer
+
+	// groupVersionKind is the group-version-kind of the resource.
+	groupVersionKind schema.GroupVersionKind
+}
+
+// Get checks the indexer for the object and writes a copy of it if found
+func (c *CacheReader) Get(_ context.Context, key client.ObjectKey, out runtime.Object) error {
+	storeKey := objectKeyToStoreKey(key)
+
+	// Lookup the object from the indexer cache
+	obj, exists, err := c.indexer.GetByKey(storeKey)
+	if err != nil {
+		return err
+	}
+
+	// Not found, return an error
+	if !exists {
+		// Resource gets transformed into Kind in the error anyway, so this is fine
+		return errors.NewNotFound(schema.GroupResource{
+			Group:    c.groupVersionKind.Group,
+			Resource: c.groupVersionKind.Kind,
+		}, key.Name)
+	}
+
+	// Verify the result is a runtime.Object
+	if _, isObj := obj.(runtime.Object); !isObj {
+		// This should never happen
+		return fmt.Errorf("cache contained %T, which is not an Object", obj)
+	}
+
+	// deep copy to avoid mutating cache
+	// TODO(directxman12): revisit the decision to always deepcopy
+	obj = obj.(runtime.Object).DeepCopyObject()
+
+	// Copy the value of the item in the cache to the returned value
+	// TODO(directxman12): this is a terrible hack, pls fix (we should have deepcopyinto)
+	outVal := reflect.ValueOf(out)
+	objVal := reflect.ValueOf(obj)
+	if !objVal.Type().AssignableTo(outVal.Type()) {
+		return fmt.Errorf("cache had type %s, but %s was asked for", objVal.Type(), outVal.Type())
+	}
+	reflect.Indirect(outVal).Set(reflect.Indirect(objVal))
+	out.GetObjectKind().SetGroupVersionKind(c.groupVersionKind)
+
+	return nil
+}
+
+// List lists items out of the indexer and writes them to out
+func (c *CacheReader) List(_ context.Context, out runtime.Object, opts ...client.ListOption) error {
+	var objs []interface{}
+	var err error
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	if listOpts.FieldSelector != nil {
+		// TODO(directxman12): support more complicated field selectors by
+		// combining multiple indices, GetIndexers, etc
+		field, val, requiresExact := requiresExactMatch(listOpts.FieldSelector)
+		if !requiresExact {
+			return fmt.Errorf("non-exact field matches are not supported by the cache")
+		}
+		// list all objects by the field selector.  If this is namespaced and we have one, ask for the
+		// namespaced index key.  Otherwise, ask for the non-namespaced variant by using the fake "all namespaces"
+		// namespace.
+		objs, err = c.indexer.ByIndex(FieldIndexName(field), KeyToNamespacedKey(listOpts.Namespace, val))
+	} else if listOpts.Namespace != "" {
+		objs, err = c.indexer.ByIndex(cache.NamespaceIndex, listOpts.Namespace)
+	} else {
+		objs = c.indexer.List()
+	}
+	if err != nil {
+		return err
+	}
+	var labelSel labels.Selector
+	if listOpts.LabelSelector != nil {
+		labelSel = listOpts.LabelSelector
+	}
+
+	runtimeObjs := make([]runtime.Object, 0, len(objs))
+	for _, item := range objs {
+		obj, isObj := item.(runtime.Object)
+		if !isObj {
+			return fmt.Errorf("cache contained %T, which is not an Object", obj)
+		}
+		meta, err := apimeta.Accessor(obj)
+		if err != nil {
+			return err
+		}
+		if labelSel != nil {
+			lbls := labels.Set(meta.GetLabels())
+			if !labelSel.Matches(lbls) {
+				continue
+			}
+		}
+
+		outObj := obj.DeepCopyObject()
+		outObj.GetObjectKind().SetGroupVersionKind(c.groupVersionKind)
+		runtimeObjs = append(runtimeObjs, outObj)
+	}
+	return apimeta.SetList(out, runtimeObjs)
+}
+
+// objectKeyToStorageKey converts an object key to store key.
+// It's akin to MetaNamespaceKeyFunc.  It's separate from
+// String to allow keeping the key format easily in sync with
+// MetaNamespaceKeyFunc.
+func objectKeyToStoreKey(k client.ObjectKey) string {
+	if k.Namespace == "" {
+		return k.Name
+	}
+	return k.Namespace + "/" + k.Name
+}
+
+// requiresExactMatch checks if the given field selector is of the form `k=v` or `k==v`.
+func requiresExactMatch(sel fields.Selector) (field, val string, required bool) {
+	reqs := sel.Requirements()
+	if len(reqs) != 1 {
+		return "", "", false
+	}
+	req := reqs[0]
+	if req.Operator != selection.Equals && req.Operator != selection.DoubleEquals {
+		return "", "", false
+	}
+	return req.Field, req.Value, true
+}
+
+// FieldIndexName constructs the name of the index over the given field,
+// for use with an indexer.
+func FieldIndexName(field string) string {
+	return "field:" + field
+}
+
+// noNamespaceNamespace is used as the "namespace" when we want to list across all namespaces
+const allNamespacesNamespace = "__all_namespaces"
+
+// KeyToNamespacedKey prefixes the given index key with a namespace
+// for use in field selector indexes.
+func KeyToNamespacedKey(ns string, baseKey string) string {
+	if ns != "" {
+		return ns + "/" + baseKey
+	}
+	return allNamespacesNamespace + "/" + baseKey
+}

--- a/pkg/cache/internal/cache_reader.go
+++ b/pkg/cache/internal/cache_reader.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/tools/cache"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -42,10 +43,16 @@ type CacheReader struct {
 
 	// groupVersionKind is the group-version-kind of the resource.
 	groupVersionKind schema.GroupVersionKind
+
+	// scopeName is the scope of the resource (namespaced or cluster-scoped).
+	scopeName apimeta.RESTScopeName
 }
 
 // Get checks the indexer for the object and writes a copy of it if found
-func (c *CacheReader) Get(_ context.Context, key client.ObjectKey, out runtime.Object) error {
+func (c *CacheReader) Get(_ context.Context, key client.ObjectKey, out client.Object) error {
+	if c.scopeName == apimeta.RESTScopeNameRoot {
+		key.Namespace = ""
+	}
 	storeKey := objectKeyToStoreKey(key)
 
 	// Lookup the object from the indexer cache
@@ -87,7 +94,7 @@ func (c *CacheReader) Get(_ context.Context, key client.ObjectKey, out runtime.O
 }
 
 // List lists items out of the indexer and writes them to out
-func (c *CacheReader) List(_ context.Context, out runtime.Object, opts ...client.ListOption) error {
+func (c *CacheReader) List(_ context.Context, out client.ObjectList, opts ...client.ListOption) error {
 	var objs []interface{}
 	var err error
 

--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+// InformersMap create and caches Informers for (runtime.Object, schema.GroupVersionKind) pairs.
+// It uses a standard parameter codec constructed based on the given generated Scheme.
+type InformersMap struct {
+	// we abstract over the details of structured vs unstructured with the specificInformerMaps
+
+	structured   *specificInformersMap
+	unstructured *specificInformersMap
+
+	// Scheme maps runtime.Objects to GroupVersionKinds
+	Scheme *runtime.Scheme
+}
+
+// NewInformersMap creates a new InformersMap that can create informers for
+// both structured and unstructured objects.
+func NewInformersMap(config *rest.Config,
+	scheme *runtime.Scheme,
+	mapper meta.RESTMapper,
+	resync time.Duration,
+	namespace string,
+	fieldSelectorByResource, labelSelectorByResource map[string]string) *InformersMap {
+
+	return &InformersMap{
+		structured:   newStructuredInformersMap(config, scheme, mapper, resync, namespace, fieldSelectorByResource, labelSelectorByResource),
+		unstructured: newUnstructuredInformersMap(config, scheme, mapper, resync, namespace, fieldSelectorByResource, labelSelectorByResource),
+
+		Scheme: scheme,
+	}
+}
+
+// Start calls Run on each of the informers and sets started to true.  Blocks on the stop channel.
+func (m *InformersMap) Start(stop <-chan struct{}) error {
+	go m.structured.Start(stop)
+	go m.unstructured.Start(stop)
+	<-stop
+	return nil
+}
+
+// WaitForCacheSync waits until all the caches have been started and synced.
+func (m *InformersMap) WaitForCacheSync(stop <-chan struct{}) bool {
+	syncedFuncs := append([]cache.InformerSynced(nil), m.structured.HasSyncedFuncs()...)
+	syncedFuncs = append(syncedFuncs, m.unstructured.HasSyncedFuncs()...)
+
+	if !m.structured.waitForStarted(stop) {
+		return false
+	}
+	if !m.unstructured.waitForStarted(stop) {
+		return false
+	}
+	return cache.WaitForCacheSync(stop, syncedFuncs...)
+}
+
+// Get will create a new Informer and add it to the map of InformersMap if none exists.  Returns
+// the Informer from the map.
+func (m *InformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object) (bool, *MapEntry, error) {
+	_, isUnstructured := obj.(*unstructured.Unstructured)
+	_, isUnstructuredList := obj.(*unstructured.UnstructuredList)
+	isUnstructured = isUnstructured || isUnstructuredList
+
+	if isUnstructured {
+		return m.unstructured.Get(ctx, gvk, obj)
+	}
+
+	return m.structured.Get(ctx, gvk, obj)
+}
+
+// newStructuredInformersMap creates a new InformersMap for structured objects.
+func newStructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string, fieldSelectorByResource, labelSelectorByResource map[string]string) *specificInformersMap {
+	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, fieldSelectorByResource, labelSelectorByResource, createStructuredListWatch)
+}
+
+// newUnstructuredInformersMap creates a new InformersMap for unstructured objects.
+func newUnstructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string, fieldSelectorByResource, labelSelectorByResource map[string]string) *specificInformersMap {
+	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, fieldSelectorByResource, labelSelectorByResource, createUnstructuredListWatch)
+}

--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,10 +32,12 @@ import (
 // InformersMap create and caches Informers for (runtime.Object, schema.GroupVersionKind) pairs.
 // It uses a standard parameter codec constructed based on the given generated Scheme.
 type InformersMap struct {
-	// we abstract over the details of structured vs unstructured with the specificInformerMaps
+	// we abstract over the details of structured/unstructured/metadata with the specificInformerMaps
+	// TODO(directxman12): genericize this over different projections now that we have 3 different maps
 
 	structured   *specificInformersMap
 	unstructured *specificInformersMap
+	metadata     *specificInformersMap
 
 	// Scheme maps runtime.Objects to GroupVersionKinds
 	Scheme *runtime.Scheme
@@ -47,58 +50,72 @@ func NewInformersMap(config *rest.Config,
 	mapper meta.RESTMapper,
 	resync time.Duration,
 	namespace string,
-	fieldSelectorByResource, labelSelectorByResource map[string]string) *InformersMap {
+	fieldSelectorByResource, labelSelectorByResource map[schema.GroupResource]string) *InformersMap {
 
 	return &InformersMap{
 		structured:   newStructuredInformersMap(config, scheme, mapper, resync, namespace, fieldSelectorByResource, labelSelectorByResource),
 		unstructured: newUnstructuredInformersMap(config, scheme, mapper, resync, namespace, fieldSelectorByResource, labelSelectorByResource),
+		metadata:     newMetadataInformersMap(config, scheme, mapper, resync, namespace, fieldSelectorByResource, labelSelectorByResource),
 
 		Scheme: scheme,
 	}
 }
 
-// Start calls Run on each of the informers and sets started to true.  Blocks on the stop channel.
-func (m *InformersMap) Start(stop <-chan struct{}) error {
-	go m.structured.Start(stop)
-	go m.unstructured.Start(stop)
-	<-stop
+// Start calls Run on each of the informers and sets started to true.  Blocks on the context.
+func (m *InformersMap) Start(ctx context.Context) error {
+	go m.structured.Start(ctx)
+	go m.unstructured.Start(ctx)
+	go m.metadata.Start(ctx)
+	<-ctx.Done()
 	return nil
 }
 
 // WaitForCacheSync waits until all the caches have been started and synced.
-func (m *InformersMap) WaitForCacheSync(stop <-chan struct{}) bool {
+func (m *InformersMap) WaitForCacheSync(ctx context.Context) bool {
 	syncedFuncs := append([]cache.InformerSynced(nil), m.structured.HasSyncedFuncs()...)
 	syncedFuncs = append(syncedFuncs, m.unstructured.HasSyncedFuncs()...)
+	syncedFuncs = append(syncedFuncs, m.metadata.HasSyncedFuncs()...)
 
-	if !m.structured.waitForStarted(stop) {
+	if !m.structured.waitForStarted(ctx) {
 		return false
 	}
-	if !m.unstructured.waitForStarted(stop) {
+	if !m.unstructured.waitForStarted(ctx) {
 		return false
 	}
-	return cache.WaitForCacheSync(stop, syncedFuncs...)
+	if !m.metadata.waitForStarted(ctx) {
+		return false
+	}
+	return cache.WaitForCacheSync(ctx.Done(), syncedFuncs...)
 }
 
 // Get will create a new Informer and add it to the map of InformersMap if none exists.  Returns
 // the Informer from the map.
 func (m *InformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object) (bool, *MapEntry, error) {
-	_, isUnstructured := obj.(*unstructured.Unstructured)
-	_, isUnstructuredList := obj.(*unstructured.UnstructuredList)
-	isUnstructured = isUnstructured || isUnstructuredList
-
-	if isUnstructured {
+	switch obj.(type) {
+	case *unstructured.Unstructured:
 		return m.unstructured.Get(ctx, gvk, obj)
+	case *unstructured.UnstructuredList:
+		return m.unstructured.Get(ctx, gvk, obj)
+	case *metav1.PartialObjectMetadata:
+		return m.metadata.Get(ctx, gvk, obj)
+	case *metav1.PartialObjectMetadataList:
+		return m.metadata.Get(ctx, gvk, obj)
+	default:
+		return m.structured.Get(ctx, gvk, obj)
 	}
-
-	return m.structured.Get(ctx, gvk, obj)
 }
 
 // newStructuredInformersMap creates a new InformersMap for structured objects.
-func newStructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string, fieldSelectorByResource, labelSelectorByResource map[string]string) *specificInformersMap {
-	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, fieldSelectorByResource, labelSelectorByResource, createStructuredListWatch)
+func newStructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string, fieldSelectorByResource, labelSelectorByResource map[schema.GroupResource]string) *specificInformersMap {
+	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, createStructuredListWatch, fieldSelectorByResource, labelSelectorByResource)
 }
 
 // newUnstructuredInformersMap creates a new InformersMap for unstructured objects.
-func newUnstructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string, fieldSelectorByResource, labelSelectorByResource map[string]string) *specificInformersMap {
-	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, fieldSelectorByResource, labelSelectorByResource, createUnstructuredListWatch)
+func newUnstructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string, fieldSelectorByResource, labelSelectorByResource map[schema.GroupResource]string) *specificInformersMap {
+	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, createUnstructuredListWatch, fieldSelectorByResource, labelSelectorByResource)
+}
+
+// newMetadataInformersMap creates a new InformersMap for metadata-only objects.
+func newMetadataInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string, fieldSelectorByResource, labelSelectorByResource map[schema.GroupResource]string) *specificInformersMap {
+	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, createMetadataListWatch, fieldSelectorByResource, labelSelectorByResource)
 }

--- a/pkg/cache/internal/informers_map.go
+++ b/pkg/cache/internal/informers_map.go
@@ -1,0 +1,358 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// clientListWatcherFunc knows how to create a ListWatcher
+type createListWatcherFunc func(gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error)
+
+// newSpecificInformersMap returns a new specificInformersMap (like
+// the generical InformersMap, except that it doesn't implement WaitForCacheSync).
+func newSpecificInformersMap(config *rest.Config,
+	scheme *runtime.Scheme,
+	mapper meta.RESTMapper,
+	resync time.Duration,
+	namespace string,
+	fieldSelectorByResource, labelSelectorByResource map[string]string,
+	createListWatcher createListWatcherFunc) *specificInformersMap {
+	ip := &specificInformersMap{
+		config:                  config,
+		Scheme:                  scheme,
+		mapper:                  mapper,
+		informersByGVK:          make(map[schema.GroupVersionKind]*MapEntry),
+		codecs:                  serializer.NewCodecFactory(scheme),
+		paramCodec:              runtime.NewParameterCodec(scheme),
+		resync:                  resync,
+		startWait:               make(chan struct{}),
+		createListWatcher:       createListWatcher,
+		namespace:               namespace,
+		fieldSelectorByResource: fieldSelectorByResource,
+		labelSelectorByResource: labelSelectorByResource,
+	}
+	return ip
+}
+
+// MapEntry contains the cached data for an Informer
+type MapEntry struct {
+	// Informer is the cached informer
+	Informer cache.SharedIndexInformer
+
+	// CacheReader wraps Informer and implements the CacheReader interface for a single type
+	Reader CacheReader
+}
+
+// specificInformersMap create and caches Informers for (runtime.Object, schema.GroupVersionKind) pairs.
+// It uses a standard parameter codec constructed based on the given generated Scheme.
+type specificInformersMap struct {
+	// Scheme maps runtime.Objects to GroupVersionKinds
+	Scheme *runtime.Scheme
+
+	// config is used to talk to the apiserver
+	config *rest.Config
+
+	// mapper maps GroupVersionKinds to Resources
+	mapper meta.RESTMapper
+
+	// informersByGVK is the cache of informers keyed by groupVersionKind
+	informersByGVK map[schema.GroupVersionKind]*MapEntry
+
+	// codecs is used to create a new REST client
+	codecs serializer.CodecFactory
+
+	// paramCodec is used by list and watch
+	paramCodec runtime.ParameterCodec
+
+	// stop is the stop channel to stop informers
+	stop <-chan struct{}
+
+	// resync is the base frequency the informers are resynced
+	// a 10 percent jitter will be added to the resync period between informers
+	// so that all informers will not send list requests simultaneously.
+	resync time.Duration
+
+	// mu guards access to the map
+	mu sync.RWMutex
+
+	// start is true if the informers have been started
+	started bool
+
+	// startWait is a channel that is closed after the
+	// informer has been started.
+	startWait chan struct{}
+
+	// createClient knows how to create a client and a list object,
+	// and allows for abstracting over the particulars of structured vs
+	// unstructured objects.
+	createListWatcher createListWatcherFunc
+
+	// namespace is the namespace that all ListWatches are restricted to
+	// default or empty string means all namespaces
+	namespace string
+
+	// fieldSelectorByResource is the fieldSelector depending on the resource
+	// that will restrict ListWatches if resource is not present or
+	// its fieldSelector is empty all the instances will be List/Watch
+	fieldSelectorByResource map[string]string
+
+	// labelSelectorByResource is the labelSelector depending on the resource
+	// that will restrict ListWatches if resource is not present or
+	// its labelSelector is empty all the instances will be List/Watch
+	labelSelectorByResource map[string]string
+}
+
+// Start calls Run on each of the informers and sets started to true.  Blocks on the stop channel.
+// It doesn't return start because it can't return an error, and it's not a runnable directly.
+func (ip *specificInformersMap) Start(stop <-chan struct{}) {
+	func() {
+		ip.mu.Lock()
+		defer ip.mu.Unlock()
+
+		// Set the stop channel so it can be passed to informers that are added later
+		ip.stop = stop
+
+		// Start each informer
+		for _, informer := range ip.informersByGVK {
+			go informer.Informer.Run(stop)
+		}
+
+		// Set started to true so we immediately start any informers added later.
+		ip.started = true
+		close(ip.startWait)
+	}()
+	<-stop
+}
+
+func (ip *specificInformersMap) waitForStarted(stop <-chan struct{}) bool {
+	select {
+	case <-ip.startWait:
+		return true
+	case <-stop:
+		return false
+	}
+}
+
+// HasSyncedFuncs returns all the HasSynced functions for the informers in this map.
+func (ip *specificInformersMap) HasSyncedFuncs() []cache.InformerSynced {
+	ip.mu.RLock()
+	defer ip.mu.RUnlock()
+	syncedFuncs := make([]cache.InformerSynced, 0, len(ip.informersByGVK))
+	for _, informer := range ip.informersByGVK {
+		syncedFuncs = append(syncedFuncs, informer.Informer.HasSynced)
+	}
+	return syncedFuncs
+}
+
+// Get will create a new Informer and add it to the map of specificInformersMap if none exists.  Returns
+// the Informer from the map.
+func (ip *specificInformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object) (bool, *MapEntry, error) {
+	// Return the informer if it is found
+	i, started, ok := func() (*MapEntry, bool, bool) {
+		ip.mu.RLock()
+		defer ip.mu.RUnlock()
+		i, ok := ip.informersByGVK[gvk]
+		return i, ip.started, ok
+	}()
+
+	if !ok {
+		var err error
+		if i, started, err = ip.addInformerToMap(gvk, obj); err != nil {
+			return started, nil, err
+		}
+	}
+
+	if started && !i.Informer.HasSynced() {
+		// Wait for it to sync before returning the Informer so that folks don't read from a stale cache.
+		if !cache.WaitForCacheSync(ctx.Done(), i.Informer.HasSynced) {
+			return started, nil, apierrors.NewTimeoutError(fmt.Sprintf("failed waiting for %T Informer to sync", obj), 0)
+		}
+	}
+
+	return started, i, nil
+}
+
+func (ip *specificInformersMap) addInformerToMap(gvk schema.GroupVersionKind, obj runtime.Object) (*MapEntry, bool, error) {
+	ip.mu.Lock()
+	defer ip.mu.Unlock()
+
+	// Check the cache to see if we already have an Informer.  If we do, return the Informer.
+	// This is for the case where 2 routines tried to get the informer when it wasn't in the map
+	// so neither returned early, but the first one created it.
+	if i, ok := ip.informersByGVK[gvk]; ok {
+		return i, ip.started, nil
+	}
+
+	// Create a NewSharedIndexInformer and add it to the map.
+	var lw *cache.ListWatch
+	lw, err := ip.createListWatcher(gvk, ip)
+	if err != nil {
+		return nil, false, err
+	}
+	ni := cache.NewSharedIndexInformer(lw, obj, resyncPeriod(ip.resync)(), cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	i := &MapEntry{
+		Informer: ni,
+		Reader:   CacheReader{indexer: ni.GetIndexer(), groupVersionKind: gvk},
+	}
+	ip.informersByGVK[gvk] = i
+
+	// Start the Informer if need by
+	// TODO(seans): write thorough tests and document what happens here - can you add indexers?
+	// can you add eventhandlers?
+	if ip.started {
+		go i.Informer.Run(ip.stop)
+	}
+	return i, ip.started, nil
+}
+
+// newListWatch returns a new ListWatch object that can be used to create a SharedIndexInformer.
+func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error) {
+	// Kubernetes APIs work against Resources, not GroupVersionKinds.  Map the
+	// groupVersionKind to the Resource API we will use.
+	mapping, err := ip.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := apiutil.RESTClientForGVK(gvk, ip.config, ip.codecs)
+	if err != nil {
+		return nil, err
+	}
+	listGVK := gvk.GroupVersion().WithKind(gvk.Kind + "List")
+	listObj, err := ip.Scheme.New(listGVK)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: the functions that make use of this ListWatch should be adapted to
+	//  pass in their own contexts instead of relying on this fixed one here.
+	ctx := context.TODO()
+	// Create a new ListWatch for the obj
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			fieldSelector, ok := ip.fieldSelectorByResource[mapping.Resource.Resource]
+			if ok {
+				opts.FieldSelector = fieldSelector
+			}
+			labelSelector, ok := ip.labelSelectorByResource[mapping.Resource.Resource]
+			if ok {
+				opts.LabelSelector = labelSelector
+			}
+			res := listObj.DeepCopyObject()
+			isNamespaceScoped := ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot
+			err := client.Get().NamespaceIfScoped(ip.namespace, isNamespaceScoped).Resource(mapping.Resource.Resource).VersionedParams(&opts, ip.paramCodec).Do(ctx).Into(res)
+			return res, err
+		},
+		// Setup the watch function
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			fieldSelector, ok := ip.fieldSelectorByResource[mapping.Resource.Resource]
+			if ok {
+				opts.FieldSelector = fieldSelector
+			}
+			labelSelector, ok := ip.labelSelectorByResource[mapping.Resource.Resource]
+			if ok {
+				opts.LabelSelector = labelSelector
+			}
+			// Watch needs to be set to true separately
+			opts.Watch = true
+			isNamespaceScoped := ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot
+			return client.Get().NamespaceIfScoped(ip.namespace, isNamespaceScoped).Resource(mapping.Resource.Resource).VersionedParams(&opts, ip.paramCodec).Watch(ctx)
+		},
+	}, nil
+}
+
+func createUnstructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error) {
+	// Kubernetes APIs work against Resources, not GroupVersionKinds.  Map the
+	// groupVersionKind to the Resource API we will use.
+	mapping, err := ip.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, err
+	}
+	dynamicClient, err := dynamic.NewForConfig(ip.config)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: the functions that make use of this ListWatch should be adapted to
+	//  pass in their own contexts instead of relying on this fixed one here.
+	ctx := context.TODO()
+	// Create a new ListWatch for the obj
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			fieldSelector, ok := ip.fieldSelectorByResource[mapping.Resource.Resource]
+			if ok {
+				opts.FieldSelector = fieldSelector
+			}
+			labelSelector, ok := ip.labelSelectorByResource[mapping.Resource.Resource]
+			if ok {
+				opts.LabelSelector = labelSelector
+			}
+			if ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {
+				return dynamicClient.Resource(mapping.Resource).Namespace(ip.namespace).List(ctx, opts)
+			}
+			return dynamicClient.Resource(mapping.Resource).List(ctx, opts)
+		},
+		// Setup the watch function
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			fieldSelector, ok := ip.fieldSelectorByResource[mapping.Resource.Resource]
+			if ok {
+				opts.FieldSelector = fieldSelector
+			}
+			labelSelector, ok := ip.labelSelectorByResource[mapping.Resource.Resource]
+			if ok {
+				opts.LabelSelector = labelSelector
+			}
+			// Watch needs to be set to true separately
+			opts.Watch = true
+			if ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {
+				return dynamicClient.Resource(mapping.Resource).Namespace(ip.namespace).Watch(ctx, opts)
+			}
+			return dynamicClient.Resource(mapping.Resource).Watch(ctx, opts)
+		},
+	}, nil
+}
+
+// resyncPeriod returns a function which generates a duration each time it is
+// invoked; this is so that multiple controllers don't get into lock-step and all
+// hammer the apiserver with list requests simultaneously.
+func resyncPeriod(resync time.Duration) func() time.Duration {
+	return func() time.Duration {
+		// the factor will fall into [0.9, 1.1)
+		factor := rand.Float64()/5.0 + 0.9 // #nosec
+		return time.Duration(float64(resync.Nanoseconds()) * factor)
+	}
+}

--- a/pkg/cache/internal/informers_map.go
+++ b/pkg/cache/internal/informers_map.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
@@ -47,8 +48,8 @@ func newSpecificInformersMap(config *rest.Config,
 	mapper meta.RESTMapper,
 	resync time.Duration,
 	namespace string,
-	fieldSelectorByResource, labelSelectorByResource map[string]string,
-	createListWatcher createListWatcherFunc) *specificInformersMap {
+	createListWatcher createListWatcherFunc,
+	fieldSelectorByResource, labelSelectorByResource map[schema.GroupResource]string) *specificInformersMap {
 	ip := &specificInformersMap{
 		config:                  config,
 		Scheme:                  scheme,
@@ -123,44 +124,42 @@ type specificInformersMap struct {
 	// default or empty string means all namespaces
 	namespace string
 
-	// fieldSelectorByResource is the fieldSelector depending on the resource
-	// that will restrict ListWatches if resource is not present or
-	// its fieldSelector is empty all the instances will be List/Watch
-	fieldSelectorByResource map[string]string
+	// fieldSelectorByResource restricts the cache's ListWatch to the resources with desired field
+	// Default watches resources with any field
+	fieldSelectorByResource map[schema.GroupResource]string
 
-	// labelSelectorByResource is the labelSelector depending on the resource
-	// that will restrict ListWatches if resource is not present or
-	// its labelSelector is empty all the instances will be List/Watch
-	labelSelectorByResource map[string]string
+	// labelSelectorByResource restricts the cache's ListWatch to the resources with desired label
+	// Default watches resources with any label
+	labelSelectorByResource map[schema.GroupResource]string
 }
 
-// Start calls Run on each of the informers and sets started to true.  Blocks on the stop channel.
+// Start calls Run on each of the informers and sets started to true.  Blocks on the context.
 // It doesn't return start because it can't return an error, and it's not a runnable directly.
-func (ip *specificInformersMap) Start(stop <-chan struct{}) {
+func (ip *specificInformersMap) Start(ctx context.Context) {
 	func() {
 		ip.mu.Lock()
 		defer ip.mu.Unlock()
 
 		// Set the stop channel so it can be passed to informers that are added later
-		ip.stop = stop
+		ip.stop = ctx.Done()
 
 		// Start each informer
 		for _, informer := range ip.informersByGVK {
-			go informer.Informer.Run(stop)
+			go informer.Informer.Run(ctx.Done())
 		}
 
 		// Set started to true so we immediately start any informers added later.
 		ip.started = true
 		close(ip.startWait)
 	}()
-	<-stop
+	<-ctx.Done()
 }
 
-func (ip *specificInformersMap) waitForStarted(stop <-chan struct{}) bool {
+func (ip *specificInformersMap) waitForStarted(ctx context.Context) bool {
 	select {
 	case <-ip.startWait:
 		return true
-	case <-stop:
+	case <-ctx.Done():
 		return false
 	}
 }
@@ -224,9 +223,13 @@ func (ip *specificInformersMap) addInformerToMap(gvk schema.GroupVersionKind, ob
 	ni := cache.NewSharedIndexInformer(lw, obj, resyncPeriod(ip.resync)(), cache.Indexers{
 		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
 	})
+	rm, err := ip.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, false, err
+	}
 	i := &MapEntry{
 		Informer: ni,
-		Reader:   CacheReader{indexer: ni.GetIndexer(), groupVersionKind: gvk},
+		Reader:   CacheReader{indexer: ni.GetIndexer(), groupVersionKind: gvk, scopeName: rm.Scope.Name()},
 	}
 	ip.informersByGVK[gvk] = i
 
@@ -248,7 +251,7 @@ func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformer
 		return nil, err
 	}
 
-	client, err := apiutil.RESTClientForGVK(gvk, ip.config, ip.codecs)
+	client, err := apiutil.RESTClientForGVK(gvk, false, ip.config, ip.codecs)
 	if err != nil {
 		return nil, err
 	}
@@ -264,14 +267,8 @@ func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformer
 	// Create a new ListWatch for the obj
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-			fieldSelector, ok := ip.fieldSelectorByResource[mapping.Resource.Resource]
-			if ok {
-				opts.FieldSelector = fieldSelector
-			}
-			labelSelector, ok := ip.labelSelectorByResource[mapping.Resource.Resource]
-			if ok {
-				opts.LabelSelector = labelSelector
-			}
+			opts.FieldSelector = ip.findFieldSelectorByGVR(mapping.Resource)
+			opts.LabelSelector = ip.findLabelSelectorByGVR(mapping.Resource)
 			res := listObj.DeepCopyObject()
 			isNamespaceScoped := ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot
 			err := client.Get().NamespaceIfScoped(ip.namespace, isNamespaceScoped).Resource(mapping.Resource.Resource).VersionedParams(&opts, ip.paramCodec).Do(ctx).Into(res)
@@ -279,14 +276,8 @@ func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformer
 		},
 		// Setup the watch function
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-			fieldSelector, ok := ip.fieldSelectorByResource[mapping.Resource.Resource]
-			if ok {
-				opts.FieldSelector = fieldSelector
-			}
-			labelSelector, ok := ip.labelSelectorByResource[mapping.Resource.Resource]
-			if ok {
-				opts.LabelSelector = labelSelector
-			}
+			opts.FieldSelector = ip.findFieldSelectorByGVR(mapping.Resource)
+			opts.LabelSelector = ip.findLabelSelectorByGVR(mapping.Resource)
 			// Watch needs to be set to true separately
 			opts.Watch = true
 			isNamespaceScoped := ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot
@@ -313,14 +304,8 @@ func createUnstructuredListWatch(gvk schema.GroupVersionKind, ip *specificInform
 	// Create a new ListWatch for the obj
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-			fieldSelector, ok := ip.fieldSelectorByResource[mapping.Resource.Resource]
-			if ok {
-				opts.FieldSelector = fieldSelector
-			}
-			labelSelector, ok := ip.labelSelectorByResource[mapping.Resource.Resource]
-			if ok {
-				opts.LabelSelector = labelSelector
-			}
+			opts.FieldSelector = ip.findFieldSelectorByGVR(mapping.Resource)
+			opts.LabelSelector = ip.findLabelSelectorByGVR(mapping.Resource)
 			if ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {
 				return dynamicClient.Resource(mapping.Resource).Namespace(ip.namespace).List(ctx, opts)
 			}
@@ -328,20 +313,56 @@ func createUnstructuredListWatch(gvk schema.GroupVersionKind, ip *specificInform
 		},
 		// Setup the watch function
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-			fieldSelector, ok := ip.fieldSelectorByResource[mapping.Resource.Resource]
-			if ok {
-				opts.FieldSelector = fieldSelector
-			}
-			labelSelector, ok := ip.labelSelectorByResource[mapping.Resource.Resource]
-			if ok {
-				opts.LabelSelector = labelSelector
-			}
+			opts.FieldSelector = ip.findFieldSelectorByGVR(mapping.Resource)
+			opts.LabelSelector = ip.findLabelSelectorByGVR(mapping.Resource)
 			// Watch needs to be set to true separately
 			opts.Watch = true
 			if ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {
 				return dynamicClient.Resource(mapping.Resource).Namespace(ip.namespace).Watch(ctx, opts)
 			}
 			return dynamicClient.Resource(mapping.Resource).Watch(ctx, opts)
+		},
+	}, nil
+}
+
+func createMetadataListWatch(gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error) {
+	// Kubernetes APIs work against Resources, not GroupVersionKinds.  Map the
+	// groupVersionKind to the Resource API we will use.
+	mapping, err := ip.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	// grab the metadata client
+	client, err := metadata.NewForConfig(ip.config)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: the functions that make use of this ListWatch should be adapted to
+	//  pass in their own contexts instead of relying on this fixed one here.
+	ctx := context.TODO()
+
+	// create the relevant listwatch
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			opts.FieldSelector = ip.findFieldSelectorByGVR(mapping.Resource)
+			opts.LabelSelector = ip.findLabelSelectorByGVR(mapping.Resource)
+			if ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {
+				return client.Resource(mapping.Resource).Namespace(ip.namespace).List(ctx, opts)
+			}
+			return client.Resource(mapping.Resource).List(ctx, opts)
+		},
+		// Setup the watch function
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			opts.FieldSelector = ip.findFieldSelectorByGVR(mapping.Resource)
+			opts.LabelSelector = ip.findLabelSelectorByGVR(mapping.Resource)
+			// Watch needs to be set to true separately
+			opts.Watch = true
+			if ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {
+				return client.Resource(mapping.Resource).Namespace(ip.namespace).Watch(ctx, opts)
+			}
+			return client.Resource(mapping.Resource).Watch(ctx, opts)
 		},
 	}, nil
 }
@@ -355,4 +376,14 @@ func resyncPeriod(resync time.Duration) func() time.Duration {
 		factor := rand.Float64()/5.0 + 0.9 // #nosec
 		return time.Duration(float64(resync.Nanoseconds()) * factor)
 	}
+}
+
+func (ip *specificInformersMap) findFieldSelectorByGVR(gvr schema.GroupVersionResource) string {
+	gr := schema.GroupResource{Group: gvr.Group, Resource: gvr.Resource}
+	return ip.fieldSelectorByResource[gr]
+}
+
+func (ip *specificInformersMap) findLabelSelectorByGVR(gvr schema.GroupVersionResource) string {
+	gr := schema.GroupResource{Group: gvr.Group, Resource: gvr.Resource}
+	return ip.labelSelectorByResource[gr]
 }

--- a/pkg/k8s/store.go
+++ b/pkg/k8s/store.go
@@ -158,11 +158,12 @@ func newPodInformer(kubeClient kubernetes.Interface, resyncPeriod time.Duration,
 
 // newSecretInformer returns a secret informer
 func newSecretInformer(kubeClient kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return coreInformers.NewSecretInformer(
+	return coreInformers.NewFilteredSecretInformer(
 		kubeClient,
 		v1.NamespaceAll,
 		resyncPeriod,
 		cache.Indexers{},
+		managedFilterForSecret(),
 	)
 }
 
@@ -208,4 +209,11 @@ func nodeNameFilterForPod(nodeName string) internalinterfaces.TweakListOptionsFu
 func getStoreKey(name, namespace string) string {
 	// client-go cache store uses <namespace>/<name> as key
 	return fmt.Sprintf("%s/%s", namespace, name)
+}
+
+// managedFilterForSecret returns tweak options to filter using managed label.
+func managedFilterForSecret() internalinterfaces.TweakListOptionsFunc {
+	return func(options *metav1.ListOptions) {
+		options.LabelSelector = "secrets-store.csi.k8s.io/managed=true"
+	}
 }

--- a/pkg/k8s/store_test.go
+++ b/pkg/k8s/store_test.go
@@ -43,7 +43,7 @@ func TestGetPod(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset()
 	crdClient := secretsStoreFakeClient.NewSimpleClientset()
 
-	testStore, err := New(kubeClient, crdClient, "node1", 1*time.Millisecond)
+	testStore, err := New(kubeClient, crdClient, "node1", 1*time.Millisecond, false)
 	g.Expect(err).NotTo(HaveOccurred())
 	err = testStore.Run(wait.NeverStop)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -81,7 +81,7 @@ func TestListSecretProviderClassPodStatus(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset()
 	crdClient := secretsStoreFakeClient.NewSimpleClientset()
 
-	testStore, err := New(kubeClient, crdClient, "node1", 1*time.Millisecond)
+	testStore, err := New(kubeClient, crdClient, "node1", 1*time.Millisecond, false)
 	g.Expect(err).NotTo(HaveOccurred())
 	err = testStore.Run(wait.NeverStop)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -127,7 +127,7 @@ func TestGetSecret(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset()
 	crdClient := secretsStoreFakeClient.NewSimpleClientset()
 
-	testStore, err := New(kubeClient, crdClient, "node1", 1*time.Millisecond)
+	testStore, err := New(kubeClient, crdClient, "node1", 1*time.Millisecond, false)
 	g.Expect(err).NotTo(HaveOccurred())
 	err = testStore.Run(wait.NeverStop)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -161,7 +161,7 @@ func TestGetSecretProviderClass(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset()
 	crdClient := secretsStoreFakeClient.NewSimpleClientset()
 
-	testStore, err := New(kubeClient, crdClient, "node1", 1*time.Millisecond)
+	testStore, err := New(kubeClient, crdClient, "node1", 1*time.Millisecond, false)
 	g.Expect(err).NotTo(HaveOccurred())
 	err = testStore.Run(wait.NeverStop)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/pkg/rotation/reconciler.go
+++ b/pkg/rotation/reconciler.go
@@ -80,12 +80,12 @@ type Reconciler struct {
 	queue                workqueue.RateLimitingInterface
 	reporter             StatsReporter
 	eventRecorder        record.EventRecorder
-	kubeClient           *kubernetes.Clientset
-	crdClient            *versioned.Clientset
+	kubeClient           kubernetes.Interface
+	crdClient            versioned.Interface
 }
 
 // NewReconciler returns a new reconciler for rotation
-func NewReconciler(s *runtime.Scheme, providerVolumePath, nodeName string, rotationPollInterval time.Duration, providerClients map[string]*secretsstore.CSIProviderClient) (*Reconciler, error) {
+func NewReconciler(s *runtime.Scheme, providerVolumePath, nodeName string, rotationPollInterval time.Duration, providerClients map[string]*secretsstore.CSIProviderClient, filteredWatchSecret bool) (*Reconciler, error) {
 	config, err := buildConfig()
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func NewReconciler(s *runtime.Scheme, providerVolumePath, nodeName string, rotat
 	config.UserAgent = version.GetUserAgent("rotation")
 	kubeClient := kubernetes.NewForConfigOrDie(config)
 	crdClient := secretsStoreClient.NewForConfigOrDie(config)
-	store, err := k8s.New(kubeClient, crdClient, nodeName, 5*time.Second)
+	store, err := k8s.New(kubeClient, crdClient, nodeName, 5*time.Second, filteredWatchSecret)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rotation/reconciler.go
+++ b/pkg/rotation/reconciler.go
@@ -245,7 +245,7 @@ func (r *Reconciler) reconcile(ctx context.Context, spcps *v1alpha1.SecretProvid
 		secretNamespace := spcps.Namespace
 
 		// read secret from the informer cache
-		secret, err := r.store.GetSecret(secretName, secretNamespace)
+		secret, err := r.store.GetNodePublishSecretRefSecret(secretName, secretNamespace)
 		if err != nil {
 			errorReason = internalerrors.NodePublishSecretRefNotFound
 			r.generateEvent(pod, v1.EventTypeWarning, mountRotationFailedReason, fmt.Sprintf("failed to get node publish secret %s/%s, err: %+v", secretNamespace, secretName, err))


### PR DESCRIPTION
**What this PR does / why we need it**:
The `pkg/cache` added as part of this PR is copied from the cache pkg in controller-runtime.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #459 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

Docs: https://docs.google.com/document/d/1ba8gTC-i33Df6uiOB8rW8jBX2B0lK8LszUjYlPzNwlQ/edit?usp=sharing

Based on load testing with a 100 node cluster:
- With v0.0.20, csi pod memory goes up to 110Mi for just 200 pods using csi, 7k pods total and 3k secrets
- With the patch, csi pod memory is ~50Mi with  4.5k pods with csi volume, 11k pods total and 3k secrets