### PR TITLE
cleanup: remove windows file deletion on unmount

### DIFF
--- a/pkg/secrets-store/nodeserver.go
+++ b/pkg/secrets-store/nodeserver.go
@@ -21,11 +21,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"runtime"
 
 	csicommon "sigs.k8s.io/secrets-store-csi-driver/pkg/csi-common"
 	internalerrors "sigs.k8s.io/secrets-store-csi-driver/pkg/errors"
-	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/fileutil"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
@@ -222,23 +220,11 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 		return nil, status.Error(codes.InvalidArgument, "Target path missing in request")
 	}
 	targetPath := req.GetTargetPath()
-	// Assume no mounted files if GetMountedFiles fails.
-	files, _ := fileutil.GetMountedFiles(targetPath)
 
 	if isMockTargetPath(targetPath) {
 		return &csi.NodeUnpublishVolumeResponse{}, nil
 	}
 
-	// remove files
-	if runtime.GOOS == "windows" {
-		for _, file := range files {
-			err = os.RemoveAll(file)
-			if err != nil {
-				klog.ErrorS(err, "failed to remove file from target path", "file", file)
-				return nil, status.Error(codes.Internal, err.Error())
-			}
-		}
-	}
 	err = mount.CleanupMountPoint(targetPath, ns.mounter, false)
 	if err != nil && !os.IsNotExist(err) {
 		klog.ErrorS(err, "failed to clean and unmount target path", "targetPath", targetPath)


### PR DESCRIPTION
**What this PR does / why we need it**:

the k8s.io/mount-utils package includes necessary logic:
https://github.com/kubernetes/mount-utils/blob/77a9b3dc97f9e87135fbdc74e84ab9611bcf9a1c/mount_windows.go#L215

I noticed this when going through some windows specific code paths and think its probably better to rely on the mounter to take care of this logic instead of including it in our unmount handler

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

N/A

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
