### PR TITLE
chore: list builder instances in image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,6 @@ ARCH ?= amd64
 OSVERSION ?= 1809
 # Output type of docker buildx build
 OUTPUT_TYPE ?= registry
-BUILDKIT_VERSION ?= v0.8.1
 
 # Binaries
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
@@ -265,7 +264,7 @@ container-windows: docker-buildx-builder
 .PHONY: docker-buildx-builder
 docker-buildx-builder:
 	@if ! docker buildx ls | grep -q container-builder; then\
-		DOCKER_CLI_EXPERIMENTAL=enabled docker buildx create --name container-builder --use --driver-opt image=moby/buildkit:$(BUILDKIT_VERSION);\
+		DOCKER_CLI_EXPERIMENTAL=enabled docker buildx create --name container-builder --use;\
 	fi
 
 .PHONY: container-all

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -73,11 +73,10 @@ docker_version_check() {
 build_and_push() {
   docker_version_check
 
-  # only moby/buildkit:foreign-mediatype works on building Windows image now
-  # https://github.com/moby/buildkit/pull/1879
-  # Github issue: https://github.com/moby/buildkit/issues/1877
-  docker buildx create --name img-builder --use --driver-opt image=moby/buildkit:v0.7.2
-  trap "docker buildx rm img-builder" EXIT
+  docker buildx create --name img-builder --use
+  # List builder instances
+  docker buildx ls
+  trap "docker buildx ls && docker buildx rm img-builder" EXIT
 
   os_archs=$(listOsArchs)
   for os_arch in ${os_archs}; do


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- The `arm64` build fails in gcb. So adding debug logs in the image build script. Ref: https://storage.googleapis.com/kubernetes-jenkins/logs/secrets-store-csi-driver-push-image/1402073906189176832/build-log.txt
```bash
failed to load LLB: runtime execution on platform linux/arm64 not supported
```
- Removes the pinned buildkit version

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
