### PR TITLE
e2e: add driver-crd image to e2e-helm-upgrade target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,8 +388,9 @@ e2e-helm-upgrade:
 		--set linux.image.repository=$(REGISTRY)/$(IMAGE_NAME) \
 		--set linux.image.tag=$(IMAGE_VERSION) \
 		--set windows.image.repository=$(REGISTRY)/$(IMAGE_NAME) \
-		--set windows.image.tag=$(IMAGE_VERSION)
-	kubectl apply -f manifest_staging/charts/secrets-store-csi-driver/crds/
+		--set windows.image.tag=$(IMAGE_VERSION) \
+		--set linux.crds.image.repository=$(REGISTRY)/$(CRD_IMAGE_NAME) \
+		--set linux.crds.image.tag=$(IMAGE_VERSION)
 
 .PHONY: e2e-helm-deploy-release # test helm package for the release
 e2e-helm-deploy-release:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- This fixes the upgrade test failure: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-secrets-store-csi-driver-upgrade-test-azure/1418269724701102080
- Should also help us catch the issue with https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/656

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
