### PR TITLE
docs: fix typo in chart url

### DIFF
--- a/charts/secrets-store-csi-driver/README.md
+++ b/charts/secrets-store-csi-driver/README.md
@@ -10,7 +10,7 @@ Quick start instructions for the setup and configuration of secrets-store-csi-dr
 
 ### Installing the chart
 
-> Note: The helm chart repository URL has changed from `https://raw.githubusercontent.com/kuberentes-sigs/secrets-store-csi-driver/master/charts` to `https://kuberentes-sigs.github.io/secrets-store-csi-driver/charts`.
+> Note: The helm chart repository URL has changed from `https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts` to `https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts`.
 
 <details>
 <summary>Update helm chart repository if using the old URL</summary>
@@ -19,7 +19,7 @@ Run the following commands to update your Helm chart repositories if using the o
 
 ```bash
 helm repo rm secrets-store-csi-driver
-helm repo add secrets-store-csi-driver https://kuberentes-sigs.github.io/secrets-store-csi-driver/charts
+helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
 helm repo update
 ```
 
@@ -28,7 +28,7 @@ helm repo update
 #### Add the chart repo
 
 ```bash
-helm repo add secrets-store-csi-driver https://kuberentes-sigs.github.io/secrets-store-csi-driver/charts
+helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
 ```
 
 #### Install chart using Helm v3.0+


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
Additional changes on top of https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/720. The readme in charts is used by users for configuring the charts so fixing the typo in that doc too. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
