### PR TITLE
helm chart repo doesn't work

### DIFF
--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -4,8 +4,7 @@ entries:
   - apiVersion: v1
     appVersion: 0.0.23
     created: "2021-06-10T12:27:24.468813-07:00"
-    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes
-      cluster.
+    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
     digest: 8207abf0e14ffe7d828119937e11fa72340d19d824e9a326b8f40fc8b6c8bd86
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     kubeVersion: '>=1.16.0-0'
@@ -21,8 +20,7 @@ entries:
   - apiVersion: v1
     appVersion: 0.0.22
     created: "2021-05-17T17:56:19.441550381-04:00"
-    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes
-      cluster.
+    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
     digest: e0df45a819f1fd99976bc26fc3b06b4d3ab8034d48829ed62b168dee79d96b88
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     kubeVersion: '>=1.16.0-0'
@@ -38,8 +36,7 @@ entries:
   - apiVersion: v1
     appVersion: 0.0.21
     created: "2021-04-01T09:50:24.248603-07:00"
-    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes
-      cluster.
+    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
     digest: cab95625686b388faa1e298dc913a14c5b28ffff7888074664e98dc392c94814
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     kubeVersion: '>=1.16.0-0'
@@ -55,8 +52,7 @@ entries:
   - apiVersion: v1
     appVersion: 0.0.20
     created: "2021-02-18T11:02:39.04869-08:00"
-    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes
-      cluster.
+    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
     digest: b08ef96a751c05859ea3cb21b5e39d11c9a66ad033ff020ee5f7ecbffb761aa1
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     kubeVersion: '>=1.16.0-0'
@@ -72,8 +68,7 @@ entries:
   - apiVersion: v1
     appVersion: 0.0.19
     created: "2021-01-19T13:25:13.508507-08:00"
-    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes
-      cluster.
+    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
     digest: 0070b72ba43a76e8bcda9e06d68dcbb27a2893954ffe92e7b30aae8c0012593b
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     kubeVersion: '>=1.16.0-0'
@@ -89,8 +84,7 @@ entries:
   - apiVersion: v1
     appVersion: 0.0.18
     created: "2020-12-10T16:54:59.318983-08:00"
-    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes
-      cluster.
+    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
     digest: 1f096be8bb4afdb001f03d0074f1629ad0fa6459388862df3e3ad5f98b4288cf
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     kubeVersion: '>=1.16.0-0'
@@ -122,8 +116,7 @@ entries:
   - apiVersion: v1
     appVersion: 0.0.16
     created: "2020-11-10T12:43:33.123624-08:00"
-    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes
-      cluster.
+    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
     digest: 28801272b580f6c5a8ec7cf634b05176debf8b7e92724847f594512ac081171c
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     kubeVersion: '>=1.16.0-0'
@@ -139,8 +132,7 @@ entries:
   - apiVersion: v1
     appVersion: 0.0.15
     created: "2020-11-10T12:43:33.120968-08:00"
-    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes
-      cluster.
+    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
     digest: 155ead450f2f8824f99f8508a11d14ae703084a5b95d7dbac391658199cf4a9a
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     kubeVersion: '>=1.16.0-0'
@@ -156,8 +148,7 @@ entries:
   - apiVersion: v1
     appVersion: 0.0.14
     created: "2020-11-10T12:43:33.119724-08:00"
-    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes
-      cluster.
+    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
     digest: 6390ebd13eeb76d1ed22263831d5383f8258bec1731d4f98e6c8dfe8b6256249
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     kubeVersion: '>=1.16.0-0'
@@ -173,8 +164,7 @@ entries:
   - apiVersion: v1
     appVersion: 0.0.13
     created: "2020-11-10T12:43:33.11841-08:00"
-    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes
-      cluster.
+    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
     digest: 426ea403ad1083cae569a13d8ecf686e4797b7816f6254709070afc4f4b858ab
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     kubeVersion: '>=1.15.0-0'
@@ -190,8 +180,7 @@ entries:
   - apiVersion: v1
     appVersion: 0.0.12
     created: "2020-11-10T12:43:33.1164-08:00"
-    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes
-      cluster.
+    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
     digest: 0c132d4be8c4eb48109a4fe8cc0ce29e6fc9f68647bb522c4040d033861a0e78
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     kubeVersion: '>=1.15.0-0'
@@ -207,8 +196,7 @@ entries:
   - apiVersion: v1
     appVersion: 0.0.11
     created: "2020-11-10T12:43:33.115646-08:00"
-    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes
-      cluster.
+    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
     digest: 2751ae7aed8ea2fc7dcdcbbf26240fccb2eefd83d3943cef45bb58bb1d297692
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     kubeVersion: '>=1.15.0-0'
@@ -224,8 +212,7 @@ entries:
   - apiVersion: v1
     appVersion: 0.0.10
     created: "2020-11-10T12:43:33.11489-08:00"
-    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes
-      cluster.
+    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
     digest: 9fae95e4611c9c120ed12505e735680b70ed133ea987fd32db05046cb45eda9e
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     kubeVersion: '>=1.15.0-0'
@@ -241,8 +228,7 @@ entries:
   - apiVersion: v1
     appVersion: 0.0.9
     created: "2020-11-10T12:43:33.125205-08:00"
-    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes
-      cluster.
+    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
     digest: 0f74454ca36c979a352d8a7b6d847521897ebf78195527ed8946201a841887a7
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     kubeVersion: '>=1.15.0-0'

--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -106,8 +106,7 @@ entries:
   - apiVersion: v1
     appVersion: 0.0.17
     created: "2020-11-10T12:43:33.124534-08:00"
-    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes
-      cluster.
+    description: A Helm chart to install the SecretsStore CSI Driver inside a Kubernetes cluster.
     digest: d83ee8e6e436c90350c5371a9e597663bd586286a1e9f851a6010eb79f3c9244
     icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
     kubeVersion: '>=1.16.0-0'


### PR DESCRIPTION
Fix typo in `description` key for version 0.0.17

**What this PR does / why we need it**:
Helm chart repo doesn't work with terraform helm provider

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #621 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
