### PR TITLE
chore: update release docs and makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,8 +355,9 @@ release-manifest:
 	$(MAKE) manifests
 	@sed -i "s/version: .*/version: ${NEWVERSION}/" manifest_staging/charts/secrets-store-csi-driver/Chart.yaml
 	@sed -i "s/appVersion: .*/appVersion: ${NEWVERSION}/" manifest_staging/charts/secrets-store-csi-driver/Chart.yaml
-	@sed -i "s/tag: .*/tag: ${NEWVERSION}/" manifest_staging/charts/secrets-store-csi-driver/values.yaml
-	@sed -i "s/image tag | .*/image tag | \`${NEWVERSION}\` |/" manifest_staging/charts/secrets-store-csi-driver/README.md
+	@sed -i "s/tag: v${CURRENTVERSION}/tag: v${NEWVERSION}/" manifest_staging/charts/secrets-store-csi-driver/values.yaml
+	@sed -i "s/v${CURRENTVERSION}/v${NEWVERSION}/" manifest_staging/charts/secrets-store-csi-driver/README.md
+	@sed -i "s/driver:v${CURRENTVERSION}/driver:v${NEWVERSION}/" manifest_staging/deploy/secrets-store-csi-driver.yaml manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
 
 .PHONY: promote-staging-manifest
 promote-staging-manifest: #promote staging manifests to release dir

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -6,7 +6,7 @@ The release process consists of three phases: versioning, building and publishin
 
 Versioning involves maintaining the following files:
 
-- Makefile - the Makefile contains a `VERSION` variable that defines the version of the project.
+- Makefile - the Makefile contains a `IMAGE_VERSION` variable that defines the version of the project.
 - secrets-store-csi-driver.yaml - the Linux driver deployment yaml that contains the latest release tag image of the project.
 - secrets-store-csi-driver-windows.yaml - the Windows driver deployment yaml that contains the latest release tag image of the project.
 - `deploy/` dir that contains all the secrets-store-csi-driver resources to be deployed to the cluster including the latest release tag image of the project.
@@ -22,44 +22,55 @@ Publishing involves creating a release tag and creating a new Release on GitHub.
 1. Update the version to the semantic version of the new release similar to [this](https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/251)
 1. Commit the changes and push to remote repository to create a pull request
 
-    ```
+    ```bash
     git checkout -b bump-version-<NEW VERSION>
-    git commit -m "Bump versions for <NEW VERSION"
+    git commit -m "Bump versions for <NEW VERSION>"
     git push <YOUR FORK>
     ```
-   
- 1. Once the PR is merged to master, the [prow job](https://testgrid.k8s.io/sig-auth-secrets-store-csi-driver#secrets-store-csi-driver-push-image) is triggered to build and push the new version to staging repo (`gcr.io/k8s-staging-csi-secrets-store/driver`)
- 1. Once the prow job completes, follow the [instructions](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#image-promoter) to promote the image to production repo
+  
+1. Once the PR is merged to master, the [prow job](https://testgrid.k8s.io/sig-auth-secrets-store-csi-driver#secrets-store-csi-driver-push-image) is triggered to build and push the new version to staging repo (`gcr.io/k8s-staging-csi-secrets-store/driver`)
+1. Once the prow job completes, follow the [instructions](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#image-promoter) to promote the image to production repo
     - Run generate script to append the new image to promoter manifest
+
     ```bash
     k8s.gcr.io/images/k8s-staging-csi-secrets-store/generate.sh > k8s.gcr.io/images/k8s-staging-csi-secrets-store/images.yaml
     ```
+
     - Preview the changes
+
     ```bash
     git diff
     ```
+
     - Commit the changes and push to remote repository to create a pull request
-  1. Once the image promoter PR is merged, the image will be promoted to prod repo (`us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver`)
+1. Once the image promoter PR is merged, the image will be promoted to prod repo (`k8s.gcr.io/csi-secrets-store/driver`)
   
 ## Building and releasing
 
 1. Execute the promote-staging-manifest target to generate patch and promote staging manifest to release
+
+    ```bash
+   make promote-staging-manifest NEWVERSION=0.0.12 CURRENTVERSION=0.0.11
     ```
-   make promote-staging-manifest NEWVERSION=v0.0.12
-    ```
-2. Preview the changes
+
+1. Preview the changes
+
     ```bash
    git diff
     ```
-3. Commit the changes and push to remote repository to create a pull request
-    ```
+
+1. Commit the changes and push to remote repository to create a pull request
+
+    ```bash
     git checkout -b release-<NEW VERSION>
     git commit -a -s -m "release: update manifests and helm chart for <NEW VERSION>"
     git push <YOUR FORK>
     ```
-4. Once the PR is merged to master, tag master with release version and push tags to remote repository.
+
+1. Once the PR is merged to master, tag master with release version and push tags to remote repository.
     - An [OWNER](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/OWNERS) runs git tag and pushes the tag with git push
-   ```
+
+   ```bash
    git checkout master
    git pull origin master
    git tag -a <NEW VERSION> -m '<NEW VERSION>'


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Updates makefile target for automating release
- Updates release doc

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
