### PR TITLE
fix: updates CSIDriver api ver to storage.k8s.io/v1

### DIFF
--- a/manifest_staging/deploy/csidriver.yaml
+++ b/manifest_staging/deploy/csidriver.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: secrets-store.csi.k8s.io


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the `apiVersion` to `storage.k8s.io/v1` for csidriver in `manifest_staging/deploy/csidriver.yaml`

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/403

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
