### PR TITLE
ci: add workflow for publishing helm charts

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -1,0 +1,34 @@
+name: publish_helm_chart
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - ".github/workflows/chart.yaml"
+      - "charts/**"    
+
+# List of all permissions: https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
+# We need write permission for contents to be able to publish the chart
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          fetch-depth: 0
+      - name: Publish Helm chart
+        # pinning to the sha f1701eb82e4d4b82016e7965501c8b6d79feaec9 from https://github.com/stefanprodan/helm-gh-pages/releases/tag/v1.4.1
+        uses: stefanprodan/helm-gh-pages@f1701eb82e4d4b82016e7965501c8b6d79feaec9
+        with:
+          # GitHub automatically creates a GITHUB_TOKEN secret to use in your workflow. You can use the GITHUB_TOKEN to authenticate in a workflow run.
+          # See https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: charts
+          target_dir: charts
+          linting: off

--- a/Makefile
+++ b/Makefile
@@ -506,11 +506,6 @@ promote-staging-manifest: #promote staging manifests to release dir
 	@cp -r manifest_staging/deploy .
 	@rm -rf charts/secrets-store-csi-driver
 	@cp -r manifest_staging/charts/secrets-store-csi-driver ./charts
-	@mkdir -p ./charts/tmp
-	@helm package ./charts/secrets-store-csi-driver -d ./charts/tmp/
-	@helm repo index ./charts/tmp --url https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts --merge ./charts/index.yaml
-	@mv ./charts/tmp/* ./charts
-	@rm -rf ./charts/tmp
 
 ## --------------------------------------
 ## Local


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Adds github action to package and publish helm charts on GitHub pages.
- I've created the `gh-pages` branch with the updated index for url `https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts` for all the current releases: https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/gh-pages
- Updates the `promote-staging-manifest` makefile target to remove `helm package`. The helm charts are packaged and published by the GitHub action.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #687 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
