### PR TITLE
chore: switch to using distroless base image for driver-crds

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -1,8 +1,9 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 
 # this must be specified in seconds. If omitted, defaults to 600s (10 mins)
-# setting it to 3600s to accommodate multi-os image builds.
-timeout: 3600s
+# setting it to 5400s to accommodate multi-os image builds for driver and
+# multi-arch build for driver-crds.
+timeout: 5400s
 # this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:

--- a/docker/crd.Dockerfile
+++ b/docker/crd.Dockerfile
@@ -1,2 +1,12 @@
-FROM bitnami/kubectl:1.21.2
+FROM alpine as builder
+ARG KUBE_VERSION=v1.21.2
+ARG ARCH
+
+RUN apk add --no-cache curl && \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/${ARCH}/kubectl && \
+    chmod +x kubectl
+
+FROM gcr.io/distroless/static
 COPY * /crds/
+COPY --from=builder /kubectl /kubectl
+ENTRYPOINT ["/kubectl"]

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
@@ -53,11 +53,10 @@ spec:
   containers:
     - name: crds-upgrade
       image: "{{ .Values.linux.crds.image.repository }}:{{ .Values.linux.crds.image.tag }}"
-      command:
-      - sh
-      - -c
-      - >
-       kubectl apply -f /crds;
+      args:
+      - apply
+      - -f
+      - crds/
       imagePullPolicy: {{ .Values.linux.crds.image.pullPolicy }}
   {{- if .Values.imagePullSecrets }}
   imagePullSecrets:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
Switches to using scratch base image for the driver-crds. The entrypoint is set to kubectl to prevent shell access. Enabled image scan for the `driver-crds` image.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
