### PR TITLE
e2e: ensure pod deletion is successful

### DIFF
--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -118,6 +118,33 @@ setup() {
   [[ "${result_base64_encoded}" == *"${KEY_VALUE_CONTAINS}"* ]]
 }
 
+@test "CSI inline volume test with pod portability - unmount succeeds" {
+  # https://github.com/kubernetes/kubernetes/pull/96702
+  # kubectl wait --for=delete does not work on already deleted pods.
+  # Instead we will start the wait before initiating the delete.
+  kubectl wait --for=delete --timeout=${WAIT_TIME}s pod/secrets-store-inline-crd &
+  WAIT_PID=$!
+
+  sleep 1
+  run kubectl delete pod secrets-store-inline-crd
+
+  # On Linux a failure to unmount the tmpfs will block the pod from being
+  # deleted.
+  run wait $WAIT_PID
+  assert_success
+
+  # Sleep to allow time for logs to propagate.
+  sleep 10
+  # save debug information to archive in case of failure
+  archive_info
+
+  # On Windows, the failed unmount calls from: https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/545
+  # do not prevent the pod from being deleted. Search through the driver logs
+  # for the error.
+  run bash -c "kubectl logs -l app=secrets-store-csi-driver --tail -1 -c secrets-store -n kube-system | grep '^E.*failed to clean and unmount target path.*$'"
+  assert_failure
+}
+
 @test "Sync with K8s secrets - create deployment" {
   envsubst < $BATS_TESTS_DIR/azure_synck8s_v1alpha1_secretproviderclass.yaml | kubectl apply -f - 
 
@@ -392,6 +419,8 @@ setup() {
 }
 
 teardown_file() {
+  archive_info || true
+
   #cleanup
   run kubectl delete namespace non-filtered-watch
   run kubectl delete namespace rotation

--- a/test/bats/helpers.bash
+++ b/test/bats/helpers.bash
@@ -80,3 +80,25 @@ check_secret_deleted() {
   result=$(kubectl get secret -n ${namespace} | grep "^${secret}$" | wc -l)
   [[ "$result" -eq 0 ]]
 }
+
+archive_info() {
+  if [[ -z "${ARTIFACTS}" ]]; then
+    return 0
+  fi
+
+  FILE_PREFIX=$(date +"%FT%H%M%S")
+
+  # print all pod information
+  kubectl get pods -A -o json > ${ARTIFACTS}/${FILE_PREFIX}-pods.json
+
+  # print detailed pod information
+  kubectl describe pods --all-namespaces > ${ARTIFACTS}/${FILE_PREFIX}-pods-describe.txt
+
+  # print logs from the CSI Driver
+  #
+  # assumes driver is installed with helm into the `kube-system` namespace which
+  # sets the `app` selector to `secrets-store-csi-driver`.
+  #
+  # Note: the yaml deployment would require `app=csi-secrets-store`
+  kubectl logs -l app=secrets-store-csi-driver  --tail -1 -c secrets-store -n kube-system > ${ARTIFACTS}/${FILE_PREFIX}-csi-secrets-store-driver.logs
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

#526 removed some code and integration tests passed. It was only through manual verification that it was discovered that deletion before unmount was actually required: #545

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #546

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
