### PR TITLE
test: gcp use workload id instead of node publish

### DIFF
--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -5,7 +5,7 @@ load helpers
 BATS_TESTS_DIR=test/bats/tests/azure
 WAIT_TIME=60
 SLEEP_TIME=1
-NAMESPACE=default
+NAMESPACE=kube-system
 PROVIDER_YAML=https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/deployment/provider-azure-installer.yaml
 NODE_SELECTOR_OS=linux
 BASE64_FLAGS="-w 0"
@@ -419,6 +419,7 @@ setup() {
 }
 
 teardown_file() {
+  archive_provider "app=csi-secrets-store-provider-azure" || true
   archive_info || true
 
   #cleanup

--- a/test/bats/gcp.bats
+++ b/test/bats/gcp.bats
@@ -14,13 +14,6 @@ export RESOURCE_NAME=${RESOURCE_NAME:-"projects/735463103342/secrets/test-secret
 export FILE_NAME=${FILE_NAME:-"secret"}
 export SECRET_VALUE=${SECRET_VALUE:-"aHVudGVyMg=="}
 
-setup() {
-  if [[ -z "${GCP_SA_JSON}" ]]; then
-    echo "Error: GCP Service Account (GCP_SA_JSON) is not provided" >&2
-    return 1
-  fi
-}
-
 @test "install gcp provider" {	
   run kubectl apply -f $PROVIDER_YAML --namespace $PROVIDER_NAMESPACE
   assert_success	
@@ -30,15 +23,6 @@ setup() {
   GCP_PROVIDER_POD=$(kubectl get pod --namespace $PROVIDER_NAMESPACE -l app=csi-secrets-store-provider-gcp -o jsonpath="{.items[0].metadata.name}")	
 
   run kubectl get pod/$GCP_PROVIDER_POD --namespace $PROVIDER_NAMESPACE
-  assert_success
-}
-
-@test "create gcp k8s secret for provider auth" {
-  run kubectl create secret generic secrets-store-creds --namespace $NAMESPACE --from-literal=key.json="${GCP_SA_JSON}"
-  assert_success
-
-  # label the node publish secret ref secret
-  run kubectl label secret secrets-store-creds secrets-store.csi.k8s.io/used=true
   assert_success
 }
 
@@ -117,25 +101,7 @@ setup() {
   assert_failure
 }
 
-@test "Test filtered-watch-secret=false for nodePublishSecretRef" {
-  run helm upgrade csi-secrets-store manifest_staging/charts/secrets-store-csi-driver --reuse-values --set filteredWatchSecret=false --wait --timeout=5m -v=5 --debug --namespace kube-system
-  assert_success
-
-  kubectl create ns non-filtered-watch
-  kubectl create secret generic secrets-store-creds --from-literal=key.json="${GCP_SA_JSON}" -n non-filtered-watch
-
-  envsubst < $BATS_TESTS_DIR/gcp_v1alpha1_secretproviderclass.yaml | kubectl apply -n non-filtered-watch -f -
-  envsubst < $BATS_TESTS_DIR/pod-secrets-store-inline-volume-crd.yaml | kubectl apply -n non-filtered-watch -f -
-
-  kubectl wait -n non-filtered-watch --for=condition=Ready --timeout=60s pod/secrets-store-inline-crd
-
-  run kubectl get pod/secrets-store-inline-crd -n non-filtered-watch
-  assert_success
-
-  result=$(kubectl exec -n non-filtered-watch secrets-store-inline-crd -- cat /mnt/secrets-store/$FILE_NAME)
-  [[ "${result//$'\r'}" == "${SECRET_VALUE}" ]]
-}
-
 teardown_file() {
+  archive_provider "app=csi-secrets-store-provider-gcp" || true
   archive_info || true
 }

--- a/test/bats/helpers.bash
+++ b/test/bats/helpers.bash
@@ -81,6 +81,21 @@ check_secret_deleted() {
   [[ "$result" -eq 0 ]]
 }
 
+# Usage:
+#
+# archive_provider "<pod label selector>"
+#
+# provider pod must be in kube-system
+archive_provider() {
+  if [[ -z "${ARTIFACTS}" ]]; then
+    return 0
+  fi
+
+  FILE_PREFIX=$(date +"%FT%H%M%S")
+
+  kubectl logs -l $1 --tail -1 -n kube-system > ${ARTIFACTS}/${FILE_PREFIX}-provider.logs
+}
+
 archive_info() {
   if [[ -z "${ARTIFACTS}" ]]; then
     return 0

--- a/test/bats/tests/gcp/gcp_v1alpha1_secretproviderclass.yaml
+++ b/test/bats/tests/gcp/gcp_v1alpha1_secretproviderclass.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   provider: gcp
   parameters:
+    auth: provider-adc
     secrets: |
       - resourceName: $RESOURCE_NAME
         fileName: $FILE_NAME

--- a/test/bats/tests/gcp/pod-secrets-store-inline-volume-crd.yaml
+++ b/test/bats/tests/gcp/pod-secrets-store-inline-volume-crd.yaml
@@ -22,5 +22,3 @@ spec:
         readOnly: true
         volumeAttributes:
           secretProviderClass: "gcp"
-        nodePublishSecretRef:
-          name: secrets-store-creds


### PR DESCRIPTION
**What this PR does / why we need it**:

Update GCP tests to use workload identity in the secret mount (provided through prow).

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #640 and #507

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
