### PR TITLE
test: include nested path in secret sync

### DIFF
--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -117,11 +117,18 @@ setup() {
   result=$(kubectl exec $POD -- cat /mnt/secrets-store/secretalias)
   [[ "${result//$'\r'}" == "${SECRET_VALUE}" ]]
 
+  result=$(kubectl exec $POD -- cat /mnt/secrets-store/nested/secretalias)
+  [[ "${result//$'\r'}" == "${SECRET_VALUE}" ]]
+
   result=$(kubectl exec $POD -- cat /mnt/secrets-store/$KEY_NAME)
   result_base64_encoded=$(echo "${result//$'\r'}" | base64 ${BASE64_FLAGS})
   [[ "${result_base64_encoded}" == *"${KEY_VALUE_CONTAINS}"* ]]
 
   result=$(kubectl get secret foosecret -o jsonpath="{.data.username}" | base64 -d)
+  [[ "${result//$'\r'}" == "${SECRET_VALUE}" ]]
+
+  # test synced kubernetes secret data set from nested file
+  result=$(kubectl get secret foosecret -o jsonpath="{.data.nested}" | base64 -d)
   [[ "${result//$'\r'}" == "${SECRET_VALUE}" ]]
 
   result=$(kubectl exec $POD -- printenv | grep SECRET_USERNAME) | awk -F"=" '{ print $2}'

--- a/test/bats/tests/azure/azure_synck8s_v1alpha1_secretproviderclass.yaml
+++ b/test/bats/tests/azure/azure_synck8s_v1alpha1_secretproviderclass.yaml
@@ -12,6 +12,8 @@ spec:
     data: 
     - objectName: secretalias                    # name of the mounted content to sync. this could be the object name or object alias 
       key: username
+    - objectName: nested/secretalias             # name of the mounted content to sync. this could be the object name or object alias 
+      key: nested
   parameters:
     usePodIdentity: "false"                      # [OPTIONAL] if not provided, will default to "false"
     keyvaultName: "$KEYVAULT_NAME"               # the name of the KeyVault
@@ -21,6 +23,11 @@ spec:
           objectName: $SECRET_NAME
           objectType: secret                     # object types: secret, key or cert
           objectAlias: secretalias
+          objectVersion: $SECRET_VERSION         # [OPTIONAL] object versions, default to latest if empty
+        - |
+          objectName: $SECRET_NAME
+          objectType: secret                     # object types: secret, key or cert
+          objectAlias: nested/secretalias
           objectVersion: $SECRET_VERSION         # [OPTIONAL] object versions, default to latest if empty
         - |
           objectName: $KEY_NAME


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
Building on top of #521 to enable testing for nested paths during secret sync

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #515 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
