### PR TITLE
docs: add load test spec and results

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -12,5 +12,6 @@
     - [Set as ENV var](./topics/set-as-env-var.md)
 - [Providers](./providers.md)
 - [Troubleshooting](./troubleshooting.md)
+- [Load tests](./load-tests.md)
 - [Testing](./testing.md)
 - [Known Limitations](./known-limitations.md)

--- a/docs/book/src/load-tests.md
+++ b/docs/book/src/load-tests.md
@@ -1,0 +1,67 @@
+# Load tests
+
+This document highlights the results from load tests using secrets-store-csi-driver `v0.0.21`.
+
+> Note: Refer to [doc](https://docs.google.com/document/d/1ba8gTC-i33Df6uiOB8rW8jBX2B0lK8LszUjYlPzNwlQ/edit?usp=sharing) for more details on the optimization done as part of `v0.0.21` release.
+
+The results posted here can be used as a guide for configuring resource and memory limits for the CSI driver **daemonset** pods.
+
+## Testing Environment
+
+1. 250 nodes [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/) cluster
+    - VM Size: [Standard_DS2_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series#dsv2-series) (2 vCPU, 7GiB)
+2. 3500 Kubernetes secrets in the cluster
+    - These secrets were pre-configured to ensure existing Kubernetes secrets doesn't impact the memory for the CSI driver.
+3. 7250 pods running in the cluster
+    - These pods were pre-configured to ensure existing Kubernetes pods doesn't impact the memory for the CSI driver.
+
+The Secrets Store CSI Driver and [Azure Keyvault Provider](https://azure.github.io/secrets-store-csi-driver-provider-azure/) were deployed to the cluster.
+
+Secrets Store CSI Driver features enabled:
+
+1. [Sync as Kubernetes secret](./topics/sync-as-kubernetes-secret.md)
+2. [Secret Auto rotation](./topics/secret-auto-rotation.md)
+    - Rotation Poll Interval: 2m
+
+## Testing scenarios
+
+### 10000 pods with CSI volume
+
+1. 10000 pods with CSI volume.
+    - Total number of pods in the cluster = 7250 + 10000 = 17250 pods.
+2. `SecretProviderClass` with syncing 2 Kubernetes secrets.
+
+```bash
+➜ kubectl top pods -l app=csi-secrets-store -n kube-system --sort-by=memory
+NAME                      CPU(cores)   MEMORY(bytes)
+csi-secrets-store-kd2bc   3m           54Mi
+csi-secrets-store-wx6z9   3m           52Mi
+csi-secrets-store-6gjqq   3m           52Mi
+csi-secrets-store-knl5g   4m           52Mi
+csi-secrets-store-9lzzn   4m           51Mi
+```
+
+The current default memory and resource limits have been configured based on the above tests.
+
+## Understanding Secrets Store CSI Driver memory consumption
+
+As of Secrets Store CSI Driver `v0.0.21`, the memory consumption for the driver is dependent on:
+
+1. Number of pods on the same node as the driver pod.
+2. Number of secrets with
+    a. `secrets-store.csi.k8s.io/managed=true` label. This label is set for all the secrets created by the Secrets Store CSI Driver.
+    b. `secrets-store.csi.k8s.io/used=true` label. This label needs to be set for all `nodePublishSecretRef`.
+3. Number of `SecretProviderClass` across all namespaces.
+4. Number of `SecretProviderClassPodStatus` created by Secrets Store CSI Driver for the pod on the same node as the application pod.
+   a. Secrets Store CSI Driver creates a `SecretProviderClassPodStatus` to map pod to `SecretProviderClass`. See [doc](./concepts.md#secretproviderclasspodstatus) for more details.
+
+<aside class="note warning">
+<h1>Warning</h1>
+
+If the secret rotation feature is enabled and filtered secret watch is not enabled, it'll cache Kubernetes secrets across all namespaces. To only cache the secrets with the above 2 labels:
+
+1. Label all existing `nodePublishSecretRef` secrets with `secrets-store.csi.k8s.io/used=true` by running `kubectl label secret <node publish secret ref name> secrets-store.csi.k8s.io/used=true`.
+2. Enable filtered secret watch by setting `--filtered-secret-watch=true` in `secrets-store` container or via helm using `--set filteredSecretWatch=true`.
+
+**NOTE:** `--filtered-secret-watch=true` will be enabled by default in n+3 releases (`v0.0.25`). Please take the necessary action to label the `nodePublishSecretRef` secrets with the `secrets-store.csi.k8s.io/used=true` label.
+</aside>

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -4,13 +4,14 @@ The Secrets Store CSI Driver uses Google Docs for design documents and proposals
 
 ## In Progress
 
-- [secret-store-csi-driver file IO consolidation](https://docs.google.com/document/d/1y1Oc1_-JGxMh-MZ57iqrVnoCIn6V-W0vJcj3qmq8EWU/edit?usp=sharing)
 
 ## Implemented
 
 - [Secrets Store CSI Driver - Reconciler](https://docs.google.com/document/d/1EM0Lf-qSdUXdfjOx3AZB9yHOr-lw9_CtoUhR0eTmIwo/edit?usp=sharing)
 - [Secrets Store CSI Driver Provider using gRPC Design Proposal](https://docs.google.com/document/d/10-RHUJGM0oMN88AZNxjOmGz0NsWAvOYrWUEV-FbLWyw/edit?usp=sharing)
 - [Secrets Store CSI Driver - Rotation](https://docs.google.com/document/d/1RGT0vmeUnN71n_u5fZKsSCa2YQpGw99rfGN9RlFMgHs/edit?usp=sharing)
+- [secret-store-csi-driver file IO consolidation](https://docs.google.com/document/d/1y1Oc1_-JGxMh-MZ57iqrVnoCIn6V-W0vJcj3qmq8EWU/edit?usp=sharing)
+- [Secrets Store CSI Driver optimization based on Load testing](https://docs.google.com/document/d/1ba8gTC-i33Df6uiOB8rW8jBX2B0lK8LszUjYlPzNwlQ/edit?usp=sharing)
 
 ## Roadmap
 

--- a/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
@@ -50,6 +50,7 @@ spec:
             - "--metrics-addr=:8095"
             - "--enable-secret-rotation=false"
             - "--rotation-poll-interval=2m"
+            - "--filtered-secret-watch=false"
           env:
             - name: CSI_ENDPOINT
               value: unix://C:\\csi\\csi.sock

--- a/manifest_staging/deploy/secrets-store-csi-driver.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver.yaml
@@ -50,6 +50,7 @@ spec:
             - "--metrics-addr=:8095"
             - "--enable-secret-rotation=false"
             - "--rotation-poll-interval=2m"
+            - "--filtered-secret-watch=false"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- adds docs for load testing specs and results
- adds `--filtered-secret-watch` flag to the manifests
- updates design doc and adds load test optimization to the list

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #111

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
