### PR TITLE
e2e: include nested path in secret sync

### DIFF
--- a/test/bats/tests/vault/vault_synck8s_v1alpha1_secretproviderclass.yaml
+++ b/test/bats/tests/vault/vault_synck8s_v1alpha1_secretproviderclass.yaml
@@ -14,6 +14,8 @@ spec:
       key: pwd
     - objectName: bar1
       key: username
+    - objectName: nest/foo1
+      key: nested
   parameters:
     roleName: "example-role"
     vaultAddress: http://${VAULT_SERVICE_IP}:8200
@@ -27,4 +29,8 @@ spec:
         - |
           objectPath: "v1/secret/foo1"
           objectName: "bar1"
+          objectVersion: ""
+        - |
+          objectPath: "v1/secret/foo1"
+          objectName: "nest/foo1"
           objectVersion: ""

--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -183,8 +183,14 @@ EOF
   result=$(kubectl exec $POD -- cat /mnt/secrets-store/bar1)
   [[ "$result" == "hello1" ]]
 
+  result=$(kubectl exec $POD -- cat /mnt/secrets-store/nest/foo1)
+  [[ "$result" == "hello1" ]]
+
   result=$(kubectl get secret foosecret -o jsonpath="{.data.pwd}" | base64 -d)
   [[ "$result" == "hello" ]]
+
+  result=$(kubectl get secret foosecret -o jsonpath="{.data.nested}" | base64 -d)
+  [[ "$result" == "hello1" ]]
 
   result=$(kubectl exec $POD -- printenv | grep SECRET_USERNAME | awk -F"=" '{ print $2 }' | tr -d '\r\n')
   [[ "$result" == "hello1" ]]


### PR DESCRIPTION
**What this PR does / why we need it**:

included an integration test that should cover syncing a file in a nested folder to a K8s secret.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #515

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
