### PR TITLE
feat: add rbac role and binding for rotation

### DIFF
--- a/config/rbac-rotation/kustomization.yaml
+++ b/config/rbac-rotation/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- role.yaml
+- role_binding.yaml

--- a/config/rbac-rotation/role.yaml
+++ b/config/rbac-rotation/role.yaml
@@ -1,0 +1,16 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: secretproviderrotation-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/rbac-rotation/role_binding.yaml
+++ b/config/rbac-rotation/role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: secretproviderrotation-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secretproviderrotation-role
+subjects:
+- kind: ServiceAccount
+  name: secrets-store-csi-driver
+  namespace: kube-system

--- a/docs/book/src/getting-started/installation.md
+++ b/docs/book/src/getting-started/installation.md
@@ -42,6 +42,10 @@ kubectl apply -f deploy/secrets-store-csi-driver.yaml
 # required to enable this feature
 kubectl apply -f deploy/rbac-secretprovidersyncing.yaml
 
+# If using the secret rotation feature, deploy the additional RBAC permissions
+# required to enable this feature
+kubectl apply -f deploy/rbac-secretproviderrotation.yaml
+
 # [OPTIONAL] To deploy driver on windows nodes
 kubectl apply -f deploy/secrets-store-csi-driver-windows.yaml
 ```

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/role-rotation.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/role-rotation.yaml
@@ -1,0 +1,18 @@
+{{ if .Values.enableSecretRotation }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: secretproviderrotation-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+{{ end }}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/role-rotation_binding.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/role-rotation_binding.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.enableSecretRotation }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: secretproviderrotation-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secretproviderrotation-role
+subjects:
+- kind: ServiceAccount
+  name: secrets-store-csi-driver
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/manifest_staging/deploy/rbac-secretproviderrotation.yaml
+++ b/manifest_staging/deploy/rbac-secretproviderrotation.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: secretproviderrotation-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: secretproviderrotation-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secretproviderrotation-role
+subjects:
+- kind: ServiceAccount
+  name: secrets-store-csi-driver
+  namespace: kube-system

--- a/pkg/rotation/reconciler.go
+++ b/pkg/rotation/reconciler.go
@@ -84,6 +84,10 @@ type Reconciler struct {
 	crdClient            versioned.Interface
 }
 
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// These permissions are required for secret rotation + nodePublishSecretRef
+// TODO (aramase) remove this as part of https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/585
+
 // NewReconciler returns a new reconciler for rotation
 func NewReconciler(s *runtime.Scheme, providerVolumePath, nodeName string, rotationPollInterval time.Duration, providerClients *secretsstore.PluginClientBuilder, filteredWatchSecret bool) (*Reconciler, error) {
 	config, err := buildConfig()

--- a/test/bats/aws.bats
+++ b/test/bats/aws.bats
@@ -71,6 +71,26 @@ teardown_file() {
     assert_success
 }
 
+@test "Test rbac roles and role bindings exist" {
+  run kubectl get clusterrole/secretproviderclasses-role
+  assert_success
+
+  run kubectl get clusterrole/secretproviderrotation-role
+  assert_success
+
+  run kubectl get clusterrole/secretprovidersyncing-role
+  assert_success
+
+  run kubectl get clusterrolebinding/secretproviderclasses-rolebinding
+  assert_success
+
+  run kubectl get clusterrolebinding/secretproviderrotation-rolebinding
+  assert_success
+
+  run kubectl get clusterrolebinding/secretprovidersyncing-rolebinding
+  assert_success
+}
+
 @test "deploy aws secretproviderclass crd" {
     envsubst < $BATS_TEST_DIR/BasicTestMountSPC.yaml | kubectl --namespace $NAMESPACE apply -f -
 

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -62,6 +62,26 @@ setup() {
   assert_success
 }
 
+@test "Test rbac roles and role bindings exist" {
+  run kubectl get clusterrole/secretproviderclasses-role
+  assert_success
+
+  run kubectl get clusterrole/secretproviderrotation-role
+  assert_success
+
+  run kubectl get clusterrole/secretprovidersyncing-role
+  assert_success
+
+  run kubectl get clusterrolebinding/secretproviderclasses-rolebinding
+  assert_success
+
+  run kubectl get clusterrolebinding/secretproviderrotation-rolebinding
+  assert_success
+
+  run kubectl get clusterrolebinding/secretprovidersyncing-rolebinding
+  assert_success
+}
+
 @test "deploy azure secretproviderclass crd" {
   envsubst < $BATS_TESTS_DIR/azure_v1alpha1_secretproviderclass.yaml | kubectl apply -f -
 

--- a/test/bats/gcp.bats
+++ b/test/bats/gcp.bats
@@ -47,6 +47,26 @@ setup() {
   assert_success
 }
 
+@test "Test rbac roles and role bindings exist" {
+  run kubectl get clusterrole/secretproviderclasses-role
+  assert_success
+
+  run kubectl get clusterrole/secretproviderrotation-role
+  assert_success
+
+  run kubectl get clusterrole/secretprovidersyncing-role
+  assert_success
+
+  run kubectl get clusterrolebinding/secretproviderclasses-rolebinding
+  assert_success
+
+  run kubectl get clusterrolebinding/secretproviderrotation-rolebinding
+  assert_success
+
+  run kubectl get clusterrolebinding/secretprovidersyncing-rolebinding
+  assert_success
+}
+
 @test "deploy gcp secretproviderclass crd" {
   envsubst < $BATS_TESTS_DIR/gcp_v1alpha1_secretproviderclass.yaml | kubectl apply -f -
 

--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -67,6 +67,26 @@ EOF
   assert_success
 }
 
+@test "Test rbac roles and role bindings exist" {
+  run kubectl get clusterrole/secretproviderclasses-role
+  assert_success
+
+  run kubectl get clusterrole/secretproviderrotation-role
+  assert_success
+
+  run kubectl get clusterrole/secretprovidersyncing-role
+  assert_success
+
+  run kubectl get clusterrolebinding/secretproviderclasses-rolebinding
+  assert_success
+
+  run kubectl get clusterrolebinding/secretproviderrotation-rolebinding
+  assert_success
+
+  run kubectl get clusterrolebinding/secretprovidersyncing-rolebinding
+  assert_success
+}
+
 @test "deploy vault secretproviderclass crd" {
   kubectl apply -f $BATS_TESTS_DIR/vault_v1alpha1_secretproviderclass.yaml
   kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.x-k8s.io


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Adds rbac clusterrole and binding for rotation reconciler to use with `nodePublishSecretRef`

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
