### PR TITLE
fix: prevent duplicate owner references

### DIFF
--- a/controllers/secretproviderclasspodstatus_controller.go
+++ b/controllers/secretproviderclasspodstatus_controller.go
@@ -444,8 +444,10 @@ func (r *SecretProviderClassPodStatusReconciler) patchSecretWithOwnerRef(ctx con
 		if _, exists := secretOwnerMap[ownerRefs[i].Name]; exists {
 			continue
 		}
+		// add to map for tracking
+		secretOwnerMap[ownerRefs[i].Name] = ownerRefs[i].UID
 		needsPatch = true
-		klog.Infof("Adding %s/%s as owner ref for %s/%s", ownerRefs[i].APIVersion, ownerRefs[i].Name, namespace, name)
+		klog.V(5).Infof("Adding %s/%s as owner ref for %s/%s", ownerRefs[i].APIVersion, ownerRefs[i].Name, namespace, name)
 		secretOwnerRefs = append(secretOwnerRefs, ownerRefs[i])
 	}
 

--- a/controllers/secretproviderclasspodstatus_controller_test.go
+++ b/controllers/secretproviderclasspodstatus_controller_test.go
@@ -172,7 +172,8 @@ func TestPatchSecretWithOwnerRef(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(scheme, initObjects...)
 	reconciler := newReconciler(client, scheme, "node1")
 
-	err = reconciler.patchSecretWithOwnerRef(context.TODO(), "my-secret", "default", ref)
+	// adding ref twice to test de-duplication of owner references when being set in the secret
+	err = reconciler.patchSecretWithOwnerRef(context.TODO(), "my-secret", "default", ref, ref)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	secret := &v1.Secret{}

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -136,7 +136,7 @@ setup() {
   result=$(kubectl get secret foosecret -o jsonpath="{.metadata.labels.secrets-store\.csi\.k8s\.io/managed}")
   [[ "${result//$'\r'}" == "true" ]]
 
-  run wait_for_process $WAIT_TIME $SLEEP_TIME "compare_owner_count foosecret default 4"
+  run wait_for_process $WAIT_TIME $SLEEP_TIME "compare_owner_count foosecret default 2"
   assert_success
 }
 
@@ -144,7 +144,7 @@ setup() {
   run kubectl delete -f $BATS_TESTS_DIR/nginx-deployment-synck8s-azure.yaml
   assert_success
 
-  run wait_for_process $WAIT_TIME $SLEEP_TIME "compare_owner_count foosecret default 2"
+  run wait_for_process $WAIT_TIME $SLEEP_TIME "compare_owner_count foosecret default 1"
   assert_success
 
   run kubectl delete -f $BATS_TESTS_DIR/nginx-deployment-two-synck8s-azure.yaml
@@ -197,7 +197,7 @@ setup() {
   result=$(kubectl exec -n test-ns $POD -- printenv | grep SECRET_USERNAME) | awk -F"=" '{ print $2}'
   [[ "${result//$'\r'}" == "${SECRET_VALUE}" ]]
 
-  run wait_for_process $WAIT_TIME $SLEEP_TIME "compare_owner_count foosecret test-ns 2"
+  run wait_for_process $WAIT_TIME $SLEEP_TIME "compare_owner_count foosecret test-ns 1"
   assert_success
 }
 

--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -196,7 +196,7 @@ EOF
   result=$(kubectl get secret foosecret -o jsonpath="{.metadata.labels.secrets-store\.csi\.k8s\.io/managed}")
   [[ "${result//$'\r'}" == "true" ]]
 
-  run wait_for_process $WAIT_TIME $SLEEP_TIME "compare_owner_count foosecret default 4"
+  run wait_for_process $WAIT_TIME $SLEEP_TIME "compare_owner_count foosecret default 2"
   assert_success
 }
 
@@ -204,7 +204,7 @@ EOF
   run kubectl delete -f $BATS_TESTS_DIR/nginx-deployment-synck8s.yaml
   assert_success
   
-  run wait_for_process $WAIT_TIME $SLEEP_TIME "compare_owner_count foosecret default 2"
+  run wait_for_process $WAIT_TIME $SLEEP_TIME "compare_owner_count foosecret default 1"
   assert_success
 
   run kubectl delete -f $BATS_TESTS_DIR/nginx-deployment-two-synck8s.yaml
@@ -254,7 +254,7 @@ EOF
   result=$(kubectl exec -n test-ns $POD -- printenv | grep SECRET_USERNAME | awk -F"=" '{ print $2 }' | tr -d '\r\n')
   [[ "$result" == "hello1" ]]
 
-  run wait_for_process $WAIT_TIME $SLEEP_TIME "compare_owner_count foosecret test-ns 2"
+  run wait_for_process $WAIT_TIME $SLEEP_TIME "compare_owner_count foosecret test-ns 1"
   assert_success
 }
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
Came across this issue while testing with older Kubernetes releases where the API server allows duplication of owner references. Although it doesn't have an impact on the core functionality of gc, it could lead to large objects if the owner refs are duplicated. This was fixed in this PR: https://github.com/kubernetes/kubernetes/pull/96185. 

Fixing the check to ensure we don't append the same owner reference twice and updating tests to conform with it. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
