### PR TITLE
chore: switch to using manifest_staging charts in the build

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -107,11 +107,12 @@ build_and_push() {
       -f "${dockerfile_name}" ..
 
     # Build and push crd image
-    # We always promote to prod from stg registry. So, Check if 'crd' dir from 'charts' exists rather than from 'manifest_staging' dir.
-    if find ../charts/secrets-store-csi-driver/crds -mindepth 1 -maxdepth 1 | read -r; then
+    # The image build is done before the charts are promoted. After image is built, the next step is to promote
+    # charts to prod dir. So we can use manifest_staging charts for the image build.
+    if find ../manifest_staging/charts/secrets-store-csi-driver/crds -mindepth 1 -maxdepth 1 | read -r; then
       if [[ "$os_name" != "windows" ]]; then
         docker buildx build --no-cache --pull --push --platform "${os_name}/${arch}" -t "${CRD_IMAGE_TAG}-${suffix}" \
-        -f crd.Dockerfile ../charts/secrets-store-csi-driver/crds
+        -f crd.Dockerfile ../manifest_staging/charts/secrets-store-csi-driver/crds
       fi
     fi
   done

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -99,7 +99,7 @@ setup() {
 @test "CSI inline volume test with pod portability" {
   envsubst < $BATS_TESTS_DIR/pod-secrets-store-inline-volume-crd.yaml | kubectl apply -f -
   
-  kubectl wait --for=condition=Ready --timeout=60s pod/secrets-store-inline-crd
+  kubectl wait --for=condition=Ready --timeout=180s pod/secrets-store-inline-crd
 
   run kubectl get pod/secrets-store-inline-crd
   assert_success
@@ -409,7 +409,7 @@ setup() {
   envsubst < $BATS_TESTS_DIR/azure_v1alpha1_secretproviderclass.yaml | kubectl apply -n non-filtered-watch -f -
   envsubst < $BATS_TESTS_DIR/pod-secrets-store-inline-volume-crd.yaml | kubectl apply -n non-filtered-watch -f -
 
-  kubectl wait -n non-filtered-watch --for=condition=Ready --timeout=60s pod/secrets-store-inline-crd
+  kubectl wait -n non-filtered-watch --for=condition=Ready --timeout=180s pod/secrets-store-inline-crd
 
   run kubectl get pod/secrets-store-inline-crd -n non-filtered-watch
   assert_success


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
The staging charts dir are promoted to charts only after image is built. So we should use the manifest_staging charts for building the crds image.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
