### PR TITLE
docs: fix urls in providers doc

### DIFF
--- a/docs/book/src/providers.md
+++ b/docs/book/src/providers.md
@@ -28,11 +28,11 @@ The driver as of `v0.0.14` adds an option to use gRPC to communicate with the pr
 
 To implement a secrets-store-csi-driver provider, you can develop a new provider gRPC server using the stub file available for Go.
 
-- Use the functions and data structures in the stub file: [service.pb.go](../provider/v1alpha1/service.pb.go) to develop the server code
+- Use the functions and data structures in the stub file: [service.pb.go](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/provider/v1alpha1/service.pb.go) to develop the server code
   - The stub file and proto file are shared and hosted in the driver. Vendor-in the stub file and proto file in the provider
-  - [fake server example](../provider/fake/fake_server.go)
-- Provider runs as a daemonset and is deployed on the same host(s) as the secrets-store-csi-driver pods
-- Provider Unix Domain Socket volume path. The default volume path for providers is [/etc/kubernetes/secrets-store-csi-driver-providers](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/deploy/secrets-store-csi-driver.yaml#L88-L89). Add the Unix Domain Socket to the dir in the format `/etc/kubernetes/secrets-store-csi-driver-providers/<provider name>.sock`
-- Provider mounts `<kubelet root dir>/pods` (default: [`/var/lib/kubelet/pods`](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/deploy/secrets-store-csi-driver.yaml#L86-L87)) with [`Bidirectional` mount propogation](https://kubernetes-csi.github.io/docs/deploying.html#driver-volume-mounts) to be able to write the external secrets store content to the volume target path
+  - [fake server example](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/provider/fake/fake_server.go)
+- Provider runs as a *daemonset* and is deployed on the same host(s) as the secrets-store-csi-driver pods
+- Provider Unix Domain Socket volume path. The default volume path for providers is [/etc/kubernetes/secrets-store-csi-driver-providers](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/v0.0.14/deploy/secrets-store-csi-driver.yaml#L88-L89). Add the Unix Domain Socket to the dir in the format `/etc/kubernetes/secrets-store-csi-driver-providers/<provider name>.sock`
+- Provider mounts `<kubelet root dir>/pods` (default: [`/var/lib/kubelet/pods`](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/v0.0.14/deploy/secrets-store-csi-driver.yaml#L86-L87)) with [`HostToContainer` mount propagation](https://kubernetes-csi.github.io/docs/deploying.html#driver-volume-mounts) to be able to write the external secrets store content to the volume target path
 
 See [design doc](https://docs.google.com/document/d/10-RHUJGM0oMN88AZNxjOmGz0NsWAvOYrWUEV-FbLWyw/edit?usp=sharing) for more details.


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
/kind documentation

Fixes broken urls in the providers doc

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
