### PR TITLE
docs: add upgrade instruction for v0.0.23

### DIFF
--- a/docs/book/src/getting-started/upgrades.md
+++ b/docs/book/src/getting-started/upgrades.md
@@ -12,6 +12,10 @@ Set `NAMESPACE` to the same namespace where the driver was originally installed,
 If you are upgrading from one of the following versions there may be additional
 steps that you should take.
 
+## pre `v0.0.23`
+
+`v0.0.23` sets `syncSecret.enabled=false` by default. This means the RBAC clusterrole and clusterrolebinding required for [sync mounted content as Kubernetes secret](https://secrets-store-csi-driver.sigs.k8s.io/topics/sync-as-kubernetes-secret.html) will no longer be created by default as part of `helm install/upgrade`. If you're using the driver to sync mounted content as Kubernetes secret, you'll need to set `syncSecret.enabled=true` as part of `helm install/upgrade`.
+
 ## pre `v0.0.20`
 
 `v0.0.20` removed support for non-gRPC based providers. Follow your provider


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Adds upgrade instruction for `v0.0.23` release

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
