### PR TITLE
move cleanup of eks cluster to cleanup_file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,10 +375,6 @@ e2e-helm-deploy-release:
 e2e-kind-cleanup:
 	kind delete cluster --name kind
 
-.PHONY: e2e-eks-cleanup
-e2e-eks-cleanup: 
-	eksctl delete cluster --name $(EKS_CLUSTER_NAME) --region $(AWS_REGION)
-
 .PHONY: e2e-azure
 e2e-azure: $(AZURE_CLI)
 	bats -t test/bats/azure.bats
@@ -393,7 +389,7 @@ e2e-gcp:
 
 .PHONY: e2e-aws
 e2e-aws:
-	bats -t test/bats/aws.bats
+	EKS_CLUSTER_NAME='$(EKS_CLUSTER_NAME)' bats -t test/bats/aws.bats
 	
 ## --------------------------------------
 ## Generate

--- a/test/bats/aws.bats
+++ b/test/bats/aws.bats
@@ -15,6 +15,8 @@ BATS_TEST_DIR=test/bats/tests/aws
 if [ -z "$UUID" ]; then 
    export UUID=secret-$(openssl rand -hex 6) 
 fi 
+echo "Running aws tests" >&2
+echo $EKS_CLUSTER_NAME >&2
 
 export SM_TEST_1_NAME=SecretsManagerTest1-$UUID 
 export SM_TEST_2_NAME=SecretsManagerTest2-$UUID 
@@ -39,6 +41,12 @@ setup_file() {
 }
 
 teardown_file() {
+    echo "teardown" >&2
+
+    eksctl delete cluster \
+        --name $EKS_CLUSTER_NAME \
+        --region $REGION
+
     aws secretsmanager delete-secret --secret-id $SM_TEST_1_NAME --force-delete-without-recovery --region $REGION
     aws secretsmanager delete-secret --secret-id $SM_TEST_2_NAME --force-delete-without-recovery --region $REGION
     aws secretsmanager delete-secret --secret-id $SM_SYNC_NAME --force-delete-without-recovery --region $REGION


### PR DESCRIPTION
**What this PR does / why we need it**:

To ensure cleanup of eks cluster happens regardless of the tests pass or fail 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/634

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
