### PR TITLE
test: update tests to use multi-os image

### DIFF
--- a/test/bats/tests/azure/deployment-synck8s-azure.yaml
+++ b/test/bats/tests/azure/deployment-synck8s-azure.yaml
@@ -1,23 +1,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment-two
+  name: busybox-deployment
   labels:
-    app: nginx
+    app: busybox
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: nginx
+      app: busybox
   template:
     metadata:
       labels:
-        app: nginx
+        app: busybox
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: $CONTAINER_IMAGE
-        name: nginx
+      - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+        name: busybox
+        imagePullPolicy: IfNotPresent
+        command:
+        - "/bin/sleep"
+        - "10000"
         env:
         - name: SECRET_USERNAME
           valueFrom:

--- a/test/bats/tests/azure/deployment-two-synck8s-azure.yaml
+++ b/test/bats/tests/azure/deployment-two-synck8s-azure.yaml
@@ -1,23 +1,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment
+  name: busybox-deployment-two
   labels:
-    app: nginx
+    app: busybox
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: nginx
+      app: busybox
   template:
     metadata:
       labels:
-        app: nginx
+        app: busybox
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: nginx
-        name: nginx
+      - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+        name: busybox
+        imagePullPolicy: IfNotPresent
+        command:
+        - "/bin/sleep"
+        - "10000"
         env:
         - name: SECRET_USERNAME
           valueFrom:
@@ -34,4 +38,6 @@ spec:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
-              secretProviderClass: "vault-foo-sync"
+              secretProviderClass: "azure-sync"
+            nodePublishSecretRef:
+              name: secrets-store-creds

--- a/test/bats/tests/azure/pod-azure-inline-volume-multiple-spc.yaml
+++ b/test/bats/tests/azure/pod-azure-inline-volume-multiple-spc.yaml
@@ -1,12 +1,16 @@
 kind: Pod
 apiVersion: v1
 metadata:
-  name: nginx-secrets-store-inline-multiple-crd
+  name: secrets-store-inline-multiple-crd
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: $CONTAINER_IMAGE
-    name: nginx
+  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    name: busybox
+    imagePullPolicy: IfNotPresent
+    command:
+    - "/bin/sleep"
+    - "10000"
     volumeMounts:
     - name: secrets-store-inline-0
       mountPath: "/mnt/secrets-store-0"

--- a/test/bats/tests/azure/pod-secrets-store-inline-volume-crd.yaml
+++ b/test/bats/tests/azure/pod-secrets-store-inline-volume-crd.yaml
@@ -1,12 +1,16 @@
 kind: Pod
 apiVersion: v1
 metadata:
-  name: nginx-secrets-store-inline-crd
+  name: secrets-store-inline-crd
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: $CONTAINER_IMAGE
-    name: nginx
+  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    name: busybox
+    imagePullPolicy: IfNotPresent
+    command:
+    - "/bin/sleep"
+    - "10000"
     volumeMounts:
     - name: secrets-store-inline
       mountPath: "/mnt/secrets-store"

--- a/test/bats/tests/azure/rotation/pod-synck8s-azure.yaml
+++ b/test/bats/tests/azure/rotation/pod-synck8s-azure.yaml
@@ -1,12 +1,22 @@
 kind: Pod
 apiVersion: v1
 metadata:
-  name: nginx-secrets-store-inline-crd
+  name: secrets-store-inline-rotation
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: $CONTAINER_IMAGE
-    name: nginx
+  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    name: busybox
+    imagePullPolicy: IfNotPresent
+    command:
+    - "/bin/sleep"
+    - "10000"
+    env:
+    - name: SECRET_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: rotationsecret
+          key: username
     volumeMounts:
     - name: secrets-store-inline
       mountPath: "/mnt/secrets-store"
@@ -17,6 +27,6 @@ spec:
         driver: secrets-store.csi.k8s.io
         readOnly: true
         volumeAttributes:
-          secretProviderClass: "gcp"
+          secretProviderClass: "azure-auto-rotation"
         nodePublishSecretRef:
           name: secrets-store-creds

--- a/test/bats/tests/gcp/pod-secrets-store-inline-volume-crd.yaml
+++ b/test/bats/tests/gcp/pod-secrets-store-inline-volume-crd.yaml
@@ -1,18 +1,16 @@
 kind: Pod
 apiVersion: v1
 metadata:
-  name: nginx-secrets-store-inline-rotation
+  name: secrets-store-inline-crd
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: $CONTAINER_IMAGE
-    name: nginx
-    env:
-    - name: SECRET_USERNAME
-      valueFrom:
-        secretKeyRef:
-          name: rotationsecret
-          key: username
+  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    name: busybox
+    imagePullPolicy: IfNotPresent
+    command:
+    - "/bin/sleep"
+    - "10000"
     volumeMounts:
     - name: secrets-store-inline
       mountPath: "/mnt/secrets-store"
@@ -23,6 +21,6 @@ spec:
         driver: secrets-store.csi.k8s.io
         readOnly: true
         volumeAttributes:
-          secretProviderClass: "azure-auto-rotation"
+          secretProviderClass: "gcp"
         nodePublishSecretRef:
           name: secrets-store-creds

--- a/test/bats/tests/vault/deployment-synck8s.yaml
+++ b/test/bats/tests/vault/deployment-synck8s.yaml
@@ -1,23 +1,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment
+  name: busybox-deployment
   labels:
-    app: nginx
+    app: busybox
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: nginx
+      app: busybox
   template:
     metadata:
       labels:
-        app: nginx
+        app: busybox
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: $CONTAINER_IMAGE
-        name: nginx
+      - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+        name: busybox
+        imagePullPolicy: IfNotPresent
+        command:
+        - "/bin/sleep"
+        - "10000"
         env:
         - name: SECRET_USERNAME
           valueFrom:
@@ -34,6 +38,4 @@ spec:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
-              secretProviderClass: "azure-sync"
-            nodePublishSecretRef:
-              name: secrets-store-creds
+              secretProviderClass: "vault-foo-sync"

--- a/test/bats/tests/vault/deployment-two-synck8s.yaml
+++ b/test/bats/tests/vault/deployment-two-synck8s.yaml
@@ -1,23 +1,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment-two
+  name: busybox-deployment-two
   labels:
-    app: nginx
+    app: busybox
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: nginx
+      app: busybox
   template:
     metadata:
       labels:
-        app: nginx
+        app: busybox
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: nginx
-        name: nginx
+      - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+        name: busybox
+        imagePullPolicy: IfNotPresent
+        command:
+        - "/bin/sleep"
+        - "10000"
         env:
         - name: SECRET_USERNAME
           valueFrom:

--- a/test/bats/tests/vault/pod-vault-inline-volume-multiple-spc.yaml
+++ b/test/bats/tests/vault/pod-vault-inline-volume-multiple-spc.yaml
@@ -1,12 +1,16 @@
 kind: Pod
 apiVersion: v1
 metadata:
-  name: nginx-secrets-store-inline-multiple-crd
+  name: secrets-store-inline-multiple-crd
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: $CONTAINER_IMAGE
-    name: nginx
+  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    name: busybox
+    imagePullPolicy: IfNotPresent
+    command:
+    - "/bin/sleep"
+    - "10000"
     volumeMounts:
     - name: secrets-store-inline-0
       mountPath: "/mnt/secrets-store-0"

--- a/test/bats/tests/vault/pod-vault-inline-volume-secretproviderclass.yaml
+++ b/test/bats/tests/vault/pod-vault-inline-volume-secretproviderclass.yaml
@@ -1,11 +1,15 @@
 kind: Pod
 apiVersion: v1
 metadata:
-  name: nginx-secrets-store-inline
+  name: secrets-store-inline
 spec:
   containers:
-  - image: $CONTAINER_IMAGE
-    name: cont1
+  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    name: busybox
+    imagePullPolicy: IfNotPresent
+    command:
+    - "/bin/sleep"
+    - "10000"
     volumeMounts:
     - name: secrets-store-inline
       mountPath: "/mnt/secrets-store"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Switches to using lightweight busybox image for tests. This image `k8s.gcr.io/e2e-test-images/busybox:1.29` is multi-os and can be used for windows as well. 
- Reduces windows tests run time by 50%

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
