### PR TITLE
test: use kubectl exec instead of cp

### DIFF
--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -363,12 +363,8 @@ setup() {
 }
 
 @test "Test auto rotation of mount contents and K8s secrets" {
-  run kubectl cp -n rotation secrets-store-inline-rotation:/mnt/secrets-store/secretalias $BATS_TMPDIR/before_rotation
-  assert_success
-
-  result=$(cat $BATS_TMPDIR/before_rotation)
+  result=$(kubectl exec -n rotation secrets-store-inline-rotation -- cat /mnt/secrets-store/secretalias)
   [[ "${result//$'\r'}" == "secret" ]]
-  rm $BATS_TMPDIR/before_rotation
 
   result=$(kubectl get secret -n rotation rotationsecret -o jsonpath="{.data.username}" | base64 -d)
   [[ "${result//$'\r'}" == "secret" ]]
@@ -378,12 +374,8 @@ setup() {
 
   sleep 60
 
-  run kubectl cp -n rotation secrets-store-inline-rotation:/mnt/secrets-store/secretalias $BATS_TMPDIR/after_rotation
-  assert_success
-
-  result=$(cat $BATS_TMPDIR/after_rotation)
+  result=$(kubectl exec -n rotation secrets-store-inline-rotation -- cat /mnt/secrets-store/secretalias)
   [[ "${result//$'\r'}" == "rotated" ]]
-  rm $BATS_TMPDIR/after_rotation
 
   result=$(kubectl get secret -n rotation rotationsecret -o jsonpath="{.data.username}" | base64 -d)
   [[ "${result//$'\r'}" == "rotated" ]]


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Using `kubectl exec` output instead of `kubectl cp`. `kubectl cp` for symlinks fails with the error:
```bash
warning: skipping symlink: "here" -> "..data/secretalias" (consider using "kubectl exec -n "" "secrets-store-inline-rotation" -- tar cf - "/mnt/secrets-store/secretalias/" | tar xf -")
```

Ref: https://github.com/kubernetes/kubernetes/issues/78211

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #663 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
