### PR TITLE
docs: set-as-env-var pod indent

### DIFF
--- a/docs/book/src/topics/set-as-env-var.md
+++ b/docs/book/src/topics/set-as-env-var.md
@@ -46,28 +46,28 @@ metadata:
   name: secrets-store-inline
 spec:
   containers:
-    - name: busybox
-      image: k8s.gcr.io/e2e-test-images/busybox:1.29
-      command:
-      - "/bin/sleep"
-      - "10000"
-      volumeMounts:
-      - name: secrets-store01-inline
-        mountPath: "/mnt/secrets-store"
-        readOnly: true
-        env:
-        - name: SECRET_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: foosecret
-              key: username
-  volumes:
+  - name: busybox
+    image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    command:
+    - "/bin/sleep"
+    - "10000"
+    volumeMounts:
     - name: secrets-store01-inline
-      csi:
-        driver: secrets-store.csi.k8s.io
-        readOnly: true
-        volumeAttributes:
-          secretProviderClass: "azure-sync"
+      mountPath: "/mnt/secrets-store"
+      readOnly: true
+    env:
+    - name: SECRET_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: foosecret
+          key: username
+  volumes:
+  - name: secrets-store01-inline
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: "azure-sync"
 ```
 
 </details>


### PR DESCRIPTION
**What this PR does / why we need it**: mainly fix `env` indent

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:


<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
