### PR TITLE
test: update vault e2e to use versioned deployment

### DIFF
--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -6,7 +6,7 @@ BATS_TESTS_DIR=test/bats/tests/vault
 WAIT_TIME=120
 SLEEP_TIME=1
 NAMESPACE=default
-PROVIDER_YAML=https://raw.githubusercontent.com/hashicorp/secrets-store-csi-driver-provider-vault/master/deployment/provider-vault-installer.yaml
+PROVIDER_YAML=https://raw.githubusercontent.com/hashicorp/vault-csi-provider/e0eae762c669658b55cf458dedaddf53277af759/deployment/provider-vault-installer.yaml
 
 export CONTAINER_IMAGE=nginx
 export LABEL_VALUE=${LABEL_VALUE:-"test"}


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Update the vault deployment manifests to a specific commit instead of master. More info on the change here: https://github.com/hashicorp/vault-csi-provider/issues/74

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
partially fixes: #483 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
