### PR TITLE
chore: Add metrics port definition to DS

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -108,6 +108,9 @@ spec:
             - containerPort: {{ .Values.livenessProbe.port }}
               name: healthz
               protocol: TCP
+            - containerPort: {{ trimPrefix ":" .Values.windows.metricsAddr }}
+              name: metrics
+              protocol: TCP
           livenessProbe:
               failureThreshold: 5
               httpGet:

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -110,6 +110,9 @@ spec:
             - containerPort: {{ .Values.livenessProbe.port }}
               name: healthz
               protocol: TCP
+            - containerPort: {{ trimPrefix ":" .Values.linux.metricsAddr }}
+              name: metrics
+              protocol: TCP
           livenessProbe:
               failureThreshold: 5
               httpGet:

--- a/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
@@ -66,6 +66,9 @@ spec:
             - containerPort: 9808
               name: healthz
               protocol: TCP
+            - containerPort: 8095
+              name: metrics
+              protocol: TCP
           livenessProbe:
               failureThreshold: 5
               httpGet:

--- a/manifest_staging/deploy/secrets-store-csi-driver.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver.yaml
@@ -68,6 +68,9 @@ spec:
             - containerPort: 9808
               name: healthz
               protocol: TCP
+            - containerPort: 8095
+              name: metrics
+              protocol: TCP
           livenessProbe:
               failureThreshold: 5
               httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:

PodMonitors in the prometheus operator only supports defining port names and not numbers.
To be able to call on the name we need to define the port name in the pod.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
