### PR TITLE
Added GOPROXY propagation to container builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,13 @@
 ARG BASEIMAGE=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.7.0
 
-FROM golang:1.16-alpine as builder
+FROM golang:1.16 as builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver
 ADD . .
 ARG TARGETARCH
 ARG TARGETOS
 ARG LDFLAGS
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "${LDFLAGS}" -o _output/secrets-store-csi ./cmd/secrets-store-csi-driver
 
 FROM $BASEIMAGE

--- a/docker/windows.Dockerfile
+++ b/docker/windows.Dockerfile
@@ -9,6 +9,8 @@ ADD . .
 ARG TARGETARCH
 ARG TARGETOS
 ARG LDFLAGS
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "${LDFLAGS}" -o _output/secrets-store-csi.exe ./cmd/secrets-store-csi-driver
 
 FROM $BASEIMAGE


### PR DESCRIPTION
**What this PR does / why we need it**:

Some corporate environments block access to `proxy.golang.org`. When building secrets-store-csi-driver in a container, setting `GOPROXY=direct` is not propagated, and even when it is, the absence of `git` causes builds to fail.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #570

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

You're awesome. Remember that.
