### PR TITLE
feat: add arm64 build

### DIFF
--- a/docker/BASEIMAGE
+++ b/docker/BASEIMAGE
@@ -1,4 +1,5 @@
-linux/amd64=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.7.0
+linux/amd64=us.gcr.io/k8s-artifacts-prod/build-image/debian-base:buster-v1.7.0
+linux/arm64=us.gcr.io/k8s-artifacts-prod/build-image/debian-base:buster-v1.7.0
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/1903=mcr.microsoft.com/windows/nanoserver:1903
 windows/amd64/1909=mcr.microsoft.com/windows/nanoserver:1909

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,15 @@
-ARG BASEIMAGE=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.7.0
+ARG BASEIMAGE=us.gcr.io/k8s-artifacts-prod/build-image/debian-base:buster-v1.7.0
 
 FROM golang:1.16 as builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver
 ADD . .
 ARG TARGETARCH
 ARG TARGETOS
-ARG LDFLAGS
-ARG GOPROXY
-ENV GOPROXY=${GOPROXY}
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "${LDFLAGS}" -o _output/secrets-store-csi ./cmd/secrets-store-csi-driver
+ARG TARGETPLATFORM
+
+RUN export GOOS=$TARGETOS && \
+    export GOARCH=$TARGETARCH && \
+    make build
 
 FROM $BASEIMAGE
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi

--- a/docker/windows.Dockerfile
+++ b/docker/windows.Dockerfile
@@ -3,15 +3,15 @@ ARG BASEIMAGE_CORE=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1
 
 FROM --platform=linux/amd64 ${BASEIMAGE_CORE} as core
 
-FROM --platform=$BUILDPLATFORM golang:1.16-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1.16 as builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver
 ADD . .
 ARG TARGETARCH
 ARG TARGETOS
-ARG LDFLAGS
-ARG GOPROXY
-ENV GOPROXY=${GOPROXY}
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "${LDFLAGS}" -o _output/secrets-store-csi.exe ./cmd/secrets-store-csi-driver
+
+RUN export GOOS=$TARGETOS && \
+    export GOARCH=$TARGETARCH && \
+    make build-windows
 
 FROM $BASEIMAGE
 LABEL description="Secrets Store CSI Driver"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Adds `arm64` build for Linux images
- Refactors dockerfile

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #525 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
