### PR TITLE
dial: grpc naming is not compatible with windows unix socket

### DIFF
--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -88,6 +88,8 @@ setup() {
 }
 
 @test "CSI inline volume test with pod portability - read azure kv secret from pod" {
+  wait_for_process $WAIT_TIME $SLEEP_TIME "kubectl exec nginx-secrets-store-inline-crd -- $EXEC_COMMAND /mnt/secrets-store/$SECRET_NAME | grep '${SECRET_VALUE}'"
+
   result=$(kubectl exec nginx-secrets-store-inline-crd -- $EXEC_COMMAND /mnt/secrets-store/$SECRET_NAME)
   [[ "${result//$'\r'}" == "${SECRET_VALUE}" ]]
 }
@@ -127,7 +129,7 @@ setup() {
   result=$(kubectl get secret foosecret -o jsonpath="{.data.username}" | base64 -d)
   [[ "${result//$'\r'}" == "${SECRET_VALUE}" ]]
 
-  result=$(kubectl exec $POD printenv | grep SECRET_USERNAME) | awk -F"=" '{ print $2}'
+  result=$(kubectl exec $POD -- printenv | grep SECRET_USERNAME) | awk -F"=" '{ print $2}'
   [[ "${result//$'\r'}" == "${SECRET_VALUE}" ]]
 
   result=$(kubectl get secret foosecret -o jsonpath="{.metadata.labels.environment}")


### PR DESCRIPTION
**What this PR does / why we need it**:

Windows grpc connections are currently broken:

```
E0324 17:53:17.547284    6228 utils.go:79] GRPC error: failed to mount secrets store objects for pod default/nginx-secrets-store-inline-crd, err: rpc error: code = DeadlineExceeded desc = latest balancer error: connection error: desc = "transport: Error while dialing dial tcp: address unix://C:\\k\\secrets-store-csi-providers/azure.sock: too many colons in address"
```

Believe this was caused by https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/462 where `grpc.Dial` was replaced with [`grpc.DialContext`](https://pkg.go.dev/google.golang.org/grpc#DialContext).

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
