### PR TITLE
feat: use the atomic file writer

### DIFF
--- a/pkg/secrets-store/nodeserver_test.go
+++ b/pkg/secrets-store/nodeserver_test.go
@@ -363,7 +363,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 			name: "Success for a mounted volume with a retry",
 			nodeUnpublishVolReq: csi.NodeUnpublishVolumeRequest{
 				VolumeId:   "testvolid1",
-				TargetPath: tmpdir.New(t, "", `*\\pods\\fakePod\\volumes\\kubernetes.io~csi\\myvol\\mount`),
+				TargetPath: tmpdir.New(t, "", `*mount`),
 			},
 			mountPoints:        []mount.MountPoint{},
 			shouldRetryUnmount: true,

--- a/pkg/secrets-store/provider_client_test.go
+++ b/pkg/secrets-store/provider_client_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -64,6 +65,7 @@ func TestMountContent(t *testing.T) {
 		files          []*v1alpha1.File
 		// expectations
 		expectedFiles map[string]os.FileMode
+		skipon        string
 	}{
 		{
 			name:           "provider successful response (no files)",
@@ -77,13 +79,13 @@ func TestMountContent(t *testing.T) {
 			files: []*v1alpha1.File{
 				{
 					Path:     "foo",
-					Mode:     0644,
+					Mode:     0666,
 					Contents: []byte("foo"),
 				},
 			},
 			objectVersions: map[string]string{"foo": "v1"},
 			expectedFiles: map[string]os.FileMode{
-				"foo": 0644,
+				"foo": 0666,
 			},
 		},
 		{
@@ -92,23 +94,23 @@ func TestMountContent(t *testing.T) {
 			files: []*v1alpha1.File{
 				{
 					Path:     "foo",
-					Mode:     0644,
+					Mode:     0666,
 					Contents: []byte("foo"),
 				},
 				{
 					Path:     "bar",
-					Mode:     0777,
+					Mode:     0444,
 					Contents: []byte("bar"),
 				},
 			},
 			objectVersions: map[string]string{"foo": "v1"},
 			expectedFiles: map[string]os.FileMode{
-				"foo": 0644,
-				"bar": 0777,
+				"foo": 0666,
+				"bar": 0444,
 			},
 		},
 		{
-			name:       "provider response with nested files",
+			name:       "provider response with nested files (linux)",
 			permission: "777",
 			files: []*v1alpha1.File{
 				{
@@ -133,11 +135,46 @@ func TestMountContent(t *testing.T) {
 				"baz/bar": 0777,
 				"baz/qux": 0777,
 			},
+			skipon: "windows",
+		},
+		{
+			// note: this is a bit weird because the path `baz\bar` on windows
+			// should be a file `bar` nested in a folder `baz`. it _actually_
+			// works on linux though because the `\` character is just treated
+			// as part of the filename.
+			name:       "provider response with nested files (windows)",
+			permission: "777",
+			files: []*v1alpha1.File{
+				{
+					Path:     "foo",
+					Mode:     0444,
+					Contents: []byte("foo"),
+				},
+				{
+					Path:     "baz\\bar",
+					Mode:     0444,
+					Contents: []byte("bar"),
+				},
+				{
+					Path:     "baz\\qux",
+					Mode:     0666,
+					Contents: []byte("qux"),
+				},
+			},
+			objectVersions: map[string]string{"foo": "v1"},
+			expectedFiles: map[string]os.FileMode{
+				"foo":      0444,
+				"baz\\bar": 0444,
+				"baz\\qux": 0666,
+			},
 		},
 	}
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
+			if test.skipon == runtime.GOOS {
+				t.SkipNow()
+			}
 			socketPath := tmpdir.New(t, "", "ut")
 			targetPath := tmpdir.New(t, "", "ut")
 

--- a/pkg/util/fileutil/atomic_writer.go
+++ b/pkg/util/fileutil/atomic_writer.go
@@ -1,0 +1,463 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Vendored from kubernetes/pkg/volume/util/atomic_writer.go
+//  * tag: v1.20.6,
+//  * commit: 8a62859e515889f07e3e3be6a1080413f17cf2c3
+//  * link: https://github.com/kubernetes/kubernetes/blob/8a62859e515889f07e3e3be6a1080413f17cf2c3/pkg/volume/util/atomic_writer.go
+
+package fileutil
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	maxFileNameLength = 255
+	maxPathLength     = 4096
+)
+
+// AtomicWriter handles atomically projecting content for a set of files into
+// a target directory.
+//
+// Note:
+//
+// 1. AtomicWriter reserves the set of pathnames starting with `..`.
+// 2. AtomicWriter offers no concurrency guarantees and must be synchronized
+//    by the caller.
+//
+// The visible files in this volume are symlinks to files in the writer's data
+// directory.  Actual files are stored in a hidden timestamped directory which
+// is symlinked to by the data directory. The timestamped directory and
+// data directory symlink are created in the writer's target dir.  This scheme
+// allows the files to be atomically updated by changing the target of the
+// data directory symlink.
+//
+// Consumers of the target directory can monitor the ..data symlink using
+// inotify or fanotify to receive events when the content in the volume is
+// updated.
+type AtomicWriter struct {
+	targetDir  string
+	logContext string
+}
+
+// FileProjection contains file Data and access Mode
+type FileProjection struct {
+	Data   []byte
+	Mode   int32
+	FsUser *int64
+}
+
+// NewAtomicWriter creates a new AtomicWriter configured to write to the given
+// target directory, or returns an error if the target directory does not exist.
+func NewAtomicWriter(targetDir string, logContext string) (*AtomicWriter, error) {
+	_, err := os.Stat(targetDir)
+	if os.IsNotExist(err) {
+		return nil, err
+	}
+
+	return &AtomicWriter{targetDir: targetDir, logContext: logContext}, nil
+}
+
+const (
+	dataDirName    = "..data"
+	newDataDirName = "..data_tmp"
+)
+
+// Write does an atomic projection of the given payload into the writer's target
+// directory.  Input paths must not begin with '..'.
+//
+// The Write algorithm is:
+//
+//  1.  The payload is validated; if the payload is invalid, the function returns
+//  2.  The current timestamped directory is detected by reading the data directory
+//      symlink
+//  3.  The old version of the volume is walked to determine whether any
+//      portion of the payload was deleted and is still present on disk.
+//  4.  The data in the current timestamped directory is compared to the projected
+//      data to determine if an update is required.
+//  5.  A new timestamped dir is created
+//  6.  The payload is written to the new timestamped directory
+//  7.  Symlinks and directory for new user-visible files are created (if needed).
+//
+//      For example, consider the files:
+//        <target-dir>/podName
+//        <target-dir>/user/labels
+//        <target-dir>/k8s/annotations
+//
+//      The user visible files are symbolic links into the internal data directory:
+//        <target-dir>/podName         -> ..data/podName
+//        <target-dir>/usr -> ..data/usr
+//        <target-dir>/k8s -> ..data/k8s
+//
+//      The data directory itself is a link to a timestamped directory with
+//      the real data:
+//        <target-dir>/..data          -> ..2016_02_01_15_04_05.12345678/
+//  8.  A symlink to the new timestamped directory ..data_tmp is created that will
+//      become the new data directory
+//  9.  The new data directory symlink is renamed to the data directory; rename is atomic
+// 10.  Old paths are removed from the user-visible portion of the target directory
+// 11.  The previous timestamped directory is removed, if it exists
+func (w *AtomicWriter) Write(payload map[string]FileProjection) error {
+	// (1)
+	cleanPayload, err := validatePayload(payload)
+	if err != nil {
+		klog.Errorf("%s: invalid payload: %v", w.logContext, err)
+		return err
+	}
+
+	// (2)
+	dataDirPath := filepath.Join(w.targetDir, dataDirName)
+	oldTsDir, err := os.Readlink(dataDirPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			klog.Errorf("%s: error reading link for data directory: %v", w.logContext, err)
+			return err
+		}
+		// although Readlink() returns "" on err, don't be fragile by relying on it (since it's not specified in docs)
+		// empty oldTsDir indicates that it didn't exist
+		oldTsDir = ""
+	}
+	oldTsPath := filepath.Join(w.targetDir, oldTsDir)
+
+	var pathsToRemove sets.String
+	// if there was no old version, there's nothing to remove
+	if len(oldTsDir) != 0 {
+		// (3)
+		pathsToRemove, err = w.pathsToRemove(cleanPayload, oldTsPath)
+		if err != nil {
+			klog.Errorf("%s: error determining user-visible files to remove: %v", w.logContext, err)
+			return err
+		}
+
+		// (4)
+		if should, err := shouldWritePayload(cleanPayload, oldTsPath); err != nil {
+			klog.Errorf("%s: error determining whether payload should be written to disk: %v", w.logContext, err)
+			return err
+		} else if !should && len(pathsToRemove) == 0 {
+			klog.V(4).Infof("%s: no update required for target directory %v", w.logContext, w.targetDir)
+			return nil
+		} else {
+			klog.V(4).Infof("%s: write required for target directory %v", w.logContext, w.targetDir)
+		}
+	}
+
+	// (5)
+	tsDir, err := w.newTimestampDir()
+	if err != nil {
+		klog.V(4).Infof("%s: error creating new ts data directory: %v", w.logContext, err)
+		return err
+	}
+	tsDirName := filepath.Base(tsDir)
+
+	// (6)
+	if err = w.writePayloadToDir(cleanPayload, tsDir); err != nil {
+		klog.Errorf("%s: error writing payload to ts data directory %s: %v", w.logContext, tsDir, err)
+		return err
+	}
+	klog.V(4).Infof("%s: performed write of new data to ts data directory: %s", w.logContext, tsDir)
+
+	// (7)
+	if err = w.createUserVisibleFiles(cleanPayload); err != nil {
+		klog.Errorf("%s: error creating visible symlinks in %s: %v", w.logContext, w.targetDir, err)
+		return err
+	}
+
+	// (8)
+	newDataDirPath := filepath.Join(w.targetDir, newDataDirName)
+	if err = os.Symlink(tsDirName, newDataDirPath); err != nil {
+		os.RemoveAll(tsDir)
+		klog.Errorf("%s: error creating symbolic link for atomic update: %v", w.logContext, err)
+		return err
+	}
+
+	// (9)
+	if runtime.GOOS == "windows" {
+		os.Remove(dataDirPath)
+		err = os.Symlink(tsDirName, dataDirPath)
+		os.Remove(newDataDirPath)
+	} else {
+		err = os.Rename(newDataDirPath, dataDirPath)
+	}
+	if err != nil {
+		os.Remove(newDataDirPath)
+		os.RemoveAll(tsDir)
+		klog.Errorf("%s: error renaming symbolic link for data directory %s: %v", w.logContext, newDataDirPath, err)
+		return err
+	}
+
+	// (10)
+	if err = w.removeUserVisiblePaths(pathsToRemove); err != nil {
+		klog.Errorf("%s: error removing old visible symlinks: %v", w.logContext, err)
+		return err
+	}
+
+	// (11)
+	if len(oldTsDir) > 0 {
+		if err = os.RemoveAll(oldTsPath); err != nil {
+			klog.Errorf("%s: error removing old data directory %s: %v", w.logContext, oldTsDir, err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validatePayload returns an error if any path in the payload returns a copy of the payload with the paths cleaned.
+func validatePayload(payload map[string]FileProjection) (map[string]FileProjection, error) {
+	cleanPayload := make(map[string]FileProjection)
+	for k, content := range payload {
+		if err := validatePath(k); err != nil {
+			return nil, err
+		}
+
+		cleanPayload[filepath.Clean(k)] = content
+	}
+
+	return cleanPayload, nil
+}
+
+// validatePath validates a single path, returning an error if the path is
+// invalid.  paths may not:
+//
+// 1. be absolute
+// 2. contain '..' as an element
+// 3. start with '..'
+// 4. contain filenames larger than 255 characters
+// 5. be longer than 4096 characters
+func validatePath(targetPath string) error {
+	// TODO: somehow unify this with the similar api validation,
+	// validateVolumeSourcePath; the error semantics are just different enough
+	// from this that it was time-prohibitive trying to find the right
+	// refactoring to re-use.
+	if targetPath == "" {
+		return fmt.Errorf("invalid path: must not be empty: %q", targetPath)
+	}
+	if path.IsAbs(targetPath) {
+		return fmt.Errorf("invalid path: must be relative path: %s", targetPath)
+	}
+
+	if len(targetPath) > maxPathLength {
+		return fmt.Errorf("invalid path: must be less than or equal to %d characters", maxPathLength)
+	}
+
+	items := strings.Split(targetPath, string(os.PathSeparator))
+	for _, item := range items {
+		if item == ".." {
+			return fmt.Errorf("invalid path: must not contain '..': %s", targetPath)
+		}
+		if len(item) > maxFileNameLength {
+			return fmt.Errorf("invalid path: filenames must be less than or equal to %d characters", maxFileNameLength)
+		}
+	}
+	if strings.HasPrefix(items[0], "..") && len(items[0]) > 2 {
+		return fmt.Errorf("invalid path: must not start with '..': %s", targetPath)
+	}
+
+	return nil
+}
+
+// shouldWritePayload returns whether the payload should be written to disk.
+func shouldWritePayload(payload map[string]FileProjection, oldTsDir string) (bool, error) {
+	for userVisiblePath, fileProjection := range payload {
+		shouldWrite, err := shouldWriteFile(filepath.Join(oldTsDir, userVisiblePath), fileProjection.Data)
+		if err != nil {
+			return false, err
+		}
+
+		if shouldWrite {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// shouldWriteFile returns whether a new version of a file should be written to disk.
+func shouldWriteFile(path string, content []byte) (bool, error) {
+	_, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return true, nil
+	}
+
+	contentOnFs, err := ioutil.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	return !bytes.Equal(content, contentOnFs), nil
+}
+
+// pathsToRemove walks the current version of the data directory and
+// determines which paths should be removed (if any) after the payload is
+// written to the target directory.
+func (w *AtomicWriter) pathsToRemove(payload map[string]FileProjection, oldTsDir string) (sets.String, error) {
+	paths := sets.NewString()
+	visitor := func(path string, info os.FileInfo, err error) error {
+		relativePath := strings.TrimPrefix(path, oldTsDir)
+		relativePath = strings.TrimPrefix(relativePath, string(os.PathSeparator))
+		if relativePath == "" {
+			return nil
+		}
+
+		paths.Insert(relativePath)
+		return nil
+	}
+
+	err := filepath.Walk(oldTsDir, visitor)
+	if os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	klog.V(5).Infof("%s: current paths:   %+v", w.targetDir, paths.List())
+
+	newPaths := sets.NewString()
+	for file := range payload {
+		// add all subpaths for the payload to the set of new paths
+		// to avoid attempting to remove non-empty dirs
+		for subPath := file; subPath != ""; {
+			newPaths.Insert(subPath)
+			subPath, _ = filepath.Split(subPath)
+			subPath = strings.TrimSuffix(subPath, string(os.PathSeparator))
+		}
+	}
+	klog.V(5).Infof("%s: new paths:       %+v", w.targetDir, newPaths.List())
+
+	result := paths.Difference(newPaths)
+	klog.V(5).Infof("%s: paths to remove: %+v", w.targetDir, result)
+
+	return result, nil
+}
+
+// newTimestampDir creates a new timestamp directory
+func (w *AtomicWriter) newTimestampDir() (string, error) {
+	tsDir, err := ioutil.TempDir(w.targetDir, time.Now().UTC().Format("..2006_01_02_15_04_05."))
+	if err != nil {
+		klog.Errorf("%s: unable to create new temp directory: %v", w.logContext, err)
+		return "", err
+	}
+
+	// 0755 permissions are needed to allow 'group' and 'other' to recurse the
+	// directory tree.  do a chmod here to ensure that permissions are set correctly
+	// regardless of the process' umask.
+	err = os.Chmod(tsDir, 0755)
+	if err != nil {
+		klog.Errorf("%s: unable to set mode on new temp directory: %v", w.logContext, err)
+		return "", err
+	}
+
+	return tsDir, nil
+}
+
+// writePayloadToDir writes the given payload to the given directory.  The
+// directory must exist.
+func (w *AtomicWriter) writePayloadToDir(payload map[string]FileProjection, dir string) error {
+	for userVisiblePath, fileProjection := range payload {
+		content := fileProjection.Data
+		mode := os.FileMode(fileProjection.Mode)
+		fullPath := filepath.Join(dir, userVisiblePath)
+		baseDir, _ := filepath.Split(fullPath)
+
+		if err := os.MkdirAll(baseDir, os.ModePerm); err != nil {
+			klog.Errorf("%s: unable to create directory %s: %v", w.logContext, baseDir, err)
+			return err
+		}
+
+		if err := ioutil.WriteFile(fullPath, content, mode); err != nil {
+			klog.Errorf("%s: unable to write file %s with mode %v: %v", w.logContext, fullPath, mode, err)
+			return err
+		}
+		// Chmod is needed because ioutil.WriteFile() ends up calling
+		// open(2) to create the file, so the final mode used is "mode &
+		// ~umask". But we want to make sure the specified mode is used
+		// in the file no matter what the umask is.
+		if err := os.Chmod(fullPath, mode); err != nil {
+			klog.Errorf("%s: unable to change file %s with mode %v: %v", w.logContext, fullPath, mode, err)
+			return err
+		}
+
+		if fileProjection.FsUser == nil {
+			continue
+		}
+		if err := os.Chown(fullPath, int(*fileProjection.FsUser), -1); err != nil {
+			klog.Errorf("%s: unable to change file %s with owner %v: %v", w.logContext, fullPath, int(*fileProjection.FsUser), err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// createUserVisibleFiles creates the relative symlinks for all the
+// files configured in the payload. If the directory in a file path does not
+// exist, it is created.
+//
+// Viz:
+// For files: "bar", "foo/bar", "baz/bar", "foo/baz/blah"
+// the following symlinks are created:
+// bar -> ..data/bar
+// foo -> ..data/foo
+// baz -> ..data/baz
+func (w *AtomicWriter) createUserVisibleFiles(payload map[string]FileProjection) error {
+	for userVisiblePath := range payload {
+		slashpos := strings.Index(userVisiblePath, string(os.PathSeparator))
+		if slashpos == -1 {
+			slashpos = len(userVisiblePath)
+		}
+		linkname := userVisiblePath[:slashpos]
+		_, err := os.Readlink(filepath.Join(w.targetDir, linkname))
+		if err != nil && os.IsNotExist(err) {
+			// The link into the data directory for this path doesn't exist; create it
+			visibleFile := filepath.Join(w.targetDir, linkname)
+			dataDirFile := filepath.Join(dataDirName, linkname)
+
+			err = os.Symlink(dataDirFile, visibleFile)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// removeUserVisiblePaths removes the set of paths from the user-visible
+// portion of the writer's target directory.
+func (w *AtomicWriter) removeUserVisiblePaths(paths sets.String) error {
+	ps := string(os.PathSeparator)
+	var lasterr error
+	for p := range paths {
+		// only remove symlinks from the volume root directory (i.e. items that don't contain '/')
+		if strings.Contains(p, ps) {
+			continue
+		}
+		if err := os.Remove(filepath.Join(w.targetDir, p)); err != nil {
+			klog.Errorf("%s: error pruning old user-visible path %s: %v", w.logContext, p, err)
+			lasterr = err
+		}
+	}
+
+	return lasterr
+}

--- a/pkg/util/fileutil/atomic_writer_test.go
+++ b/pkg/util/fileutil/atomic_writer_test.go
@@ -1,0 +1,990 @@
+// +build linux
+
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Vendored from kubernetes/pkg/volume/util/atomic_writer_test.go
+//  * tag: v1.20.6,
+//  * commit: 8a62859e515889f07e3e3be6a1080413f17cf2c3
+//  * link: https://github.com/kubernetes/kubernetes/blob/8a62859e515889f07e3e3be6a1080413f17cf2c3/pkg/volume/util/atomic_writer_test.go
+
+package fileutil
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	utiltesting "k8s.io/client-go/util/testing"
+)
+
+func TestNewAtomicWriter(t *testing.T) {
+	targetDir, err := utiltesting.MkTmpdir("atomic-write")
+	if err != nil {
+		t.Fatalf("unexpected error creating tmp dir: %v", err)
+	}
+	defer os.RemoveAll(targetDir)
+
+	_, err = NewAtomicWriter(targetDir, "-test-")
+	if err != nil {
+		t.Fatalf("unexpected error creating writer for existing target dir: %v", err)
+	}
+
+	nonExistentDir, err := utiltesting.MkTmpdir("atomic-write")
+	if err != nil {
+		t.Fatalf("unexpected error creating tmp dir: %v", err)
+	}
+	err = os.Remove(nonExistentDir)
+	if err != nil {
+		t.Fatalf("unexpected error ensuring dir %v does not exist: %v", nonExistentDir, err)
+	}
+
+	_, err = NewAtomicWriter(nonExistentDir, "-test-")
+	if err == nil {
+		t.Fatalf("unexpected success creating writer for nonexistent target dir: %v", err)
+	}
+}
+
+func TestValidatePath(t *testing.T) {
+	maxPath := strings.Repeat("a", maxPathLength+1)
+	maxFile := strings.Repeat("a", maxFileNameLength+1)
+
+	cases := []struct {
+		name  string
+		path  string
+		valid bool
+	}{
+		{
+			name:  "valid 1",
+			path:  "i/am/well/behaved.txt",
+			valid: true,
+		},
+		{
+			name:  "valid 2",
+			path:  "keepyourheaddownandfollowtherules.txt",
+			valid: true,
+		},
+		{
+			name:  "max path length",
+			path:  maxPath,
+			valid: false,
+		},
+		{
+			name:  "max file length",
+			path:  maxFile,
+			valid: false,
+		},
+		{
+			name:  "absolute failure",
+			path:  "/dev/null",
+			valid: false,
+		},
+		{
+			name:  "reserved path",
+			path:  "..sneaky.txt",
+			valid: false,
+		},
+		{
+			name:  "contains doubledot 1",
+			path:  "hello/there/../../../../../../etc/passwd",
+			valid: false,
+		},
+		{
+			name:  "contains doubledot 2",
+			path:  "hello/../etc/somethingbad",
+			valid: false,
+		},
+		{
+			name:  "empty",
+			path:  "",
+			valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		err := validatePath(tc.path)
+		if tc.valid && err != nil {
+			t.Errorf("%v: unexpected failure: %v", tc.name, err)
+			continue
+		}
+
+		if !tc.valid && err == nil {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+	}
+}
+
+func TestPathsToRemove(t *testing.T) {
+	cases := []struct {
+		name     string
+		payload1 map[string]FileProjection
+		payload2 map[string]FileProjection
+		expected sets.String
+	}{
+		{
+			name: "simple",
+			payload1: map[string]FileProjection{
+				"foo.txt": {Mode: 0644, Data: []byte("foo")},
+				"bar.txt": {Mode: 0644, Data: []byte("bar")},
+			},
+			payload2: map[string]FileProjection{
+				"foo.txt": {Mode: 0644, Data: []byte("foo")},
+			},
+			expected: sets.NewString("bar.txt"),
+		},
+		{
+			name: "simple 2",
+			payload1: map[string]FileProjection{
+				"foo.txt":     {Mode: 0644, Data: []byte("foo")},
+				"zip/bar.txt": {Mode: 0644, Data: []byte("zip/b}ar")},
+			},
+			payload2: map[string]FileProjection{
+				"foo.txt": {Mode: 0644, Data: []byte("foo")},
+			},
+			expected: sets.NewString("zip/bar.txt", "zip"),
+		},
+		{
+			name: "subdirs 1",
+			payload1: map[string]FileProjection{
+				"foo.txt":         {Mode: 0644, Data: []byte("foo")},
+				"zip/zap/bar.txt": {Mode: 0644, Data: []byte("zip/bar")},
+			},
+			payload2: map[string]FileProjection{
+				"foo.txt": {Mode: 0644, Data: []byte("foo")},
+			},
+			expected: sets.NewString("zip/zap/bar.txt", "zip", "zip/zap"),
+		},
+		{
+			name: "subdirs 2",
+			payload1: map[string]FileProjection{
+				"foo.txt":             {Mode: 0644, Data: []byte("foo")},
+				"zip/1/2/3/4/bar.txt": {Mode: 0644, Data: []byte("zip/b}ar")},
+			},
+			payload2: map[string]FileProjection{
+				"foo.txt": {Mode: 0644, Data: []byte("foo")},
+			},
+			expected: sets.NewString("zip/1/2/3/4/bar.txt", "zip", "zip/1", "zip/1/2", "zip/1/2/3", "zip/1/2/3/4"),
+		},
+		{
+			name: "subdirs 3",
+			payload1: map[string]FileProjection{
+				"foo.txt":             {Mode: 0644, Data: []byte("foo")},
+				"zip/1/2/3/4/bar.txt": {Mode: 0644, Data: []byte("zip/b}ar")},
+				"zap/a/b/c/bar.txt":   {Mode: 0644, Data: []byte("zap/bar")},
+			},
+			payload2: map[string]FileProjection{
+				"foo.txt": {Mode: 0644, Data: []byte("foo")},
+			},
+			expected: sets.NewString("zip/1/2/3/4/bar.txt", "zip", "zip/1", "zip/1/2", "zip/1/2/3", "zip/1/2/3/4", "zap", "zap/a", "zap/a/b", "zap/a/b/c", "zap/a/b/c/bar.txt"),
+		},
+		{
+			name: "subdirs 4",
+			payload1: map[string]FileProjection{
+				"foo.txt":             {Mode: 0644, Data: []byte("foo")},
+				"zap/1/2/3/4/bar.txt": {Mode: 0644, Data: []byte("zip/bar")},
+				"zap/1/2/c/bar.txt":   {Mode: 0644, Data: []byte("zap/bar")},
+				"zap/1/2/magic.txt":   {Mode: 0644, Data: []byte("indigo")},
+			},
+			payload2: map[string]FileProjection{
+				"foo.txt":           {Mode: 0644, Data: []byte("foo")},
+				"zap/1/2/magic.txt": {Mode: 0644, Data: []byte("indigo")},
+			},
+			expected: sets.NewString("zap/1/2/3/4/bar.txt", "zap/1/2/3", "zap/1/2/3/4", "zap/1/2/3/4/bar.txt", "zap/1/2/c", "zap/1/2/c/bar.txt"),
+		},
+		{
+			name: "subdirs 5",
+			payload1: map[string]FileProjection{
+				"foo.txt":             {Mode: 0644, Data: []byte("foo")},
+				"zap/1/2/3/4/bar.txt": {Mode: 0644, Data: []byte("zip/bar")},
+				"zap/1/2/c/bar.txt":   {Mode: 0644, Data: []byte("zap/bar")},
+			},
+			payload2: map[string]FileProjection{
+				"foo.txt":           {Mode: 0644, Data: []byte("foo")},
+				"zap/1/2/magic.txt": {Mode: 0644, Data: []byte("indigo")},
+			},
+			expected: sets.NewString("zap/1/2/3/4/bar.txt", "zap/1/2/3", "zap/1/2/3/4", "zap/1/2/3/4/bar.txt", "zap/1/2/c", "zap/1/2/c/bar.txt"),
+		},
+	}
+
+	for _, tc := range cases {
+		targetDir, err := utiltesting.MkTmpdir("atomic-write")
+		if err != nil {
+			t.Errorf("%v: unexpected error creating tmp dir: %v", tc.name, err)
+			continue
+		}
+		defer os.RemoveAll(targetDir)
+
+		writer := &AtomicWriter{targetDir: targetDir, logContext: "-test-"}
+		err = writer.Write(tc.payload1)
+		if err != nil {
+			t.Errorf("%v: unexpected error writing: %v", tc.name, err)
+			continue
+		}
+
+		dataDirPath := filepath.Join(targetDir, dataDirName)
+		oldTsDir, err := os.Readlink(dataDirPath)
+		if err != nil && os.IsNotExist(err) {
+			t.Errorf("Data symlink does not exist: %v", dataDirPath)
+			continue
+		} else if err != nil {
+			t.Errorf("Unable to read symlink %v: %v", dataDirPath, err)
+			continue
+		}
+
+		actual, err := writer.pathsToRemove(tc.payload2, filepath.Join(targetDir, oldTsDir))
+		if err != nil {
+			t.Errorf("%v: unexpected error determining paths to remove: %v", tc.name, err)
+			continue
+		}
+
+		if e, a := tc.expected, actual; !e.Equal(a) {
+			t.Errorf("%v: unexpected paths to remove:\nexpected: %v\n     got: %v", tc.name, e, a)
+		}
+	}
+}
+
+func TestWriteOnce(t *testing.T) {
+	// $1 if you can tell me what this binary is
+	encodedMysteryBinary := `f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAAB
+AAAAAAAAAAEAAAAFAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAAfQAAAAAAAAB9AAAAAAAAAAAA
+IAAAAAAAsDyZDwU=`
+
+	mysteryBinaryBytes := make([]byte, base64.StdEncoding.DecodedLen(len(encodedMysteryBinary)))
+	numBytes, err := base64.StdEncoding.Decode(mysteryBinaryBytes, []byte(encodedMysteryBinary))
+	if err != nil {
+		t.Fatalf("Unexpected error decoding binary payload: %v", err)
+	}
+
+	if numBytes != 125 {
+		t.Fatalf("Unexpected decoded binary size: expected 125, got %v", numBytes)
+	}
+
+	cases := []struct {
+		name    string
+		payload map[string]FileProjection
+		success bool
+	}{
+		{
+			name: "invalid payload 1",
+			payload: map[string]FileProjection{
+				"foo":        {Mode: 0644, Data: []byte("foo")},
+				"..bar":      {Mode: 0644, Data: []byte("bar")},
+				"binary.bin": {Mode: 0644, Data: mysteryBinaryBytes},
+			},
+			success: false,
+		},
+		{
+			name: "invalid payload 2",
+			payload: map[string]FileProjection{
+				"foo/../bar": {Mode: 0644, Data: []byte("foo")},
+			},
+			success: false,
+		},
+		{
+			name: "basic 1",
+			payload: map[string]FileProjection{
+				"foo": {Mode: 0644, Data: []byte("foo")},
+				"bar": {Mode: 0644, Data: []byte("bar")},
+			},
+			success: true,
+		},
+		{
+			name: "basic 2",
+			payload: map[string]FileProjection{
+				"binary.bin":  {Mode: 0644, Data: mysteryBinaryBytes},
+				".binary.bin": {Mode: 0644, Data: mysteryBinaryBytes},
+			},
+			success: true,
+		},
+		{
+			name: "basic mode 1",
+			payload: map[string]FileProjection{
+				"foo": {Mode: 0777, Data: []byte("foo")},
+				"bar": {Mode: 0400, Data: []byte("bar")},
+			},
+			success: true,
+		},
+		{
+			name: "dotfiles",
+			payload: map[string]FileProjection{
+				"foo":           {Mode: 0644, Data: []byte("foo")},
+				"bar":           {Mode: 0644, Data: []byte("bar")},
+				".dotfile":      {Mode: 0644, Data: []byte("dotfile")},
+				".dotfile.file": {Mode: 0644, Data: []byte("dotfile.file")},
+			},
+			success: true,
+		},
+		{
+			name: "dotfiles mode",
+			payload: map[string]FileProjection{
+				"foo":           {Mode: 0407, Data: []byte("foo")},
+				"bar":           {Mode: 0440, Data: []byte("bar")},
+				".dotfile":      {Mode: 0777, Data: []byte("dotfile")},
+				".dotfile.file": {Mode: 0666, Data: []byte("dotfile.file")},
+			},
+			success: true,
+		},
+		{
+			name: "subdirectories 1",
+			payload: map[string]FileProjection{
+				"foo/bar.txt": {Mode: 0644, Data: []byte("foo/bar")},
+				"bar/zab.txt": {Mode: 0644, Data: []byte("bar/zab.txt")},
+			},
+			success: true,
+		},
+		{
+			name: "subdirectories mode 1",
+			payload: map[string]FileProjection{
+				"foo/bar.txt": {Mode: 0400, Data: []byte("foo/bar")},
+				"bar/zab.txt": {Mode: 0644, Data: []byte("bar/zab.txt")},
+			},
+			success: true,
+		},
+		{
+			name: "subdirectories 2",
+			payload: map[string]FileProjection{
+				"foo//bar.txt":      {Mode: 0644, Data: []byte("foo//bar")},
+				"bar///bar/zab.txt": {Mode: 0644, Data: []byte("bar/../bar/zab.txt")},
+			},
+			success: true,
+		},
+		{
+			name: "subdirectories 3",
+			payload: map[string]FileProjection{
+				"foo/bar.txt":      {Mode: 0644, Data: []byte("foo/bar")},
+				"bar/zab.txt":      {Mode: 0644, Data: []byte("bar/zab.txt")},
+				"foo/blaz/bar.txt": {Mode: 0644, Data: []byte("foo/blaz/bar")},
+				"bar/zib/zab.txt":  {Mode: 0644, Data: []byte("bar/zib/zab.txt")},
+			},
+			success: true,
+		},
+		{
+			name: "kitchen sink",
+			payload: map[string]FileProjection{
+				"foo.log":                           {Mode: 0644, Data: []byte("foo")},
+				"bar.zap":                           {Mode: 0644, Data: []byte("bar")},
+				".dotfile":                          {Mode: 0644, Data: []byte("dotfile")},
+				"foo/bar.txt":                       {Mode: 0644, Data: []byte("foo/bar")},
+				"bar/zab.txt":                       {Mode: 0644, Data: []byte("bar/zab.txt")},
+				"foo/blaz/bar.txt":                  {Mode: 0644, Data: []byte("foo/blaz/bar")},
+				"bar/zib/zab.txt":                   {Mode: 0400, Data: []byte("bar/zib/zab.txt")},
+				"1/2/3/4/5/6/7/8/9/10/.dotfile.lib": {Mode: 0777, Data: []byte("1-2-3-dotfile")},
+			},
+			success: true,
+		},
+	}
+
+	for _, tc := range cases {
+		targetDir, err := utiltesting.MkTmpdir("atomic-write")
+		if err != nil {
+			t.Errorf("%v: unexpected error creating tmp dir: %v", tc.name, err)
+			continue
+		}
+		defer os.RemoveAll(targetDir)
+
+		writer := &AtomicWriter{targetDir: targetDir, logContext: "-test-"}
+		err = writer.Write(tc.payload)
+		if err != nil && tc.success {
+			t.Errorf("%v: unexpected error writing payload: %v", tc.name, err)
+			continue
+		} else if err == nil && !tc.success {
+			t.Errorf("%v: unexpected success", tc.name)
+			continue
+		} else if err != nil {
+			continue
+		}
+
+		checkVolumeContents(targetDir, tc.name, tc.payload, t)
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	cases := []struct {
+		name        string
+		first       map[string]FileProjection
+		next        map[string]FileProjection
+		shouldWrite bool
+	}{
+		{
+			name: "update",
+			first: map[string]FileProjection{
+				"foo": {Mode: 0644, Data: []byte("foo")},
+				"bar": {Mode: 0644, Data: []byte("bar")},
+			},
+			next: map[string]FileProjection{
+				"foo": {Mode: 0644, Data: []byte("foo2")},
+				"bar": {Mode: 0640, Data: []byte("bar2")},
+			},
+			shouldWrite: true,
+		},
+		{
+			name: "no update",
+			first: map[string]FileProjection{
+				"foo": {Mode: 0644, Data: []byte("foo")},
+				"bar": {Mode: 0644, Data: []byte("bar")},
+			},
+			next: map[string]FileProjection{
+				"foo": {Mode: 0644, Data: []byte("foo")},
+				"bar": {Mode: 0644, Data: []byte("bar")},
+			},
+			shouldWrite: false,
+		},
+		{
+			name: "no update 2",
+			first: map[string]FileProjection{
+				"foo/bar.txt": {Mode: 0644, Data: []byte("foo")},
+				"bar/zab.txt": {Mode: 0644, Data: []byte("bar")},
+			},
+			next: map[string]FileProjection{
+				"foo/bar.txt": {Mode: 0644, Data: []byte("foo")},
+				"bar/zab.txt": {Mode: 0644, Data: []byte("bar")},
+			},
+			shouldWrite: false,
+		},
+		{
+			name: "add 1",
+			first: map[string]FileProjection{
+				"foo/bar.txt": {Mode: 0644, Data: []byte("foo")},
+				"bar/zab.txt": {Mode: 0644, Data: []byte("bar")},
+			},
+			next: map[string]FileProjection{
+				"foo/bar.txt": {Mode: 0644, Data: []byte("foo")},
+				"bar/zab.txt": {Mode: 0644, Data: []byte("bar")},
+				"blu/zip.txt": {Mode: 0644, Data: []byte("zip")},
+			},
+			shouldWrite: true,
+		},
+		{
+			name: "add 2",
+			first: map[string]FileProjection{
+				"foo/bar.txt": {Mode: 0644, Data: []byte("foo")},
+				"bar/zab.txt": {Mode: 0644, Data: []byte("bar")},
+			},
+			next: map[string]FileProjection{
+				"foo/bar.txt":             {Mode: 0644, Data: []byte("foo")},
+				"bar/zab.txt":             {Mode: 0644, Data: []byte("bar")},
+				"blu/two/2/3/4/5/zip.txt": {Mode: 0644, Data: []byte("zip")},
+			},
+			shouldWrite: true,
+		},
+		{
+			name: "add 3",
+			first: map[string]FileProjection{
+				"foo/bar.txt": {Mode: 0644, Data: []byte("foo")},
+				"bar/zab.txt": {Mode: 0644, Data: []byte("bar")},
+			},
+			next: map[string]FileProjection{
+				"foo/bar.txt":         {Mode: 0644, Data: []byte("foo")},
+				"bar/zab.txt":         {Mode: 0644, Data: []byte("bar")},
+				"bar/2/3/4/5/zip.txt": {Mode: 0644, Data: []byte("zip")},
+			},
+			shouldWrite: true,
+		},
+		{
+			name: "delete 1",
+			first: map[string]FileProjection{
+				"foo/bar.txt": {Mode: 0644, Data: []byte("foo")},
+				"bar/zab.txt": {Mode: 0644, Data: []byte("bar")},
+			},
+			next: map[string]FileProjection{
+				"foo/bar.txt": {Mode: 0644, Data: []byte("foo")},
+			},
+			shouldWrite: true,
+		},
+		{
+			name: "delete 2",
+			first: map[string]FileProjection{
+				"foo/bar.txt":       {Mode: 0644, Data: []byte("foo")},
+				"bar/1/2/3/zab.txt": {Mode: 0644, Data: []byte("bar")},
+			},
+			next: map[string]FileProjection{
+				"foo/bar.txt": {Mode: 0644, Data: []byte("foo")},
+			},
+			shouldWrite: true,
+		},
+		{
+			name: "delete 3",
+			first: map[string]FileProjection{
+				"foo/bar.txt":       {Mode: 0644, Data: []byte("foo")},
+				"bar/1/2/sip.txt":   {Mode: 0644, Data: []byte("sip")},
+				"bar/1/2/3/zab.txt": {Mode: 0644, Data: []byte("bar")},
+			},
+			next: map[string]FileProjection{
+				"foo/bar.txt":     {Mode: 0644, Data: []byte("foo")},
+				"bar/1/2/sip.txt": {Mode: 0644, Data: []byte("sip")},
+			},
+			shouldWrite: true,
+		},
+		{
+			name: "delete 4",
+			first: map[string]FileProjection{
+				"foo/bar.txt":            {Mode: 0644, Data: []byte("foo")},
+				"bar/1/2/sip.txt":        {Mode: 0644, Data: []byte("sip")},
+				"bar/1/2/3/4/5/6zab.txt": {Mode: 0644, Data: []byte("bar")},
+			},
+			next: map[string]FileProjection{
+				"foo/bar.txt":     {Mode: 0644, Data: []byte("foo")},
+				"bar/1/2/sip.txt": {Mode: 0644, Data: []byte("sip")},
+			},
+			shouldWrite: true,
+		},
+		{
+			name: "delete all",
+			first: map[string]FileProjection{
+				"foo/bar.txt":            {Mode: 0644, Data: []byte("foo")},
+				"bar/1/2/sip.txt":        {Mode: 0644, Data: []byte("sip")},
+				"bar/1/2/3/4/5/6zab.txt": {Mode: 0644, Data: []byte("bar")},
+			},
+			next:        map[string]FileProjection{},
+			shouldWrite: true,
+		},
+		{
+			name: "add and delete 1",
+			first: map[string]FileProjection{
+				"foo/bar.txt": {Mode: 0644, Data: []byte("foo")},
+			},
+			next: map[string]FileProjection{
+				"bar/baz.txt": {Mode: 0644, Data: []byte("baz")},
+			},
+			shouldWrite: true,
+		},
+	}
+
+	for _, tc := range cases {
+		targetDir, err := utiltesting.MkTmpdir("atomic-write")
+		if err != nil {
+			t.Errorf("%v: unexpected error creating tmp dir: %v", tc.name, err)
+			continue
+		}
+		defer os.RemoveAll(targetDir)
+
+		writer := &AtomicWriter{targetDir: targetDir, logContext: "-test-"}
+
+		err = writer.Write(tc.first)
+		if err != nil {
+			t.Errorf("%v: unexpected error writing: %v", tc.name, err)
+			continue
+		}
+
+		checkVolumeContents(targetDir, tc.name, tc.first, t)
+		if !tc.shouldWrite {
+			continue
+		}
+
+		err = writer.Write(tc.next)
+		if err != nil {
+			if tc.shouldWrite {
+				t.Errorf("%v: unexpected error writing: %v", tc.name, err)
+				continue
+			}
+		} else if !tc.shouldWrite {
+			t.Errorf("%v: unexpected success", tc.name)
+			continue
+		}
+
+		checkVolumeContents(targetDir, tc.name, tc.next, t)
+	}
+}
+
+func TestMultipleUpdates(t *testing.T) {
+	cases := []struct {
+		name     string
+		payloads []map[string]FileProjection
+	}{
+		{
+			name: "update 1",
+			payloads: []map[string]FileProjection{
+				{
+					"foo": {Mode: 0644, Data: []byte("foo")},
+					"bar": {Mode: 0644, Data: []byte("bar")},
+				},
+				{
+					"foo": {Mode: 0400, Data: []byte("foo2")},
+					"bar": {Mode: 0400, Data: []byte("bar2")},
+				},
+				{
+					"foo": {Mode: 0600, Data: []byte("foo3")},
+					"bar": {Mode: 0600, Data: []byte("bar3")},
+				},
+			},
+		},
+		{
+			name: "update 2",
+			payloads: []map[string]FileProjection{
+				{
+					"foo/bar.txt": {Mode: 0644, Data: []byte("foo/bar")},
+					"bar/zab.txt": {Mode: 0644, Data: []byte("bar/zab.txt")},
+				},
+				{
+					"foo/bar.txt": {Mode: 0644, Data: []byte("foo/bar2")},
+					"bar/zab.txt": {Mode: 0400, Data: []byte("bar/zab.txt2")},
+				},
+			},
+		},
+		{
+			name: "clear sentinel",
+			payloads: []map[string]FileProjection{
+				{
+					"foo": {Mode: 0644, Data: []byte("foo")},
+					"bar": {Mode: 0644, Data: []byte("bar")},
+				},
+				{
+					"foo": {Mode: 0644, Data: []byte("foo2")},
+					"bar": {Mode: 0644, Data: []byte("bar2")},
+				},
+				{
+					"foo": {Mode: 0644, Data: []byte("foo3")},
+					"bar": {Mode: 0644, Data: []byte("bar3")},
+				},
+				{
+					"foo": {Mode: 0644, Data: []byte("foo4")},
+					"bar": {Mode: 0644, Data: []byte("bar4")},
+				},
+			},
+		},
+		{
+			name: "subdirectories 2",
+			payloads: []map[string]FileProjection{
+				{
+					"foo/bar.txt":      {Mode: 0644, Data: []byte("foo/bar")},
+					"bar/zab.txt":      {Mode: 0644, Data: []byte("bar/zab.txt")},
+					"foo/blaz/bar.txt": {Mode: 0644, Data: []byte("foo/blaz/bar")},
+					"bar/zib/zab.txt":  {Mode: 0644, Data: []byte("bar/zib/zab.txt")},
+				},
+				{
+					"foo/bar.txt":      {Mode: 0644, Data: []byte("foo/bar2")},
+					"bar/zab.txt":      {Mode: 0644, Data: []byte("bar/zab.txt2")},
+					"foo/blaz/bar.txt": {Mode: 0644, Data: []byte("foo/blaz/bar2")},
+					"bar/zib/zab.txt":  {Mode: 0644, Data: []byte("bar/zib/zab.txt2")},
+				},
+			},
+		},
+		{
+			name: "add 1",
+			payloads: []map[string]FileProjection{
+				{
+					"foo/bar.txt":            {Mode: 0644, Data: []byte("foo/bar")},
+					"bar//zab.txt":           {Mode: 0644, Data: []byte("bar/zab.txt")},
+					"foo/blaz/bar.txt":       {Mode: 0644, Data: []byte("foo/blaz/bar")},
+					"bar/zib////zib/zab.txt": {Mode: 0644, Data: []byte("bar/zib/zab.txt")},
+				},
+				{
+					"foo/bar.txt":      {Mode: 0644, Data: []byte("foo/bar2")},
+					"bar/zab.txt":      {Mode: 0644, Data: []byte("bar/zab.txt2")},
+					"foo/blaz/bar.txt": {Mode: 0644, Data: []byte("foo/blaz/bar2")},
+					"bar/zib/zab.txt":  {Mode: 0644, Data: []byte("bar/zib/zab.txt2")},
+					"add/new/keys.txt": {Mode: 0644, Data: []byte("addNewKeys")},
+				},
+			},
+		},
+		{
+			name: "add 2",
+			payloads: []map[string]FileProjection{
+				{
+					"foo/bar.txt":      {Mode: 0644, Data: []byte("foo/bar2")},
+					"bar/zab.txt":      {Mode: 0644, Data: []byte("bar/zab.txt2")},
+					"foo/blaz/bar.txt": {Mode: 0644, Data: []byte("foo/blaz/bar2")},
+					"bar/zib/zab.txt":  {Mode: 0644, Data: []byte("bar/zib/zab.txt2")},
+					"add/new/keys.txt": {Mode: 0644, Data: []byte("addNewKeys")},
+				},
+				{
+					"foo/bar.txt":       {Mode: 0644, Data: []byte("foo/bar2")},
+					"bar/zab.txt":       {Mode: 0644, Data: []byte("bar/zab.txt2")},
+					"foo/blaz/bar.txt":  {Mode: 0644, Data: []byte("foo/blaz/bar2")},
+					"bar/zib/zab.txt":   {Mode: 0644, Data: []byte("bar/zib/zab.txt2")},
+					"add/new/keys.txt":  {Mode: 0644, Data: []byte("addNewKeys")},
+					"add/new/keys2.txt": {Mode: 0644, Data: []byte("addNewKeys2")},
+					"add/new/keys3.txt": {Mode: 0644, Data: []byte("addNewKeys3")},
+				},
+			},
+		},
+		{
+			name: "remove 1",
+			payloads: []map[string]FileProjection{
+				{
+					"foo/bar.txt":         {Mode: 0644, Data: []byte("foo/bar")},
+					"bar//zab.txt":        {Mode: 0644, Data: []byte("bar/zab.txt")},
+					"foo/blaz/bar.txt":    {Mode: 0644, Data: []byte("foo/blaz/bar")},
+					"zip/zap/zup/fop.txt": {Mode: 0644, Data: []byte("zip/zap/zup/fop.txt")},
+				},
+				{
+					"foo/bar.txt": {Mode: 0644, Data: []byte("foo/bar2")},
+					"bar/zab.txt": {Mode: 0644, Data: []byte("bar/zab.txt2")},
+				},
+				{
+					"foo/bar.txt": {Mode: 0644, Data: []byte("foo/bar")},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		targetDir, err := utiltesting.MkTmpdir("atomic-write")
+		if err != nil {
+			t.Errorf("%v: unexpected error creating tmp dir: %v", tc.name, err)
+			continue
+		}
+		defer os.RemoveAll(targetDir)
+
+		writer := &AtomicWriter{targetDir: targetDir, logContext: "-test-"}
+
+		for _, payload := range tc.payloads {
+			writer.Write(payload)
+
+			checkVolumeContents(targetDir, tc.name, payload, t)
+		}
+	}
+}
+
+func checkVolumeContents(targetDir, tcName string, payload map[string]FileProjection, t *testing.T) {
+	dataDirPath := filepath.Join(targetDir, dataDirName)
+	// use filepath.Walk to reconstruct the payload, then deep equal
+	observedPayload := make(map[string]FileProjection)
+	visitor := func(path string, info os.FileInfo, _ error) error {
+		if info.IsDir() {
+			return nil
+		}
+
+		relativePath := strings.TrimPrefix(path, dataDirPath)
+		relativePath = strings.TrimPrefix(relativePath, "/")
+		if strings.HasPrefix(relativePath, "..") {
+			return nil
+		}
+
+		content, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		fileInfo, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		mode := int32(fileInfo.Mode())
+
+		observedPayload[relativePath] = FileProjection{Data: content, Mode: mode}
+
+		return nil
+	}
+
+	d, err := ioutil.ReadDir(targetDir)
+	if err != nil {
+		t.Errorf("Unable to read dir %v: %v", targetDir, err)
+		return
+	}
+	for _, info := range d {
+		if strings.HasPrefix(info.Name(), "..") {
+			continue
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			p := filepath.Join(targetDir, info.Name())
+			actual, err := os.Readlink(p)
+			if err != nil {
+				t.Errorf("Unable to read symlink %v: %v", p, err)
+				continue
+			}
+			if err := filepath.Walk(filepath.Join(targetDir, actual), visitor); err != nil {
+				t.Errorf("%v: unexpected error walking directory: %v", tcName, err)
+			}
+		}
+	}
+
+	cleanPathPayload := make(map[string]FileProjection, len(payload))
+	for k, v := range payload {
+		cleanPathPayload[filepath.Clean(k)] = v
+	}
+
+	if !reflect.DeepEqual(cleanPathPayload, observedPayload) {
+		t.Errorf("%v: payload and observed payload do not match.", tcName)
+	}
+}
+
+func TestValidatePayload(t *testing.T) {
+	maxPath := strings.Repeat("a", maxPathLength+1)
+
+	cases := []struct {
+		name     string
+		payload  map[string]FileProjection
+		expected sets.String
+		valid    bool
+	}{
+		{
+			name: "valid payload",
+			payload: map[string]FileProjection{
+				"foo": {},
+				"bar": {},
+			},
+			valid:    true,
+			expected: sets.NewString("foo", "bar"),
+		},
+		{
+			name: "payload with path length > 4096 is invalid",
+			payload: map[string]FileProjection{
+				maxPath: {},
+			},
+			valid: false,
+		},
+		{
+			name: "payload with absolute path is invalid",
+			payload: map[string]FileProjection{
+				"/dev/null": {},
+			},
+			valid: false,
+		},
+		{
+			name: "payload with reserved path is invalid",
+			payload: map[string]FileProjection{
+				"..sneaky.txt": {},
+			},
+			valid: false,
+		},
+		{
+			name: "payload with doubledot path is invalid",
+			payload: map[string]FileProjection{
+				"foo/../etc/password": {},
+			},
+			valid: false,
+		},
+		{
+			name: "payload with empty path is invalid",
+			payload: map[string]FileProjection{
+				"": {},
+			},
+			valid: false,
+		},
+		{
+			name: "payload with unclean path should be cleaned",
+			payload: map[string]FileProjection{
+				"foo////bar": {},
+			},
+			valid:    true,
+			expected: sets.NewString("foo/bar"),
+		},
+	}
+	getPayloadPaths := func(payload map[string]FileProjection) sets.String {
+		paths := sets.NewString()
+		for path := range payload {
+			paths.Insert(path)
+		}
+		return paths
+	}
+
+	for _, tc := range cases {
+		real, err := validatePayload(tc.payload)
+		if !tc.valid && err == nil {
+			t.Errorf("%v: unexpected success", tc.name)
+		}
+
+		if tc.valid {
+			if err != nil {
+				t.Errorf("%v: unexpected failure: %v", tc.name, err)
+				continue
+			}
+
+			realPaths := getPayloadPaths(real)
+			if !realPaths.Equal(tc.expected) {
+				t.Errorf("%v: unexpected payload paths: %v is not equal to %v", tc.name, realPaths, tc.expected)
+			}
+		}
+
+	}
+}
+
+func TestCreateUserVisibleFiles(t *testing.T) {
+	cases := []struct {
+		name     string
+		payload  map[string]FileProjection
+		expected map[string]string
+	}{
+		{
+			name: "simple path",
+			payload: map[string]FileProjection{
+				"foo": {},
+				"bar": {},
+			},
+			expected: map[string]string{
+				"foo": "..data/foo",
+				"bar": "..data/bar",
+			},
+		},
+		{
+			name: "simple nested path",
+			payload: map[string]FileProjection{
+				"foo/bar":     {},
+				"foo/bar/txt": {},
+				"bar/txt":     {},
+			},
+			expected: map[string]string{
+				"foo": "..data/foo",
+				"bar": "..data/bar",
+			},
+		},
+		{
+			name: "unclean nested path",
+			payload: map[string]FileProjection{
+				"./bar":     {},
+				"foo///bar": {},
+			},
+			expected: map[string]string{
+				"bar": "..data/bar",
+				"foo": "..data/foo",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		targetDir, err := utiltesting.MkTmpdir("atomic-write")
+		if err != nil {
+			t.Errorf("%v: unexpected error creating tmp dir: %v", tc.name, err)
+			continue
+		}
+		defer os.RemoveAll(targetDir)
+
+		dataDirPath := filepath.Join(targetDir, dataDirName)
+		err = os.MkdirAll(dataDirPath, 0755)
+		if err != nil {
+			t.Fatalf("%v: unexpected error creating data path: %v", tc.name, err)
+		}
+
+		writer := &AtomicWriter{targetDir: targetDir, logContext: "-test-"}
+		payload, err := validatePayload(tc.payload)
+		if err != nil {
+			t.Fatalf("%v: unexpected error validating payload: %v", tc.name, err)
+		}
+		err = writer.createUserVisibleFiles(payload)
+		if err != nil {
+			t.Fatalf("%v: unexpected error creating visible files: %v", tc.name, err)
+		}
+
+		for subpath, expectedDest := range tc.expected {
+			visiblePath := filepath.Join(targetDir, subpath)
+			destination, err := os.Readlink(visiblePath)
+			if err != nil && os.IsNotExist(err) {
+				t.Fatalf("%v: visible symlink does not exist: %v", tc.name, visiblePath)
+			} else if err != nil {
+				t.Fatalf("%v: unable to read symlink %v: %v", tc.name, dataDirPath, err)
+			}
+
+			if expectedDest != destination {
+				t.Fatalf("%v: symlink destination %q not same with expected data dir %q", tc.name, destination, expectedDest)
+			}
+		}
+	}
+}

--- a/pkg/util/fileutil/filesystem.go
+++ b/pkg/util/fileutil/filesystem.go
@@ -18,7 +18,6 @@ limitations under the License.
 package fileutil
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -29,37 +28,101 @@ var (
 	targetPathRe = regexp.MustCompile(`[\\|\/]+pods[\\|\/]+(.+?)[\\|\/]+volumes[\\|\/]+kubernetes.io~csi[\\|\/]+(.+?)[\\|\/]+mount$`)
 )
 
-// GetMountedFiles returns all the mounted files names with filepath base as key
+// GetMountedFiles returns all the mounted files mapping their path relative to
+// targetPath to the absolute paths.
+//
+// This will filter out files by atomic_writer (which reserves file prefixed
+// `..` and follows the symlinks created by atomic_writer).
 func GetMountedFiles(targetPath string) (map[string]string, error) {
 	paths := make(map[string]string)
-	// loop thru all the mounted files
-	var files []string
-	err := filepath.Walk(targetPath, func(path string, fi os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if fi.IsDir() {
-			return nil
-		}
-		relpath, err := filepath.Rel(targetPath, path)
-		if err != nil {
-			return err
-		}
-		files = append(files, relpath)
-		return nil
-	})
+
+	// atomic writer will write data to, but filepath.Walk does not follow
+	// symlinks
+	d, err := os.ReadDir(targetPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list all files in target path %s, err: %v", targetPath, err)
+		return paths, err
 	}
 
-	sep := "/"
-	if strings.HasPrefix(targetPath, "c:\\") {
-		sep = "\\"
-	} else if strings.HasPrefix(targetPath, `c:\`) {
-		sep = `\`
-	}
-	for _, file := range files {
-		paths[file] = targetPath + sep + file
+	// for each item in the targetPath, walk that item
+	for _, entry := range d {
+		// skip the reserved paths of targetPath/..*
+		if strings.HasPrefix(entry.Name(), "..") {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+
+		// the path to the file relative to targetPath
+		// i.e. foo
+		base := info.Name()
+
+		// the path before following the symlink
+		// i.e. targetPath/foo
+		p := filepath.Join(targetPath, info.Name())
+
+		// for symlinks in the targetPath...
+		if info.Mode()&os.ModeSymlink != 0 {
+			// the resolved relative path
+			// i.e. ..data/foo
+			actual, err := os.Readlink(p)
+			if err != nil {
+				continue
+			}
+
+			// the root path to walk
+			// i.e. targetPath/..data/foo
+			root := filepath.Join(targetPath, actual)
+
+			if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+				// if there was an error walking path immediately propagate it
+				if err != nil {
+					return err
+				}
+
+				// do not include directories in result
+				if info.IsDir() {
+					return nil
+				}
+
+				// We want the relative path before following the symbolic link.
+				// Compute the relative path within the symlink'd directory.
+				rel, err := filepath.Rel(root, path)
+				if err != nil {
+					return err
+				}
+				paths[filepath.Join(base, rel)] = path
+
+				return nil
+			}); err != nil {
+				return paths, err
+			}
+		} else {
+			if err := filepath.Walk(p, func(path string, info os.FileInfo, err error) error {
+				// if there was an error walking path immediately propagate it
+				if err != nil {
+					return err
+				}
+
+				// do not include directories in result
+				if info.IsDir() {
+					return nil
+				}
+
+				// determine relative path
+				rel, err := filepath.Rel(targetPath, path)
+				if err != nil {
+					return err
+				}
+				paths[rel] = path
+
+				return nil
+			}); err != nil {
+				return paths, err
+			}
+		}
 	}
 	return paths, nil
 }

--- a/pkg/util/fileutil/writer_test.go
+++ b/pkg/util/fileutil/writer_test.go
@@ -14,11 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Forked from kubernetes/pkg/volume/util/atomic_writer_test.go
-//  * tag: v1.20.5,
-//  * commit: 6b1d87acf3c8253c123756b9e61dac642678305f
-//  * link: https://github.com/kubernetes/kubernetes/blob/6b1d87acf3c8253c123756b9e61dac642678305f/pkg/volume/util/atomic_writer_test.go
-
 package fileutil
 
 import (
@@ -34,85 +29,6 @@ import (
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/test_utils/tmpdir"
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
 )
-
-func TestValidatePath_Success(t *testing.T) {
-	cases := []struct {
-		name string
-		path string
-	}{
-		{
-			name: "valid 1",
-			path: "i/am/well/behaved.txt",
-		},
-		{
-			name: "valid 2",
-			path: "keepyourheaddownandfollowtherules.txt",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if err := validatePath(tc.path); err != nil {
-				t.Errorf("unexpected failure: %v", err)
-			}
-		})
-	}
-}
-
-func TestValidatePath_Error(t *testing.T) {
-	maxPath := strings.Repeat("a", maxPathLength+1)
-	maxFile := strings.Repeat("a", maxFileNameLength+1)
-
-	cases := []struct {
-		name string
-		path string
-	}{
-		{
-			name: "max path length",
-			path: maxPath,
-		},
-		{
-			name: "max file length",
-			path: maxFile,
-		},
-		{
-			name: "absolute failure",
-			path: "/dev/null",
-		},
-		{
-			name: "reserved path",
-			path: "..sneaky.txt",
-		},
-		{
-			name: "contains doubledot 1",
-			path: "hello/there/../../../../../../etc/passwd",
-		},
-		{
-			name: "contains doubledot 2",
-			path: "hello/../etc/somethingbad",
-		},
-		{
-			name: "empty",
-			path: "",
-		},
-		{
-			name: "parent",
-			path: "..",
-		},
-		{
-			name: "sibling",
-			path: "../sibling",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if validatePath(tc.path) == nil {
-				t.Error("unexpected success")
-			}
-		})
-	}
-}
 
 func TestValidate_Success(t *testing.T) {
 	cases := []struct {
@@ -226,71 +142,115 @@ func TestValidate_Error(t *testing.T) {
 func TestWritePayloads(t *testing.T) {
 	cases := []struct {
 		name    string
-		payload []*v1alpha1.File
+		first   []*v1alpha1.File
+		second  []*v1alpha1.File
+		removed []string
 	}{
 		{
 			name: "simple payload",
-			payload: []*v1alpha1.File{
+			first: []*v1alpha1.File{
 				{
 					Path:     "foo",
 					Mode:     0644,
-					Contents: []byte("foo"),
+					Contents: []byte("first"),
+				},
+			},
+			second: []*v1alpha1.File{
+				{
+					Path:     "foo",
+					Mode:     0644,
+					Contents: []byte("second"),
 				},
 			},
 		},
 		{
 			name: "simple payload - mode",
-			payload: []*v1alpha1.File{
+			first: []*v1alpha1.File{
 				{
 					Path:     "foo",
 					Mode:     0440,
-					Contents: []byte("foo"),
+					Contents: []byte("first"),
+				},
+			},
+			second: []*v1alpha1.File{
+				{
+					Path:     "foo",
+					Mode:     0644,
+					Contents: []byte("second"),
 				},
 			},
 		},
 		{
 			name: "simple payload - mode2",
-			payload: []*v1alpha1.File{
+			first: []*v1alpha1.File{
 				{
 					Path:     "foo",
 					Mode:     0777,
-					Contents: []byte("foo"),
+					Contents: []byte("first"),
+				},
+			},
+			second: []*v1alpha1.File{
+				{
+					Path:     "foo",
+					Mode:     0777,
+					Contents: []byte("second"),
 				},
 			},
 		},
 		{
 			name: "simple payload - mode3",
-			payload: []*v1alpha1.File{
+			first: []*v1alpha1.File{
 				{
 					Path:     "foo",
 					Mode:     0666,
-					Contents: []byte("foo"),
+					Contents: []byte("first"),
+				},
+			},
+			second: []*v1alpha1.File{
+				{
+					Path:     "foo",
+					Mode:     0666,
+					Contents: []byte("second"),
 				},
 			},
 		},
 		{
 			name: "nested path payload",
-			payload: []*v1alpha1.File{
+			first: []*v1alpha1.File{
 				{
 					Path:     "foo/bar",
 					Mode:     0644,
-					Contents: []byte("foo"),
+					Contents: []byte("first"),
+				},
+			},
+			second: []*v1alpha1.File{
+				{
+					Path:     "foo/bar",
+					Mode:     0644,
+					Contents: []byte("second"),
 				},
 			},
 		},
 		{
 			name: "multiple nested paths",
-			payload: []*v1alpha1.File{
+			first: []*v1alpha1.File{
 				{
 					Path:     "foo/bar/baz",
 					Mode:     0644,
-					Contents: []byte("foo"),
+					Contents: []byte("first"),
+				},
+			},
+			second: []*v1alpha1.File{
+				{
+					Path:     "foo/bar/baz",
+					Mode:     0644,
+					Contents: []byte("second"),
 				},
 			},
 		},
 		{
 			name: "multiple nested paths and files",
-			payload: []*v1alpha1.File{
+			first: []*v1alpha1.File{
 				{
 					Path:     "foo/bar/baz",
 					Mode:     0644,
@@ -312,6 +272,82 @@ func TestWritePayloads(t *testing.T) {
 					Contents: []byte("root"),
 				},
 			},
+			second: []*v1alpha1.File{
+				{
+					Path:     "foo/bar/baz",
+					Mode:     0644,
+					Contents: []byte("second - foo"),
+				},
+				{
+					Path:     "foo/bar/2.txt",
+					Mode:     0644,
+					Contents: []byte("second - two"),
+				},
+				{
+					Path:     "foo/1.txt",
+					Mode:     0644,
+					Contents: []byte("second - one"),
+				},
+				{
+					Path:     "root.txt",
+					Mode:     0644,
+					Contents: []byte("second - root"),
+				},
+			},
+		},
+		{
+			name: "removed path - simple",
+			first: []*v1alpha1.File{
+				{
+					Path:     "foo.txt",
+					Mode:     0644,
+					Contents: []byte("root"),
+				},
+			},
+			second: []*v1alpha1.File{
+				{
+					Path:     "bar.txt",
+					Mode:     0644,
+					Contents: []byte("root"),
+				},
+			},
+			removed: []string{"foo.txt"},
+		},
+		{
+			name: "removed path - nested",
+			first: []*v1alpha1.File{
+				{
+					Path:     "a/foo.txt",
+					Mode:     0644,
+					Contents: []byte("root"),
+				},
+			},
+			second: []*v1alpha1.File{
+				{
+					Path:     "a/bar.txt",
+					Mode:     0644,
+					Contents: []byte("root"),
+				},
+			},
+			removed: []string{"a/foo.txt"},
+		},
+		{
+			name: "removed path - double nesting",
+			first: []*v1alpha1.File{
+				{
+					Path:     "a/b/foo.txt",
+					Mode:     0644,
+					Contents: []byte("root"),
+				},
+			},
+			second: []*v1alpha1.File{
+				{
+					Path:     "a/c/bar.txt",
+					Mode:     0644,
+					Contents: []byte("root"),
+				},
+			},
+			removed: []string{"a/b/foo.txt"},
 		},
 	}
 
@@ -319,14 +355,67 @@ func TestWritePayloads(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := tmpdir.New(t, "", "ut")
 
-			if err := WritePayloads(dir, tc.payload); err != nil {
-				t.Errorf("WritePayload() got error: %v", err)
+			// check that the first write succeeds and the contents match
+			if err := WritePayloads(dir, tc.first); err != nil {
+				t.Errorf("WritePayload(first) got error: %v", err)
 			}
 
-			if err := readPayloads(dir, tc.payload); err != nil {
-				t.Errorf("WritePayload() could not be read: %v", err)
+			if err := readPayloads(dir, tc.first); err != nil {
+				t.Errorf("WritePayload(first) could not be read: %v", err)
+			}
+
+			// check that the second write succeeds and the contents match,
+			// ensuring that the files have the updated values
+			if err := WritePayloads(dir, tc.second); err != nil {
+				t.Errorf("WritePayload(second) got error: %v", err)
+			}
+
+			if err := readPayloads(dir, tc.second); err != nil {
+				t.Errorf("WritePayload(second) could not be read: %v", err)
+			}
+
+			// check that files that should be removed by the second write are
+			// gone
+			for i := range tc.removed {
+				if _, err := os.Lstat(filepath.Join(dir, tc.removed[i])); os.IsNotExist(err) {
+					continue
+				}
+				t.Errorf("WritePayload() did not remove file: %s", tc.removed[i])
 			}
 		})
+	}
+}
+
+func TestWritePayloads_BackwardCompatible(t *testing.T) {
+	dir := tmpdir.New(t, "", "ut")
+
+	// write a file simulating the provider-style file writing
+	path := filepath.Join(dir, "foo.txt")
+	if err := os.WriteFile(path, []byte("old"), 0777); err != nil {
+		t.Fatalf("could not write old file: %s", err)
+	}
+
+	payload := []*v1alpha1.File{
+		{
+			Path:     "foo.txt",
+			Mode:     0777,
+			Contents: []byte("new"),
+		},
+	}
+
+	want := []byte("new")
+
+	if err := WritePayloads(dir, payload); err != nil {
+		t.Fatalf("could not write new file: %s", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("could not read payload: %s", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Errorf("WritePayload() did not update the file contents. got: %s, want: %s", got, want)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When files are returned in the grpc response, the driver will use the `atomic_writer.go` code to write the files into the mount. This is the same file writer used for `ConfigMap` and `Secret` objects currently.

#481 only really included the file path validation logic. This PR updates the vendored code unchanged (other than package name and comment).

Benefits include:
* re-use k8s code
* supports nested paths
* will remove files that are not in the update

Unfortunately files written the "regular" way are not updated by the atomic writer, so I've added unit tests and a helper `cleanupProviderFiles` to ensure that a path mounted using the old style will be correctly updated if the new style is deployed.

Additionally using the atomic writer means that paths that start with `..` are not supported since the `atomic_writer` uses these as a scratch pad for making the updates before updating symlinks.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
* #500

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

Since the atomic writer relies on symlinks, locations where `filepath.Walk` is used must be examined for correctness since that function does not follow symlinks.