### PR TITLE
docs: add membership criteria and getting involved section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The Secrets Store CSI driver `secrets-store.csi.k8s.io` allows Kubernetes to mou
 ## Want to help?
 
 Join us to help define the direction and implementation of this project!
+
 - Join the [#csi-secrets-store](https://kubernetes.slack.com/messages/csi-secrets-store) channel on [Kubernetes Slack](https://kubernetes.slack.com/).
 - Join the [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-secrets-store-csi-driver) to receive notifications for releases, security announcements, etc.
 - Use [GitHub Issues](https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues) to file bugs, request features, or ask questions asynchronously.
@@ -39,6 +40,18 @@ Check out the [installation instructions](https://secrets-store-csi-driver.sigs.
 ## Documentation
 
 Please see the [docs](https://secrets-store-csi-driver.sigs.k8s.io) for more in-depth information and supported features.
+
+## Getting involved and contributing
+
+Are you interested in contributing to secrets-store-csi-driver? We, the maintainers and community, would love your suggestions, contributions, and help! Also, the maintainers can be contacted at any time to learn more about how to get involved.
+
+In the interest of getting more new people involved, we tag issues with [`good first issue`](https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22). These are typically issues that have smaller scope but are good ways to start to get acquainted with the codebase.
+
+We also encourage ALL active community participants to act as if they are maintainers, even if you don't have "official" write permissions. This is a community effort, we are here to serve the Kubernetes community. If you have an active interest and you want to get involved, you have real power! Don't assume that the only people who can get things done around here are the "maintainers".
+
+We also would love to add more "official" maintainers, so show us what you can do!
+
+> Check out [Secrets Store CSI Driver Membership](./docs/MEMBERSHIP.md) for more information.
 
 ## Code of conduct
 

--- a/docs/MEMBERSHIP.md
+++ b/docs/MEMBERSHIP.md
@@ -1,0 +1,72 @@
+# Secrets Store CSI Driver Project Membership
+
+> Note: This document is a work in progress
+
+> Original doc: [Secrets Store CSI Driver Project Membership](https://docs.google.com/document/d/1YqFVTJdxvNXhXkWogYf7AOKMnUjPFHCPuYtTgJSHohU/edit?usp=sharing)
+
+## Overview
+
+This document outlines the various responsibilities for the Secrets Store CSI Driver sig-auth subproject.
+
+### Reviewer
+
+Reviewers are able to review code for quality and correctness on the Secrets Store CSI Driver. They are knowledgeable about the codebase and software engineering principles.
+
+**Defined by:** reviewers entry in the [OWNERS](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/v0.0.22/OWNERS#L5) file
+
+**Note:** Acceptance of code contributions requires at least one approver in addition to the assigned reviewers.
+
+#### Reviewer requirements
+
+The following apply to the Secrets Store CSI Driver subproject for which one would be a reviewer in the OWNERS file.
+
+- Member of kubernetes-sigs org
+- Reviewer for at least 5 PRs to the codebase
+- Reviewed or merged at least 10 substantial PRs to the codebase
+- Knowledgeable about the codebase
+- Sponsored by a subproject approver
+  - With no objections from other approvers
+  - Done through PR to update the OWNERS file
+- May either self-nominate, be nominated by an approver in this subproject.
+
+#### Reviewer responsibilities and privileges
+
+- Tests are run for PRs from members who aren’t part of Kubernetes org
+  - This involves running ok-to-test after assessing the PR briefly
+- Responsible for project quality control via code reviews
+  - Focus on code quality and correctness, including testing and factoring
+  - May also review for more holistic issues, but not a requirement
+- Expected to be responsive to review requests as per [community expectations](https://github.com/kubernetes/community/blob/master/contributors/guide/expectations.md)
+- Assigned PRs to review
+- Assigned test bugs
+
+### Approver
+
+Code approvers are able to both review and approve code contributions. While code review is focused on code quality and correctness, approval is focused on holistic acceptance of a contribution including: backwards / forwards compatibility, adhering to API and flag conventions, subtle performance and correctness issues, interactions with other parts of the system, etc.
+
+**Defined by:** approvers entry in the [OWNERS](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/v0.0.22/OWNERS#L1) file
+
+#### Approver requirements
+
+The following apply to the Secrets Store CSI Driver subproject for which one would be an approver in the OWNERS file.
+
+- Reviewer of the codebase for at least 3 months
+- Primary reviewer for at least 10 substantial PRs to the codebase
+- Reviewed or merged at least 30 PRs to the codebase
+- Nominated by a subproject owner
+  - With no objections from other subproject owners
+  - Done through PR to update the top-level OWNERS file
+
+#### Approver Responsibilities and privileges
+
+- Approver status may be a precondition to accepting large code contributions
+- Demonstrate sound technical judgement
+- Responsible for project quality control via code reviews
+  - Focus on holistic acceptance of contribution such as dependencies with other features, backwards / forwards compatibility, API and flag definitions, etc
+- Expected to be responsive to review requests as per community expectations
+- Mentor contributors and reviewers
+- May approve code contributions for acceptance
+
+### Docs used for reference
+
+- [Community membership](https://github.com/kubernetes/community/blob/master/community-membership.md)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Adds "Getting involved and contributing" section to the readme.
- Adds the membership criteria doc

/kind documentation

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
The `Getting involved and contributing` section has been taken from the cluster-api projects.