### PR TITLE
chore: update to debian-base v1.7.0

### DIFF
--- a/docker/BASEIMAGE
+++ b/docker/BASEIMAGE
@@ -1,4 +1,4 @@
-linux/amd64=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.6.0
+linux/amd64=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.7.0
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/1903=mcr.microsoft.com/windows/nanoserver:1903
 windows/amd64/1909=mcr.microsoft.com/windows/nanoserver:1909

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.6.0
+ARG BASEIMAGE=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.7.0
 
 FROM golang:1.16-alpine as builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver
@@ -10,8 +10,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "${LDFL
 
 FROM $BASEIMAGE
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi
-# upgrading liblz4-1 due to CVE-2021-3520
-RUN clean-install ca-certificates cifs-utils mount liblz4-1
+RUN clean-install ca-certificates mount
 
 LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
Updates to debian-base v1.7.0 that resolves CVE-2021-3520. Removes cifs-utils as it's not
required for the driver.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
