### PR TITLE
Fix Windows nodes compatibility issues in pod definition

### DIFF
--- a/deploy/secrets-store-csi-driver-windows.yaml
+++ b/deploy/secrets-store-csi-driver-windows.yaml
@@ -62,20 +62,18 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
           imagePullPolicy: IfNotPresent
-          securityContext:
-            privileged: true
           ports:
             - containerPort: 9808
               name: healthz
               protocol: TCP
           livenessProbe:
-              failureThreshold: 5
-              httpGet:
-                path: /healthz
-                port: healthz
-              initialDelaySeconds: 30
-              timeoutSeconds: 10
-              periodSeconds: 15
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 15
           resources:
             limits:
               cpu: 400m
@@ -88,17 +86,16 @@ spec:
               mountPath: C:\csi
             - name: mountpoint-dir
               mountPath: "C:\\var\\lib\\kubelet\\pods"
-              mountPropagation: Bidirectional
             - name: providers-dir
               mountPath: C:\k\secrets-store-csi-providers
         - name: liveness-probe
           image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
           imagePullPolicy: IfNotPresent
           args:
-          - "--csi-address=unix://C:\\csi\\csi.sock"
-          - --probe-timeout=3s
-          - --http-endpoint=0.0.0.0:9808
-          - -v=2
+            - "--csi-address=unix://C:\\csi\\csi.sock"
+            - --probe-timeout=3s
+            - --http-endpoint=0.0.0.0:9808
+            - -v=2
           volumeMounts:
             - name: plugin-dir
               mountPath: C:\csi

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -122,7 +122,6 @@ spec:
               mountPath: C:\csi
             - name: mountpoint-dir
               mountPath: {{ .Values.windows.kubeletRootDir }}\pods
-              mountPropagation: Bidirectional
             - name: providers-dir
               mountPath: C:\k\secrets-store-csi-providers
             {{- if .Values.windows.volumeMounts }}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -103,8 +103,6 @@ spec:
                 apiVersion: v1
                 fieldPath: spec.nodeName
           imagePullPolicy: {{ .Values.windows.image.pullPolicy }}
-          securityContext:
-            privileged: true
           {{- if semverCompare ">= v0.0.9-0" .Values.windows.image.tag }}
           ports:
             - containerPort: {{ .Values.livenessProbe.port }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Secrets store driver pods do not run properly on Windows nodes due to incompatibility with specific attributes.

**Which issue(s) this PR fixes** 
Fixes #624 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
