### PR TITLE
chore: update kubectl to 1.22.1 for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,10 @@ YQ := yq
 # Test variables
 KIND_VERSION ?= 0.11.0
 KUBERNETES_VERSION ?= 1.21.1
+# Use a different kubectl version to pickup https://github.com/kubernetes/kubernetes/pull/96702 which resolves an issue
+# with kubectl wait needed for integration testing. When KUBERNETES_VERSION is updated to >= 1.22.1 this can likely be
+# removed.
+KUBECTL_VERSION ?= 1.22.1
 BATS_VERSION ?= 1.2.1
 TRIVY_VERSION ?= 0.14.0
 PROTOC_VERSION ?= 3.15.2
@@ -190,7 +194,7 @@ $(EKSCTL): ## Download and install eksctl
 	curl -sSLO  https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz && tar -zxvf eksctl_Linux_amd64.tar.gz && chmod +x eksctl && mv eksctl /usr/local/bin/
 
 $(KUBECTL): ## Install kubectl
-	curl -LO https://storage.googleapis.com/kubernetes-release/release/v$(KUBERNETES_VERSION)/bin/linux/amd64/kubectl && chmod +x ./kubectl && mv kubectl /usr/local/bin/
+	curl -LO https://storage.googleapis.com/kubernetes-release/release/v$(KUBECTL_VERSION)/bin/linux/amd64/kubectl && chmod +x ./kubectl && mv kubectl /usr/local/bin/
 
 $(TRIVY): ## Install trivy for image vulnerability scan
 	trivy -v | grep -q $(TRIVY_VERSION) || (curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v$(TRIVY_VERSION))

--- a/test/bats/aws.bats
+++ b/test/bats/aws.bats
@@ -148,23 +148,17 @@ teardown_file() {
 }
 
 @test "CSI inline volume test with pod portability - unmount succeeds" {
-  # https://github.com/kubernetes/kubernetes/pull/96702
-  # kubectl wait --for=delete does not work on already deleted pods.
-  # Instead we will start the wait before initiating the delete.
-  kubectl wait --for=delete --timeout=${WAIT_TIME}s --namespace $NAMESPACE pod/$POD_NAME &
-  WAIT_PID=$!
-
-  sleep 1
+  # On Linux a failure to unmount the tmpfs will block the pod from being
+  # deleted.
   run kubectl --namespace $NAMESPACE delete -f $BATS_TEST_DIR/BasicTestMount.yaml
   assert_success
 
-  # On Linux a failure to unmount the tmpfs will block the pod from being
-  # deleted.
-  run wait $WAIT_PID
+  run kubectl wait --for=delete --timeout=${WAIT_TIME}s --namespace $NAMESPACE pod/$POD_NAME
   assert_success
 
   # Sleep to allow time for logs to propagate.
   sleep 10
+
   # save debug information to archive in case of failure
   archive_info
 

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -126,22 +126,17 @@ setup() {
 }
 
 @test "CSI inline volume test with pod portability - unmount succeeds" {
-  # https://github.com/kubernetes/kubernetes/pull/96702
-  # kubectl wait --for=delete does not work on already deleted pods.
-  # Instead we will start the wait before initiating the delete.
-  kubectl wait --for=delete --timeout=${WAIT_TIME}s pod/secrets-store-inline-crd &
-  WAIT_PID=$!
-
-  sleep 1
-  run kubectl delete pod secrets-store-inline-crd
-
   # On Linux a failure to unmount the tmpfs will block the pod from being
   # deleted.
-  run wait $WAIT_PID
+  run kubectl delete pod secrets-store-inline-crd
+  assert_success
+
+  run kubectl wait --for=delete --timeout=${WAIT_TIME}s pod/secrets-store-inline-crd
   assert_success
 
   # Sleep to allow time for logs to propagate.
   sleep 10
+
   # save debug information to archive in case of failure
   archive_info
 

--- a/test/bats/gcp.bats
+++ b/test/bats/gcp.bats
@@ -75,22 +75,17 @@ export SECRET_VALUE=${SECRET_VALUE:-"aHVudGVyMg=="}
 }
 
 @test "CSI inline volume test with pod portability - unmount succeeds" {
-  # https://github.com/kubernetes/kubernetes/pull/96702
-  # kubectl wait --for=delete does not work on already deleted pods.
-  # Instead we will start the wait before initiating the delete.
-  kubectl wait --for=delete --timeout=${WAIT_TIME}s --namespace=$NAMESPACE pod/secrets-store-inline-crd &
-  WAIT_PID=$!
-
-  sleep 1
-  run kubectl delete pod secrets-store-inline-crd --namespace=$NAMESPACE
-
   # On Linux a failure to unmount the tmpfs will block the pod from being
   # deleted.
-  run wait $WAIT_PID
+  run kubectl delete pod secrets-store-inline-crd --namespace=$NAMESPACE
+  assert_success
+
+  run kubectl wait --for=delete --timeout=${WAIT_TIME}s --namespace=$NAMESPACE pod/secrets-store-inline-crd
   assert_success
 
   # Sleep to allow time for logs to propagate.
   sleep 10
+
   # save debug information to archive in case of failure
   archive_info
 

--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -114,22 +114,17 @@ EOF
 }
 
 @test "CSI inline volume test with pod portability - unmount succeeds" {
-  # https://github.com/kubernetes/kubernetes/pull/96702
-  # kubectl wait --for=delete does not work on already deleted pods.
-  # Instead we will start the wait before initiating the delete.
-  kubectl wait --for=delete --timeout=${WAIT_TIME}s pod/secrets-store-inline &
-  WAIT_PID=$!
-
-  sleep 1
-  run kubectl delete pod secrets-store-inline
-
   # On Linux a failure to unmount the tmpfs will block the pod from being
   # deleted.
-  run wait $WAIT_PID
+  run kubectl delete pod secrets-store-inline
+  assert_success
+
+  run kubectl wait --for=delete --timeout=${WAIT_TIME}s pod/secrets-store-inline
   assert_success
 
   # Sleep to allow time for logs to propagate.
   sleep 10
+
   # save debug information to archive in case of failure
   archive_info
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Attempt to resolve test flakes #700 by updating kubectl. We observe
that pods are deleted, but that kubectl wait will still sometimes
error 255 despite the pod being successfully deleted.

v1.22.1 includes https://github.com/kubernetes/kubernetes/pull/96702
which should allow kubectl wait to return success if pod is already
deleted.