### PR TITLE
chore: remove v1.15 yamls and update doc

### DIFF
--- a/docs/book/src/concepts.md
+++ b/docs/book/src/concepts.md
@@ -20,7 +20,7 @@ The Secrets Store CSI Driver is a **daemonset** that facilitates communication w
 
 ## Provider for the Secrets Store CSI Driver
 
-The CSI driver communicates with the provider using gRPC to fetch the mount contents from external Secrets Store. Refer to [doc] for more details on the how to implement a provider for the driver and criteria for supported providers.
+The CSI driver communicates with the provider using gRPC to fetch the mount contents from external Secrets Store. Refer to [doc](./providers.md) for more details on the how to implement a provider for the driver and criteria for supported providers.
 
 Currently supported providers:
 

--- a/docs/book/src/getting-started/installation.md
+++ b/docs/book/src/getting-started/installation.md
@@ -41,9 +41,6 @@ kubectl apply -f deploy/secrets-store-csi-driver.yaml
 # required to enable this feature
 kubectl apply -f deploy/rbac-secretprovidersyncing.yaml
 
-# [OPTIONAL] For kubernetes version < 1.16 running `kubectl apply -f deploy/csidriver.yaml` will fail. To install the driver run
-kubectl apply -f deploy/csidriver-1.15.yaml
-
 # [OPTIONAL] To deploy driver on windows nodes
 kubectl apply -f deploy/secrets-store-csi-driver-windows.yaml
 ```

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -22,3 +22,9 @@ Join us to help define the direction and implementation of this project!
 - Supports windows containers (Kubernetes version v1.18+)
 - Supports sync with Kubernetes Secrets (Secrets Store CSI Driver v0.0.10+)
 - Support auto rotation of mounted contents and synced Kubernetes secret (Secrets Store CSI Driver v0.0.15+)
+
+## Supported Providers
+
+- [Azure Provider](https://azure.github.io/secrets-store-csi-driver-provider-azure/)
+- [Vault Provider](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault)
+- [GCP Provider](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp)

--- a/manifest_staging/deploy/csidriver-1.15.yaml
+++ b/manifest_staging/deploy/csidriver-1.15.yaml
@@ -1,7 +1,0 @@
-apiVersion: storage.k8s.io/v1beta1
-kind: CSIDriver
-metadata:
-  name: secrets-store.csi.k8s.io
-spec:
-  podInfoOnMount: true
-  attachRequired: false


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- `1.15` was deprecated on `2020-05-06` and the minimum requirement for using the CSI driver is `1.16`. So removing the `1.15` manifests. 
- Adding supported providers to introduction to make it easier for new users.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
