### PR TITLE
docs: update load test doc for filtered watch secret

### DIFF
--- a/docs/book/src/load-tests.md
+++ b/docs/book/src/load-tests.md
@@ -63,5 +63,5 @@ If the secret rotation feature is enabled and filtered secret watch is not enabl
 1. Label all existing `nodePublishSecretRef` secrets with `secrets-store.csi.k8s.io/used=true` by running `kubectl label secret <node publish secret ref name> secrets-store.csi.k8s.io/used=true`.
 2. Enable filtered secret watch by setting `--filtered-watch-secret=true` in `secrets-store` container or via helm using `--set filteredWatchSecret=true`.
 
-**NOTE:** `--filtered-watch-secret=true` will be enabled by default in n+3 releases (`v0.0.25`). Please take the necessary action to label the `nodePublishSecretRef` secrets with the `secrets-store.csi.k8s.io/used=true` label.
+**NOTE:** `--filtered-watch-secret=true` is enabled by default in [v0.1.0](https://github.com/kubernetes-sigs/secrets-store-csi-driver/releases/tag/v0.1.0) release. Please take the necessary action to label the `nodePublishSecretRef` secrets with the `secrets-store.csi.k8s.io/used=true` label before upgrade.
 </aside>


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
Updating the document to mention `--filtered-watch-secret` is now enabled by default in `v0.1.0`

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
