### PR TITLE
Add test coverage report into Makefile for unit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ test: lint go-test
 
 .PHONY: go-test # Run unit tests
 go-test:
-	go test $(GO_FILES) -v
+	go test -cover $(GO_FILES) -v
 
 .PHONY: sanity-test # Run CSI sanity tests for the driver
 sanity-test:


### PR DESCRIPTION
**What this PR does / why we need it**:

Report code coverage for unit test.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
