### PR TITLE
docs: adds note about crd upgrade

### DIFF
--- a/docs/book/src/getting-started/upgrades.md
+++ b/docs/book/src/getting-started/upgrades.md
@@ -1,6 +1,7 @@
 # Upgrades
 
 This page includes instructions for upgrading the driver to the latest version.
+
 >**NOTE**: CRDs are moved to `crds` directory. Helm hooks are added to `pre-install` and `pre-upgrade` crds. This hook pod will only run on _linux_ nodes.
 
 ```bash

--- a/docs/book/src/getting-started/upgrades.md
+++ b/docs/book/src/getting-started/upgrades.md
@@ -1,6 +1,7 @@
 # Upgrades
 
 This page includes instructions for upgrading the driver to the latest version.
+>**NOTE**: CRDs are moved to `crds` directory. Helm hooks are added to `pre-install` and `pre-upgrade` crds. This hook pod will only run on _linux_ nodes.
 
 ```bash
 helm upgrade csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver --namespace=NAMESPACE

--- a/docs/book/src/getting-started/upgrades.md
+++ b/docs/book/src/getting-started/upgrades.md
@@ -2,7 +2,7 @@
 
 This page includes instructions for upgrading the driver to the latest version.
 
->**NOTE**: CRDs are moved to `crds` directory. Helm hooks are added to `pre-install` and `pre-upgrade` crds. This hook pod will only run on _linux_ nodes.
+>**NOTE**: [CustomResourceDefinitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (CRDs) have been moved from `templates` to `crds` directory in the helm charts. To manage the lifecycle of the CRDs during install/upgrade, helm `pre-install` and `pre-upgrade` hook has been added. This hook will create a pod that runs only on **linux** nodes and deploys the CRDs in the Kubernetes cluster.
 
 ```bash
 helm upgrade csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver --namespace=NAMESPACE


### PR DESCRIPTION
Signed-off-by: Nilekh Chaudhari <1626598+nilekhc@users.noreply.github.com>

**What this PR does / why we need it**:

Adds note about handling CRDs install and upgrade via helm. 
Ref https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/623#pullrequestreview-710930824

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
