### PR TITLE
fix: CVE-2021-3520

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ IMAGE_NAME ?= driver
 # Release version is the current supported release for the driver
 # Update this version when the helm chart is being updated for release
 RELEASE_VERSION := v0.0.22
-IMAGE_VERSION ?= v0.0.22
+IMAGE_VERSION ?= v0.0.23-rc.0
 # Use a custom version for E2E tests if we are testing in CI
 ifdef CI
 override IMAGE_VERSION := v0.1.0-e2e-$(BUILD_COMMIT)

--- a/docker/BASEIMAGE
+++ b/docker/BASEIMAGE
@@ -1,4 +1,4 @@
-linux/amd64=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.5.0
+linux/amd64=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.6.0
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/1903=mcr.microsoft.com/windows/nanoserver:1903
 windows/amd64/1909=mcr.microsoft.com/windows/nanoserver:1909

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.5.0
+ARG BASEIMAGE=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.6.0
 
 FROM golang:1.16-alpine as builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver
@@ -10,7 +10,8 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "${LDFL
 
 FROM $BASEIMAGE
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi
-RUN clean-install ca-certificates cifs-utils mount
+# upgrading liblz4-1 due to CVE-2021-3520
+RUN clean-install ca-certificates cifs-utils mount liblz4-1
 
 LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -14,7 +14,7 @@
 
 REGISTRY?=docker.io/deislabs
 IMAGE_NAME=driver
-IMAGE_VERSION?=v0.0.22
+IMAGE_VERSION?=v0.0.23-rc.0
 BUILD_TIMESTAMP := $(shell date +%Y-%m-%d-%H:%M)
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Bumps docker base image to debian-base-amd64:buster-v1.6.0
- Fixes CVE-2021-3520

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #561 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
