### PR TITLE
chore: update servercore reference to windows-servercore-cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ container-linux: docker-buildx-builder
 container-windows: docker-buildx-builder
 	docker buildx build --no-cache --output=type=$(OUTPUT_TYPE) --platform="windows/$(ARCH)" --build-arg LDFLAGS=$(LDFLAGS) \
 		--build-arg BASEIMAGE=mcr.microsoft.com/windows/nanoserver:$(OSVERSION) \
-		--build-arg BASEIMAGE_CORE=mcr.microsoft.com/windows/servercore:$(OSVERSION) \
+		--build-arg BASEIMAGE_CORE=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-$(OSVERSION) \
  		-t $(IMAGE_TAG)-windows-$(OSVERSION)-$(ARCH) -f docker/windows.Dockerfile .
 
 .PHONY: docker-buildx-builder

--- a/docker/BASEIMAGE_CORE
+++ b/docker/BASEIMAGE_CORE
@@ -1,4 +1,4 @@
-windows/amd64/1809=mcr.microsoft.com/windows/servercore:1809
-windows/amd64/1903=mcr.microsoft.com/windows/servercore:1903
-windows/amd64/1909=mcr.microsoft.com/windows/servercore:1909
-windows/amd64/2004=mcr.microsoft.com/windows/servercore:2004
+windows/amd64/1809=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1809
+windows/amd64/1903=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1903
+windows/amd64/1909=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1909
+windows/amd64/2004=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-2004

--- a/docker/windows.Dockerfile
+++ b/docker/windows.Dockerfile
@@ -1,5 +1,7 @@
 ARG BASEIMAGE=mcr.microsoft.com/windows/nanoserver:1809
-ARG BASEIMAGE_CORE=mcr.microsoft.com/windows/servercore:1809
+ARG BASEIMAGE_CORE=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1809
+
+FROM --platform=linux/amd64 ${BASEIMAGE_CORE} as core
 
 FROM --platform=$BUILDPLATFORM golang:1.16-alpine as builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver
@@ -9,9 +11,6 @@ ARG TARGETOS
 ARG LDFLAGS
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "${LDFLAGS}" -o _output/secrets-store-csi.exe ./cmd/secrets-store-csi-driver
 
-FROM mcr.microsoft.com/windows/servercore:1809 as core
-
-FROM $BASEIMAGE_CORE as core
 FROM $BASEIMAGE
 LABEL description="Secrets Store CSI Driver"
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
Update `servercore` base image reference to `windows-servercore-cache` to speed up builds.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
