### PR TITLE
fix: remove constraints on secret type name

### DIFF
--- a/pkg/util/secretutil/secret.go
+++ b/pkg/util/secretutil/secret.go
@@ -122,26 +122,14 @@ func getPrivateKey(data []byte) ([]byte, error) {
 	return pem.EncodeToMemory(block), nil
 }
 
-// GetSecretType returns a k8s secret type, defaults to Opaque
+// GetSecretType returns a k8s secret type.
+// Kubernetes doesn't impose any constraints on the type name: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
+// If the secret type is empty, then default is Opaque.
 func GetSecretType(sType string) corev1.SecretType {
-	switch sType {
-	case "kubernetes.io/basic-auth":
-		return corev1.SecretTypeBasicAuth
-	case "bootstrap.kubernetes.io/token":
-		return corev1.SecretTypeBootstrapToken
-	case "kubernetes.io/dockerconfigjson":
-		return corev1.SecretTypeDockerConfigJson
-	case "kubernetes.io/dockercfg":
-		return corev1.SecretTypeDockercfg
-	case "kubernetes.io/ssh-auth":
-		return corev1.SecretTypeSSHAuth
-	case "kubernetes.io/service-account-token":
-		return corev1.SecretTypeServiceAccountToken
-	case "kubernetes.io/tls":
-		return corev1.SecretTypeTLS
-	default:
+	if sType == "" {
 		return corev1.SecretTypeOpaque
 	}
+	return corev1.SecretType(sType)
 }
 
 // ValidateSecretObject performs basic validation of the secret provider class

--- a/pkg/util/secretutil/secret_test.go
+++ b/pkg/util/secretutil/secret_test.go
@@ -586,3 +586,28 @@ g+Ia2YI15BzapW0agqSSTlfGMoQHaPRh1+XYtkOd/xb4xc8d+gc0
 		})
 	}
 }
+
+func TestGetSecretType(t *testing.T) {
+	tests := []struct {
+		name   string
+		actual string
+		want   corev1.SecretType
+	}{
+		{
+			name:   "empty secret type",
+			actual: "",
+			want:   corev1.SecretTypeOpaque,
+		},
+		{
+			name:   "secret type is custom",
+			actual: "custom",
+			want:   corev1.SecretType("custom"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, GetSecretType(test.actual))
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
In the secret sync, we're only supporting the core secret types with default type always being `Opaque`. As per the [Kubernetes secret types](https://kubernetes.io/docs/concepts/configuration/secret/#secret-types) documentation, there are no constraints imposed by Kubernetes on the type of the secret. Anything the user providers as type is used and persisted. Following the same pattern in our driver to remove the constraint and set type as `Opaque` only when no secret type is set.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/611

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
