### PR TITLE
feat: add keep-crd upgrade hook

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/templates/keep-crds-upgrade-hook.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/keep-crds-upgrade-hook.yaml
@@ -1,71 +1,74 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "sscd.fullname" . }}-upgrade-crds
+  name: {{ template "sscd.fullname" . }}-keep-crds
 {{ include "sscd.labels" . | indent 2 }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook: pre-upgrade
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
-    helm.sh/hook-weight: "1"
+    helm.sh/hook-weight: "2"
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["get", "create", "update", "patch"]
+    verbs: ["get", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "sscd.fullname" . }}-upgrade-crds
+  name: {{ template "sscd.fullname" . }}-keep-crds
 {{ include "sscd.labels" . | indent 2 }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook: pre-upgrade
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
-    helm.sh/hook-weight: "1"
+    helm.sh/hook-weight: "2"
 subjects:
   - kind: ServiceAccount
-    name: {{ template "sscd.fullname" . }}-upgrade-crds
+    name: {{ template "sscd.fullname" . }}-keep-crds
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ template "sscd.fullname" . }}-upgrade-crds
+  name: {{ template "sscd.fullname" . }}-keep-crds
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "sscd.fullname" . }}-upgrade-crds
-  namespace: {{ .Release.Namespace }}
-{{ include "sscd.labels" . | indent 2 }}
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
-    helm.sh/hook-weight: "1"
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: {{ template "sscd.fullname" . }}-upgrade-crds
+  name: {{ template "sscd.fullname" . }}-keep-crds
   namespace: {{ .Release.Namespace }}
 {{ include "sscd.labels" . | indent 2 }}
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
+    helm.sh/hook-weight: "2"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "sscd.fullname" . }}-keep-crds
+  namespace: {{ .Release.Namespace }}
+{{ include "sscd.labels" . | indent 2 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "2"
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
 spec:
   backoffLimit: 0
   template:
     metadata:
-      name: {{ template "sscd.fullname" . }}-upgrade-crds
+      name: {{ template "sscd.fullname" . }}-keep-crds
     spec:
-      serviceAccountName: {{ template "sscd.fullname" . }}-upgrade-crds
+      serviceAccountName: {{ template "sscd.fullname" . }}-keep-crds
       restartPolicy: Never
       containers:
-      - name: crds-upgrade
+      - name: crds-keep
         image: "{{ .Values.linux.crds.image.repository }}:{{ .Values.linux.crds.image.tag }}"
         args:
-        - apply
-        - -f
-        - crds/
+        - patch
+        - crd
+        - secretproviderclasses.secrets-store.csi.x-k8s.io
+        - secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io
+        - -p
+        - '{"metadata":{"annotations": {"helm.sh/resource-policy": "keep"}}}'
         imagePullPolicy: {{ .Values.linux.crds.image.pullPolicy }}
       nodeSelector:
         kubernetes.io/os: linux

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -403,6 +403,12 @@ setup() {
   run helm upgrade csi-secrets-store "${chart_dir}" --reuse-values --set filteredWatchSecret=false --wait --timeout=5m -v=5 --debug --namespace kube-system
   assert_success
 
+  cmd="kubectl get crd secretproviderclasses.secrets-store.csi.x-k8s.io -o yaml | grep 'helm.sh/resource-policy: keep'"
+  wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
+
+  cmd="kubectl get crd secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io -o yaml | grep 'helm.sh/resource-policy: keep'"
+  wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
+
   kubectl create ns non-filtered-watch
   kubectl create secret generic secrets-store-creds --from-literal clientid=${AZURE_CLIENT_ID} --from-literal clientsecret=${AZURE_CLIENT_SECRET} -n non-filtered-watch
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
The crds have been moved from the templates/ to crds/ folder. When helm upgrade is run, helm will delete the crds because they're no longer in the generated template. To prevent deletion, we patch the 2 CRDs with the "helm.sh/resource-policy": "keep". Helm will skip deletion of resources with these annotation. Also, converted the hooks to a job as helm kills the pod before kubectl exec is run. With job, helm waits until the pod is run and reaches completion.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
