### PR TITLE
test: remove filteredWatchSecret=false e2e

### DIFF
--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -394,39 +394,6 @@ setup() {
   assert_success
 }
 
-@test "Test filtered-watch-secret=false for nodePublishSecretRef" {
-  if [[ "${IS_YAML_TEST}" == "true" ]]; then
-    skip "Testing with deployment manifest YAMLs"
-  fi
-
-  local chart_dir=${HELM_CHART_DIR}
-  if [[ "${chart_dir}" == "" ]]; then
-    chart_dir=manifest_staging/charts/secrets-store-csi-driver
-  fi
-  run helm upgrade csi-secrets-store "${chart_dir}" --reuse-values --set filteredWatchSecret=false --wait --timeout=5m -v=5 --debug --namespace kube-system
-  assert_success
-
-  cmd="kubectl get crd secretproviderclasses.secrets-store.csi.x-k8s.io -o yaml | grep 'helm.sh/resource-policy: keep'"
-  wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
-
-  cmd="kubectl get crd secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io -o yaml | grep 'helm.sh/resource-policy: keep'"
-  wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
-
-  kubectl create ns non-filtered-watch
-  kubectl create secret generic secrets-store-creds --from-literal clientid=${AZURE_CLIENT_ID} --from-literal clientsecret=${AZURE_CLIENT_SECRET} -n non-filtered-watch
-
-  envsubst < $BATS_TESTS_DIR/azure_v1alpha1_secretproviderclass.yaml | kubectl apply -n non-filtered-watch -f -
-  envsubst < $BATS_TESTS_DIR/pod-secrets-store-inline-volume-crd.yaml | kubectl apply -n non-filtered-watch -f -
-
-  kubectl wait -n non-filtered-watch --for=condition=Ready --timeout=180s pod/secrets-store-inline-crd
-
-  run kubectl get pod/secrets-store-inline-crd -n non-filtered-watch
-  assert_success
-
-  result=$(kubectl exec -n non-filtered-watch secrets-store-inline-crd -- cat /mnt/secrets-store/$SECRET_NAME)
-  [[ "${result//$'\r'}" == "${SECRET_VALUE}" ]]
-}
-
 teardown_file() {
   archive_provider "app=csi-secrets-store-provider-azure" || true
   archive_info || true


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
`--filtered-watch-secret` flag has been deprecated as the feature is now enabled by default: https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/697. Removing the e2e test for `--filtered-watch-secret=false` as it has no effect.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
