### PR TITLE
docs: use multi-os image for examples and update urls

### DIFF
--- a/docs/book/src/getting-started/usage.md
+++ b/docs/book/src/getting-started/usage.md
@@ -32,7 +32,7 @@ volumes:
         secretProviderClass: "my-provider"
 ```
 
-Here is a sample [deployment yaml](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/test/bats/tests/vault/nginx-pod-vault-inline-volume-secretproviderclass.yaml) using the Secrets Store CSI driver.
+Here is a sample [deployment yaml](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/test/bats/tests/vault/pod-vault-inline-volume-secretproviderclass.yaml) using the Secrets Store CSI driver.
 
 ## Secret Content is Mounted on Pod Start
 
@@ -41,7 +41,7 @@ On pod start and restart, the driver will communicate with the provider using gR
 To validate, once the pod is started, you should see the new mounted content at the volume path specified in your deployment yaml.
 
 ```bash
-kubectl exec -it nginx-secrets-store-inline ls /mnt/secrets-store/
+kubectl exec secrets-store-inline -- ls /mnt/secrets-store/
 foo
 ```
 

--- a/docs/book/src/topics/set-as-env-var.md
+++ b/docs/book/src/topics/set-as-env-var.md
@@ -43,11 +43,14 @@ spec:
 kind: Pod
 apiVersion: v1
 metadata:
-  name: nginx-secrets-store-inline
+  name: secrets-store-inline
 spec:
   containers:
-    - name: nginx
-      image: nginx
+    - name: busybox
+      image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      command:
+      - "/bin/sleep"
+      - "10000"
       volumeMounts:
       - name: secrets-store01-inline
         mountPath: "/mnt/secrets-store"
@@ -74,8 +77,11 @@ Once the [secret is created](./sync-as-kubernetes-secret.md), you may wish to se
 ```yaml
 spec:
   containers:
-  - image: nginx
-    name: nginx
+  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    name: busybox
+    command:
+    - "/bin/sleep"
+    - "10000"
     env:
     - name: SECRET_USERNAME
       valueFrom:

--- a/docs/book/src/topics/sync-as-kubernetes-secret.md
+++ b/docs/book/src/topics/sync-as-kubernetes-secret.md
@@ -43,11 +43,14 @@ spec:
 kind: Pod
 apiVersion: v1
 metadata:
-  name: nginx-secrets-store-inline
+  name: secrets-store-inline
 spec:
   containers:
-    - name: nginx
-      image: nginx
+    - name: busybox
+      image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      command:
+      - "/bin/sleep"
+      - "10000"
       volumeMounts:
       - name: secrets-store01-inline
         mountPath: "/mnt/secrets-store"

--- a/sample/ingress-controller-tls/README.md
+++ b/sample/ingress-controller-tls/README.md
@@ -6,4 +6,4 @@ For more information on securing an Ingress with TLS, refer to: https://kubernet
 Checkout provider samples on how to get started -
 
 - [Using Secrets Store CSI and Azure Key Vault Provider](https://azure.github.io/secrets-store-csi-driver-provider-azure/configurations/ingress-tls/)
-- [Using Secrets Store CSI and Hashicorp Vault Provider](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/blob/master/sample/ingress-controller-tls/README.md)
+- [Using Secrets Store CSI and HashiCorp Vault Provider](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/blob/master/sample/ingress-controller-tls/README.md)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
Now that #480 is merged with changes to file name, updating the urls in the docs and switching to use multi-os image for examples

/kind documentation

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
