### PR TITLE
helm: move default annotations out of conditional

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -17,11 +17,11 @@ spec:
 {{ toYaml .Values.windows.updateStrategy | indent 4 }}
   template:
     metadata:
-    {{- if .Values.windows.podAnnotations }}
       annotations:
         kubectl.kubernetes.io/default-logs-container: secrets-store
+{{- if .Values.windows.podAnnotations }}
 {{ toYaml .Values.windows.podAnnotations | indent 8 }}
-    {{- end }}
+{{- end }}
 {{ include "sscd.labels" . | indent 6 }}
 {{- if .Values.windows.podLabels }}
 {{- toYaml .Values.windows.podLabels | nindent 8 }}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -17,11 +17,11 @@ spec:
 {{ toYaml .Values.linux.updateStrategy | indent 4 }}
   template:
     metadata:
-    {{- if .Values.linux.podAnnotations }}
       annotations:
         kubectl.kubernetes.io/default-logs-container: secrets-store
+{{- if .Values.linux.podAnnotations }}
 {{ toYaml .Values.linux.podAnnotations | indent 8 }}
-    {{- end }}
+{{- end }}
 {{ include "sscd.labels" . | indent 6 }}
 {{- if .Values.linux.podLabels }}
 {{- toYaml .Values.linux.podLabels | nindent 8 }}


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
Move the default container annotation out of the conditional.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
