### PR TITLE
chore: use N1_HIGHCPU_8 for cloudbuild and update cloudbuild image

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -8,8 +8,12 @@ timeout: 5400s
 # or any new substitutions added in the future.
 options:
   substitution_option: ALLOW_LOOSE
+  # this is the machine type used for kubernetes releases.
+  # See https://cloud.google.com/build/docs/speeding-up-builds#using_custom_virtual_machine_sizes
+  # job builds a multi-arch docker image for amd64,arm64 and windows 1809, 1903, 1909, 2004.
+  machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210722-085d930'
     entrypoint: bash
     dir: ./docker
     env:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:

Currently we build linux/amd64, linux/arm64, windows/1809, windows/1903, windows/1909 and windows/2004 images with cloudbuild. This takes ~1h10m to complete. Use larger machine type N1_HIGHCPU_8 for cloudbuild jobs to speed up the build. Also, update the cloudbuild base image to a newer version.

Note: This machine type is used across all kubernetes builds.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
