### PR TITLE
chore: make `--filtered-watch-secret` flag no-op

### DIFF
--- a/cmd/secrets-store-csi-driver/main.go
+++ b/cmd/secrets-store-csi-driver/main.go
@@ -64,6 +64,7 @@ var (
 
 	// enable filtered watch for NodePublishSecretRef secrets. The filtering is done on the csi driver label: secrets-store.csi.k8s.io/used=true
 	// For Kubernetes secrets used to provide credentials for use with the CSI driver, set the label by running: kubectl label secret secrets-store-creds secrets-store.csi.k8s.io/used=true
+	// This feature is enabled by default starting v0.1.0 and can't be disabled starting v1.0.0 release.
 	filteredWatchSecret = flag.Bool("filtered-watch-secret", true, "enable filtered watch for NodePublishSecretRef secrets with label secrets-store.csi.k8s.io/used=true")
 
 	// Enable optional healthcheck for provider clients that exist in memory
@@ -95,8 +96,9 @@ func main() {
 			klog.ErrorS(http.ListenAndServe(addr, nil), "unable to start profiling server")
 		}()
 	}
-	if *filteredWatchSecret {
-		klog.Infof("Filtered watch for nodePublishSecretRef secret based on secrets-store.csi.k8s.io/used=true label enabled")
+
+	if !*filteredWatchSecret {
+		klog.Warning("Filtered watch for nodePublishSecretRef secret based on secrets-store.csi.k8s.io/used=true label can't be disabled. The --filtered-watch-secret flag will be deprecated in future releases.")
 	}
 
 	// initialize metrics exporter before creating measurements
@@ -181,7 +183,7 @@ func main() {
 
 	// Secret rotation
 	if *enableSecretRotation {
-		rec, err := rotation.NewReconciler(mgr.GetCache(), scheme, *providerVolumePath, *nodeID, *rotationPollInterval, providerClients, *filteredWatchSecret)
+		rec, err := rotation.NewReconciler(mgr.GetCache(), scheme, *providerVolumePath, *nodeID, *rotationPollInterval, providerClients)
 		if err != nil {
 			klog.Fatalf("failed to initialize rotation reconciler, error: %+v", err)
 		}

--- a/pkg/k8s/store.go
+++ b/pkg/k8s/store.go
@@ -55,13 +55,13 @@ type k8sStore struct {
 }
 
 // New returns store.Store for NodePublishSecretRefSecret
-func New(kubeClient kubernetes.Interface, resyncPeriod time.Duration, filteredWatchSecret bool) (Store, error) {
+func New(kubeClient kubernetes.Interface, resyncPeriod time.Duration) (Store, error) {
 	store := &k8sStore{
 		informers: &Informer{},
 		listers:   &Lister{},
 	}
 
-	store.informers.NodePublishSecretRefSecret = newNodePublishSecretRefSecretInformer(kubeClient, resyncPeriod, filteredWatchSecret)
+	store.informers.NodePublishSecretRefSecret = newNodePublishSecretRefSecretInformer(kubeClient, resyncPeriod)
 	store.listers.NodePublishSecretRefSecret.Store = store.informers.NodePublishSecretRefSecret.GetStore()
 
 	return store, nil
@@ -90,17 +90,13 @@ func (i *Informer) run(stopCh <-chan struct{}) error {
 }
 
 // newNodePublishSecretRefSecretInformer returns a NodePublishSecretRef informer
-func newNodePublishSecretRefSecretInformer(kubeClient kubernetes.Interface, resyncPeriod time.Duration, filteredWatchSecret bool) cache.SharedIndexInformer {
-	var tweakListOptionsFunc internalinterfaces.TweakListOptionsFunc
-	if filteredWatchSecret {
-		tweakListOptionsFunc = usedFilterForSecret()
-	}
+func newNodePublishSecretRefSecretInformer(kubeClient kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 	return coreInformers.NewFilteredSecretInformer(
 		kubeClient,
 		v1.NamespaceAll,
 		resyncPeriod,
 		cache.Indexers{},
-		tweakListOptionsFunc,
+		usedFilterForSecret(),
 	)
 }
 

--- a/pkg/k8s/store_test.go
+++ b/pkg/k8s/store_test.go
@@ -39,7 +39,7 @@ func TestGetNodePublishSecretRefSecret(t *testing.T) {
 
 	kubeClient := fake.NewSimpleClientset()
 
-	testStore, err := New(kubeClient, 1*time.Millisecond, false)
+	testStore, err := New(kubeClient, 1*time.Millisecond)
 	g.Expect(err).NotTo(HaveOccurred())
 	err = testStore.Run(wait.NeverStop)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/pkg/rotation/reconciler.go
+++ b/pkg/rotation/reconciler.go
@@ -94,7 +94,7 @@ type Reconciler struct {
 // TODO (aramase) remove this as part of https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/585
 
 // NewReconciler returns a new reconciler for rotation
-func NewReconciler(client client.Reader, s *runtime.Scheme, providerVolumePath, nodeName string, rotationPollInterval time.Duration, providerClients *secretsstore.PluginClientBuilder, filteredWatchSecret bool) (*Reconciler, error) {
+func NewReconciler(client client.Reader, s *runtime.Scheme, providerVolumePath, nodeName string, rotationPollInterval time.Duration, providerClients *secretsstore.PluginClientBuilder) (*Reconciler, error) {
 	config, err := buildConfig()
 	if err != nil {
 		return nil, err
@@ -105,7 +105,7 @@ func NewReconciler(client client.Reader, s *runtime.Scheme, providerVolumePath, 
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartRecordingToSink(&clientcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(s, v1.EventSource{Component: "csi-secrets-store-rotation"})
-	secretStore, err := k8s.New(kubeClient, 5*time.Second, filteredWatchSecret)
+	secretStore, err := k8s.New(kubeClient, 5*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rotation/reconciler_test.go
+++ b/pkg/rotation/reconciler_test.go
@@ -68,8 +68,8 @@ func setupScheme() (*runtime.Scheme, error) {
 	return scheme, nil
 }
 
-func newTestReconciler(client client.Reader, s *runtime.Scheme, kubeClient kubernetes.Interface, crdClient *secretsStoreFakeClient.Clientset, rotationPollInterval time.Duration, socketPath string, filteredWatchSecret bool) (*Reconciler, error) {
-	secretStore, err := k8s.New(kubeClient, 5*time.Second, filteredWatchSecret)
+func newTestReconciler(client client.Reader, s *runtime.Scheme, kubeClient kubernetes.Interface, crdClient *secretsStoreFakeClient.Clientset, rotationPollInterval time.Duration, socketPath string) (*Reconciler, error) {
+	secretStore, err := k8s.New(kubeClient, 5*time.Second)
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +454,7 @@ func TestReconcileError(t *testing.T) {
 			}
 			client := controllerfake.NewFakeClientWithScheme(scheme, initObjects...)
 
-			testReconciler, err := newTestReconciler(client, scheme, kubeClient, crdClient, test.rotationPollInterval, test.socketPath, false)
+			testReconciler, err := newTestReconciler(client, scheme, kubeClient, crdClient, test.rotationPollInterval, test.socketPath)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			err = testReconciler.secretStore.Run(wait.NeverStop)
@@ -489,18 +489,7 @@ func TestReconcileNoError(t *testing.T) {
 		nodePublishSecretRefSecretToAdd *v1.Secret
 	}{
 		{
-			name:                 "filtered watch for nodePublishSecretRef not enabled",
-			filteredWatchEnabled: false,
-			nodePublishSecretRefSecretToAdd: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret1",
-					Namespace: "default",
-				},
-				Data: map[string][]byte{"clientid": []byte("clientid")},
-			},
-		},
-		{
-			name:                 "filtered watch for nodePublishSecretRef enabled",
+			name:                 "filtered watch for nodePublishSecretRef",
 			filteredWatchEnabled: true,
 			nodePublishSecretRefSecretToAdd: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -607,7 +596,7 @@ func TestReconcileNoError(t *testing.T) {
 		}
 		client := controllerfake.NewFakeClientWithScheme(scheme, initObjects...)
 
-		testReconciler, err := newTestReconciler(client, scheme, kubeClient, crdClient, 60*time.Second, socketPath, false)
+		testReconciler, err := newTestReconciler(client, scheme, kubeClient, crdClient, 60*time.Second, socketPath)
 		g.Expect(err).NotTo(HaveOccurred())
 		err = testReconciler.secretStore.Run(wait.NeverStop)
 		g.Expect(err).NotTo(HaveOccurred())
@@ -651,7 +640,7 @@ func TestReconcileNoError(t *testing.T) {
 			test.nodePublishSecretRefSecretToAdd,
 		}
 		client = controllerfake.NewFakeClientWithScheme(scheme, initObjects...)
-		testReconciler, err = newTestReconciler(client, scheme, kubeClient, crdClient, 60*time.Second, socketPath, false)
+		testReconciler, err = newTestReconciler(client, scheme, kubeClient, crdClient, 60*time.Second, socketPath)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(err).NotTo(HaveOccurred())
 
@@ -667,7 +656,7 @@ func TestReconcileNoError(t *testing.T) {
 			test.nodePublishSecretRefSecretToAdd,
 		}
 		client = controllerfake.NewFakeClientWithScheme(scheme, initObjects...)
-		testReconciler, err = newTestReconciler(client, scheme, kubeClient, crdClient, 60*time.Second, socketPath, false)
+		testReconciler, err = newTestReconciler(client, scheme, kubeClient, crdClient, 60*time.Second, socketPath)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(err).NotTo(HaveOccurred())
 
@@ -758,7 +747,7 @@ func TestPatchSecret(t *testing.T) {
 			}
 			client := controllerfake.NewFakeClientWithScheme(scheme, initObjects...)
 
-			testReconciler, err := newTestReconciler(client, scheme, kubeClient, crdClient, 60*time.Second, "", false)
+			testReconciler, err := newTestReconciler(client, scheme, kubeClient, crdClient, 60*time.Second, "")
 			g.Expect(err).NotTo(HaveOccurred())
 			err = testReconciler.secretStore.Run(wait.NeverStop)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -783,7 +772,7 @@ func TestPatchSecret(t *testing.T) {
 func TestHandleError(t *testing.T) {
 	g := NewWithT(t)
 
-	testReconciler, err := newTestReconciler(nil, nil, nil, nil, 60*time.Second, "", false)
+	testReconciler, err := newTestReconciler(nil, nil, nil, nil, 60*time.Second, "")
 	g.Expect(err).NotTo(HaveOccurred())
 
 	testReconciler.handleError(errors.New("failed error"), "key1", false)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
Filtered watch secret has been enabled by default in `v0.1.0` release. This PR makes the flag configuration no-op to not allow disabling the feature. The flag will be removed altogether from code, deployment and helm charts in n+2 releases.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
ref https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/597

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
