### PR TITLE
Possibility to annotate the created secret with CSI driver

### DIFF
--- a/apis/v1alpha1/secretproviderclass_types.go
+++ b/apis/v1alpha1/secretproviderclass_types.go
@@ -47,8 +47,10 @@ type SecretObject struct {
 	// type of K8s secret object
 	Type string `json:"type,omitempty"`
 	// labels of K8s secret object
-	Labels map[string]string   `json:"labels,omitempty"`
-	Data   []*SecretObjectData `json:"data,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
+	// annotations of k8s secret object
+	Annotations map[string]string   `json:"annotations,omitempty"`
+	Data        []*SecretObjectData `json:"data,omitempty"`
 }
 
 // SecretProviderClassSpec defines the desired state of SecretProviderClass

--- a/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -61,6 +61,11 @@ spec:
                         type: string
                       description: labels of K8s secret object
                       type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: annotations of K8s secret object
+                      type: object
                     secretName:
                       description: name of the K8s secret object
                       type: string

--- a/manifest_staging/charts/secrets-store-csi-driver/crds/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/crds/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -61,6 +61,11 @@ spec:
                         type: string
                       description: labels of K8s secret object
                       type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: annotations of K8s secret object
+                      type: object
                     secretName:
                       description: name of the K8s secret object
                       type: string

--- a/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -61,6 +61,11 @@ spec:
                         type: string
                       description: labels of K8s secret object
                       type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: annotations of K8s secret object
+                      type: object
                     secretName:
                       description: name of the K8s secret object
                       type: string

--- a/test/bats/tests/vault/vault_synck8s_v1alpha1_secretproviderclass.yaml
+++ b/test/bats/tests/vault/vault_synck8s_v1alpha1_secretproviderclass.yaml
@@ -9,6 +9,8 @@ spec:
     type: Opaque
     labels:                                   
       environment: "test"
+    annotations:
+      kubed.appscode.com/sync: "app=test"
     data: 
     - objectName: bar
       key: pwd

--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -7,6 +7,7 @@ WAIT_TIME=120
 SLEEP_TIME=1
 
 export LABEL_VALUE=${LABEL_VALUE:-"test"}
+export ANNOTATION_VALUE=${ANNOTATION_VALUE:-"test"}
 
 @test "install vault provider" {
   # create the ns vault
@@ -150,6 +151,9 @@ EOF
 
   result=$(kubectl get secret foosecret -o jsonpath="{.metadata.labels.environment}")
   [[ "${result//$'\r'}" == "${LABEL_VALUE}" ]]
+
+  result=$(kubectl get secret foosecret -o jsonpath="{.metadata.annotations.kubed\.appscode\.com\/sync}")
+  [[ "${result//$'\r'}" == "${ANNOTATION_VALUE}" ]]
 
   result=$(kubectl get secret foosecret -o jsonpath="{.metadata.labels.secrets-store\.csi\.k8s\.io/managed}")
   [[ "${result//$'\r'}" == "true" ]]

--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -7,7 +7,7 @@ WAIT_TIME=120
 SLEEP_TIME=1
 
 export LABEL_VALUE=${LABEL_VALUE:-"test"}
-export ANNOTATION_VALUE=${ANNOTATION_VALUE:-"test"}
+export ANNOTATION_VALUE=${ANNOTATION_VALUE:-"app=test"}
 
 @test "install vault provider" {
   # create the ns vault


### PR DESCRIPTION
**What this PR does / why we need it**:
To support k8s secrets annotations

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #356 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
