### PR TITLE
test: adds make target for deploy manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,7 @@ e2e-deploy-manifest:
 
 	yq e '(.spec.template.spec.containers[1].image = "$(IMAGE_TAG)") | (.spec.template.spec.containers[1].args as $$x | $$x += "--enable-secret-rotation=true" | $$x[-1] style="double") | (.spec.template.spec.containers[1].args as $$x | $$x += "--rotation-poll-interval=30s" | $$x[-1] style="double")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
 
-	yq e '(.spec.template.spec.containers[1].args as $$x | $$x += "--enable-secret-rotation=true" | $$x[-1] style="double") | (.spec.template.spec.containers[1].args as $$x | $$x += "--rotation-poll-interval=30s" | $$x[-1] style="double")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
+	yq e '(.spec.template.spec.containers[1].args as $$x | $$x += "--enable-secret-rotation=true" | $$x[-1] style="double") | (.spec.template.spec.containers[1].args as $$x | $$x += "--rotation-poll-interval=30s" | $$x[-1] style="double")' 'manifest_staging/deploy/secrets-store-csi-driver-windows.yaml' | kubectl apply -f -
 
 .PHONY: e2e-helm-deploy
 e2e-helm-deploy:

--- a/Makefile
+++ b/Makefile
@@ -379,10 +379,6 @@ e2e-deploy-manifest:
 	kubectl apply -f manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
 	kubectl apply -f manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
 
-	# yq e '(.spec.template.spec.containers[1].image = "$(IMAGE_TAG)") | (.spec.template.spec.containers[1].args[4] = "--enable-secret-rotation=true") | (.spec.template.spec.containers[1].args[5] = "--rotation-poll-interval=30s")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
-
-	# yq e '(.spec.template.spec.containers[1].args[4] = "--enable-secret-rotation=true") | (.spec.template.spec.containers[1].args[5] = "--rotation-poll-interval=30s")' 'manifest_staging/deploy/secrets-store-csi-driver-windows.yaml' | kubectl apply -f -
-
 	yq e '(.spec.template.spec.containers[1].image = "$(IMAGE_TAG)") | (.spec.template.spec.containers[1].args as $$x | $$x += "--enable-secret-rotation=true" | $$x[-1] style="double") | (.spec.template.spec.containers[1].args as $$x | $$x += "--rotation-poll-interval=30s" | $$x[-1] style="double")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
 
 	yq e '(.spec.template.spec.containers[1].args as $$x | $$x += "--enable-secret-rotation=true" | $$x[-1] style="double") | (.spec.template.spec.containers[1].args as $$x | $$x += "--rotation-poll-interval=30s" | $$x[-1] style="double")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -

--- a/Makefile
+++ b/Makefile
@@ -365,6 +365,18 @@ e2e-test: e2e-bootstrap e2e-helm-deploy # run test for windows
 e2e-teardown: $(HELM)
 	helm delete csi-secrets-store --namespace kube-system
 
+.PHONY: e2e-deploy-manifest
+e2e-deploy-manifest:
+	kubectl apply -f manifest_staging/deploy/csidriver.yaml
+	kubectl apply -f manifest_staging/deploy/rbac-secretproviderclass.yaml
+	kubectl apply -f manifest_staging/deploy/rbac-secretproviderrotation.yaml
+	kubectl apply -f manifest_staging/deploy/rbac-secretprovidersyncing.yaml
+	kubectl apply -f manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
+	kubectl apply -f manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+	kubectl apply -f manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+
+	yq e '.spec.template.spec.containers[1].image = "$(IMAGE_TAG)"' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
+
 .PHONY: e2e-helm-deploy
 e2e-helm-deploy:
 	helm install csi-secrets-store manifest_staging/charts/secrets-store-csi-driver --namespace kube-system --wait --timeout=5m -v=5 --debug \

--- a/Makefile
+++ b/Makefile
@@ -379,9 +379,13 @@ e2e-deploy-manifest:
 	kubectl apply -f manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
 	kubectl apply -f manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
 
-	yq e '(.spec.template.spec.containers[1].image = "$(IMAGE_TAG)") | (.spec.template.spec.containers[1].args[4] = "--enable-secret-rotation=true") | (.spec.template.spec.containers[1].args[5] = "--rotation-poll-interval=30s")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
+	# yq e '(.spec.template.spec.containers[1].image = "$(IMAGE_TAG)") | (.spec.template.spec.containers[1].args[4] = "--enable-secret-rotation=true") | (.spec.template.spec.containers[1].args[5] = "--rotation-poll-interval=30s")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
 
-	yq e '(.spec.template.spec.containers[1].args[4] = "--enable-secret-rotation=true") | (.spec.template.spec.containers[1].args[5] = "--rotation-poll-interval=30s")' 'manifest_staging/deploy/secrets-store-csi-driver-windows.yaml' | kubectl apply -f -
+	# yq e '(.spec.template.spec.containers[1].args[4] = "--enable-secret-rotation=true") | (.spec.template.spec.containers[1].args[5] = "--rotation-poll-interval=30s")' 'manifest_staging/deploy/secrets-store-csi-driver-windows.yaml' | kubectl apply -f -
+
+	yq e '(.spec.template.spec.containers[1].image = "$(IMAGE_TAG)") | (.spec.template.spec.containers[1].args as $x | $x += "--enable-secret-rotation=true" | $x[-1] style="double") | (.spec.template.spec.containers[1].args as $x | $x += "--rotation-poll-interval=30s" | $x[-1] style="double")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
+
+	yq e '(.spec.template.spec.containers[1].args as $x | $x += "--enable-secret-rotation=true" | $x[-1] style="double") | (.spec.template.spec.containers[1].args as $x | $x += "--rotation-poll-interval=30s" | $x[-1] style="double")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
 
 .PHONY: e2e-helm-deploy
 e2e-helm-deploy:

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ ENVSUBST := envsubst
 SHELLCHECK := $(TOOLS_BIN_DIR)/shellcheck-$(SHELLCHECK_VER)
 EKSCTL := eksctl
 AWS_CLI := aws
+YQ := yq
 
 # Test variables
 KIND_VERSION ?= 0.11.0
@@ -96,6 +97,7 @@ BATS_VERSION ?= 1.2.1
 TRIVY_VERSION ?= 0.14.0
 PROTOC_VERSION ?= 3.15.2
 SHELLCHECK_VER ?= v0.7.2
+YQ_VERSION ?= v4.11.2
 
 # For aws integration tests 
 BUILD_TIMESTAMP_W_SEC := $(shell date +%Y-%m-%d-%H-%M-%S)
@@ -200,6 +202,9 @@ $(ENVSUBST): ## Install envsubst for running the tests
 
 $(PROTOC): ## Install protoc
 	curl -sSLO https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip bin/protoc -d $(TOOLS_BIN_DIR) && rm protoc-${PROTOC_VERSION}-linux-x86_64.zip 
+
+$(YQ): ## Install yq for running the tests
+	curl -LO https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_linux_amd64 && chmod +x ./yq_linux_amd64 && mv yq_linux_amd64 /usr/local/bin/yq
 
 $(SHELLCHECK): OS := $(shell uname | tr '[:upper:]' '[:lower:]')
 $(SHELLCHECK): ARCH := $(shell uname -m)
@@ -331,7 +336,7 @@ push-manifest:
 ## E2E Testing
 ## --------------------------------------
 .PHONY: e2e-bootstrap
-e2e-bootstrap: $(HELM) $(BATS) $(KIND) $(KUBECTL) $(ENVSUBST) #setup all required binaries and kind cluster for testing
+e2e-bootstrap: $(HELM) $(BATS) $(KIND) $(KUBECTL) $(ENVSUBST) $(YQ) #setup all required binaries and kind cluster for testing
 ifndef TEST_WINDOWS
 	$(MAKE) setup-kind
 endif

--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,7 @@ setup-kind: $(KIND)
 	kind create cluster --image kindest/node:v$(KUBERNETES_VERSION)
 
 .PHONY: setup-eks-cluster
-setup-eks-cluster: $(HELM) $(EKSCTL) $(BATS) $(ENVSUBST)
+setup-eks-cluster: $(HELM) $(EKSCTL) $(BATS) $(ENVSUBST) $(YQ)
 	bash test/scripts/initialize_eks_cluster.bash $(EKS_CLUSTER_NAME) $(IMAGE_VERSION)  
 
 .PHONY: e2e-container

--- a/Makefile
+++ b/Makefile
@@ -377,11 +377,12 @@ e2e-helm-deploy:
 	kubectl apply -f manifest_staging/deploy/rbac-secretproviderclass.yaml
 	kubectl apply -f manifest_staging/deploy/rbac-secretproviderrotation.yaml
 	kubectl apply -f manifest_staging/deploy/rbac-secretprovidersyncing.yaml
-	kubectl apply -f manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
 	kubectl apply -f manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
 	kubectl apply -f manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
 
 	yq e '(.spec.template.spec.containers[1].image = "$(IMAGE_TAG)") | (.spec.template.spec.containers[1].args[4] = "--enable-secret-rotation=true") | (.spec.template.spec.containers[1].args[5] = "--rotation-poll-interval=30s")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
+
+	yq e '(.spec.template.spec.containers[1].args[4] = "--enable-secret-rotation=true") | (.spec.template.spec.containers[1].args[5] = "--rotation-poll-interval=30s")' 'manifest_staging/deploy/secrets-store-csi-driver-windows.yaml' | kubectl apply -f -
 
 .PHONY: e2e-deploy-manifest
 e2e-deploy-manifest:

--- a/Makefile
+++ b/Makefile
@@ -370,9 +370,8 @@ e2e-test: e2e-bootstrap e2e-helm-deploy # run test for windows
 e2e-teardown: $(HELM)
 	helm delete csi-secrets-store --namespace kube-system
 
-export IS_YAML_TEST = true
-.PHONY: e2e-helm-deploy
-e2e-helm-deploy:
+.PHONY: e2e-deploy-manifest
+e2e-deploy-manifest:
 	kubectl apply -f manifest_staging/deploy/csidriver.yaml
 	kubectl apply -f manifest_staging/deploy/rbac-secretproviderclass.yaml
 	kubectl apply -f manifest_staging/deploy/rbac-secretproviderrotation.yaml
@@ -384,8 +383,8 @@ e2e-helm-deploy:
 
 	yq e '(.spec.template.spec.containers[1].args[4] = "--enable-secret-rotation=true") | (.spec.template.spec.containers[1].args[5] = "--rotation-poll-interval=30s")' 'manifest_staging/deploy/secrets-store-csi-driver-windows.yaml' | kubectl apply -f -
 
-.PHONY: e2e-deploy-manifest
-e2e-deploy-manifest:
+.PHONY: e2e-helm-deploy
+e2e-helm-deploy:
 	helm install csi-secrets-store manifest_staging/charts/secrets-store-csi-driver --namespace kube-system --wait --timeout=5m -v=5 --debug \
 		--set linux.image.pullPolicy="IfNotPresent" \
 		--set windows.image.pullPolicy="IfNotPresent" \

--- a/Makefile
+++ b/Makefile
@@ -383,9 +383,9 @@ e2e-deploy-manifest:
 
 	# yq e '(.spec.template.spec.containers[1].args[4] = "--enable-secret-rotation=true") | (.spec.template.spec.containers[1].args[5] = "--rotation-poll-interval=30s")' 'manifest_staging/deploy/secrets-store-csi-driver-windows.yaml' | kubectl apply -f -
 
-	yq e '(.spec.template.spec.containers[1].image = "$(IMAGE_TAG)") | (.spec.template.spec.containers[1].args as $x | $x += "--enable-secret-rotation=true" | $x[-1] style="double") | (.spec.template.spec.containers[1].args as $x | $x += "--rotation-poll-interval=30s" | $x[-1] style="double")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
+	yq e '(.spec.template.spec.containers[1].image = "$(IMAGE_TAG)") | (.spec.template.spec.containers[1].args as $$x | $$x += "--enable-secret-rotation=true" | $$x[-1] style="double") | (.spec.template.spec.containers[1].args as $$x | $$x += "--rotation-poll-interval=30s" | $$x[-1] style="double")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
 
-	yq e '(.spec.template.spec.containers[1].args as $x | $x += "--enable-secret-rotation=true" | $x[-1] style="double") | (.spec.template.spec.containers[1].args as $x | $x += "--rotation-poll-interval=30s" | $x[-1] style="double")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
+	yq e '(.spec.template.spec.containers[1].args as $$x | $$x += "--enable-secret-rotation=true" | $$x[-1] style="double") | (.spec.template.spec.containers[1].args as $$x | $$x += "--rotation-poll-interval=30s" | $$x[-1] style="double")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
 
 .PHONY: e2e-helm-deploy
 e2e-helm-deploy:

--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,7 @@ e2e-helm-deploy:
 	kubectl apply -f manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
 	kubectl apply -f manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
 
-	yq e '.spec.template.spec.containers[1].image = "$(IMAGE_TAG)"' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
+	yq e '(.spec.template.spec.containers[1].image = "$(IMAGE_TAG)") | (.spec.template.spec.containers[1].args[4] = "--enable-secret-rotation=true") | (.spec.template.spec.containers[1].args[5] = "--rotation-poll-interval=30s")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
 
 .PHONY: e2e-deploy-manifest
 e2e-deploy-manifest:

--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,7 @@ e2e-teardown: $(HELM)
 	helm delete csi-secrets-store --namespace kube-system
 
 .PHONY: e2e-helm-deploy
-e2e-helm-deploy:
+e2e-helm-deploy: export IS_YAML_TEST = true
 	kubectl apply -f manifest_staging/deploy/csidriver.yaml
 	kubectl apply -f manifest_staging/deploy/rbac-secretproviderclass.yaml
 	kubectl apply -f manifest_staging/deploy/rbac-secretproviderrotation.yaml

--- a/Makefile
+++ b/Makefile
@@ -370,8 +370,9 @@ e2e-test: e2e-bootstrap e2e-helm-deploy # run test for windows
 e2e-teardown: $(HELM)
 	helm delete csi-secrets-store --namespace kube-system
 
+export IS_YAML_TEST = true
 .PHONY: e2e-helm-deploy
-e2e-helm-deploy: export IS_YAML_TEST = true
+e2e-helm-deploy:
 	kubectl apply -f manifest_staging/deploy/csidriver.yaml
 	kubectl apply -f manifest_staging/deploy/rbac-secretproviderclass.yaml
 	kubectl apply -f manifest_staging/deploy/rbac-secretproviderrotation.yaml

--- a/Makefile
+++ b/Makefile
@@ -370,8 +370,8 @@ e2e-test: e2e-bootstrap e2e-helm-deploy # run test for windows
 e2e-teardown: $(HELM)
 	helm delete csi-secrets-store --namespace kube-system
 
-.PHONY: e2e-deploy-manifest
-e2e-deploy-manifest:
+.PHONY: e2e-helm-deploy
+e2e-helm-deploy:
 	kubectl apply -f manifest_staging/deploy/csidriver.yaml
 	kubectl apply -f manifest_staging/deploy/rbac-secretproviderclass.yaml
 	kubectl apply -f manifest_staging/deploy/rbac-secretproviderrotation.yaml
@@ -382,8 +382,8 @@ e2e-deploy-manifest:
 
 	yq e '.spec.template.spec.containers[1].image = "$(IMAGE_TAG)"' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
 
-.PHONY: e2e-helm-deploy
-e2e-helm-deploy:
+.PHONY: e2e-deploy-manifest
+e2e-deploy-manifest:
 	helm install csi-secrets-store manifest_staging/charts/secrets-store-csi-driver --namespace kube-system --wait --timeout=5m -v=5 --debug \
 		--set linux.image.pullPolicy="IfNotPresent" \
 		--set windows.image.pullPolicy="IfNotPresent" \

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -22,6 +22,10 @@ if [ -z "$AUTO_ROTATE_SECRET_NAME" ]; then
     export AUTO_ROTATE_SECRET_NAME=secret-$(openssl rand -hex 6)
 fi
 
+if [ -z "$IS_YAML_TEST" ]; then
+    export IS_YAML_TEST=false
+fi
+
 export KEYVAULT_NAME=${KEYVAULT_NAME:-csi-secrets-store-e2e}
 export SECRET_NAME=${KEYVAULT_SECRET_NAME:-secret1}
 export SECRET_VERSION=${KEYVAULT_SECRET_VERSION:-""}

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -388,6 +388,10 @@ setup() {
 }
 
 @test "Test filtered-watch-secret=false for nodePublishSecretRef" {
+  if [[ "${IS_YAML_TEST}" == "true" ]]; then
+    skip "Testing with deployment manifest YAMLs"
+  fi
+
   local chart_dir=${HELM_CHART_DIR}
   if [[ "${chart_dir}" == "" ]]; then
     chart_dir=manifest_staging/charts/secrets-store-csi-driver

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -22,10 +22,6 @@ if [ -z "$AUTO_ROTATE_SECRET_NAME" ]; then
     export AUTO_ROTATE_SECRET_NAME=secret-$(openssl rand -hex 6)
 fi
 
-if [ -z "$IS_YAML_TEST" ]; then
-    export IS_YAML_TEST=false
-fi
-
 export KEYVAULT_NAME=${KEYVAULT_NAME:-csi-secrets-store-e2e}
 export SECRET_NAME=${KEYVAULT_SECRET_NAME:-secret1}
 export SECRET_VERSION=${KEYVAULT_SECRET_VERSION:-""}


### PR DESCRIPTION
Signed-off-by: Nilekh Chaudhari <1626598+nilekhc@users.noreply.github.com>

**What this PR does / why we need it**:
This PR adds e2e test on deploy manifest for Secrets Store CSI driver. Ref #297 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
