### PR TITLE
chore: enable qemu for multi-arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ ARCH ?= amd64
 OSVERSION ?= 1809
 # Output type of docker buildx build
 OUTPUT_TYPE ?= registry
+QEMUVERSION ?= 5.2.0-2
 
 # Binaries
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
@@ -228,7 +229,7 @@ lint-charts: $(HELM) # Run helm lint tests
 
 .PHONY: shellcheck
 shellcheck: $(SHELLCHECK)
-	find . -name '*.sh' -not -path './docker/*' | xargs $(SHELLCHECK)
+	$(SHELLCHECK) */*.sh
 
 ## --------------------------------------
 ## Builds
@@ -269,6 +270,9 @@ docker-buildx-builder:
 
 .PHONY: container-all
 container-all:
+	# Enable execution of multi-architecture containers
+	docker run --rm --privileged multiarch/qemu-user-static:$(QEMUVERSION) --reset -p yes
+
 	for arch in $(ALL_ARCH.linux); do \
 		ARCH=$${arch} $(MAKE) container-linux; \
 	done


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Enables qemu for multi-arch builds
- Fixes shellcheck errors in docker folder

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #558 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
