### PR TITLE
chore: revert changes from deploy and add to manifest_staging

### DIFF
--- a/deploy/secrets-store-csi-driver-windows.yaml
+++ b/deploy/secrets-store-csi-driver-windows.yaml
@@ -62,6 +62,8 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
           imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
           ports:
             - containerPort: 9808
               name: healthz
@@ -86,6 +88,7 @@ spec:
               mountPath: C:\csi
             - name: mountpoint-dir
               mountPath: "C:\\var\\lib\\kubelet\\pods"
+              mountPropagation: Bidirectional
             - name: providers-dir
               mountPath: C:\k\secrets-store-csi-providers
         - name: liveness-probe

--- a/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
@@ -62,8 +62,6 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
           imagePullPolicy: IfNotPresent
-          securityContext:
-            privileged: true
           ports:
             - containerPort: 9808
               name: healthz
@@ -88,7 +86,6 @@ spec:
               mountPath: C:\csi
             - name: mountpoint-dir
               mountPath: "C:\\var\\lib\\kubelet\\pods"
-              mountPropagation: Bidirectional
             - name: providers-dir
               mountPath: C:\k\secrets-store-csi-providers
         - name: liveness-probe


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/625 removed securityContext from deploy folder. Adding it back and making the change in `manifest_staging` folder so we can promote during release. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
