### PR TITLE
chore: rename references from master to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,6 @@ Fixes #
 
 <!--
 **Is this a chart or deployment yaml update?**
-If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
+If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
 -->
 **Special notes for your reviewer**:

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -34,5 +34,5 @@ substitutions:
   # can be used as a substitution
   _GIT_TAG: '12345'
   # _PULL_BASE_REF will contain the ref that was pushed to to trigger this build -
-  # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
-  _PULL_BASE_REF: 'master'
+  # a branch like 'main' or 'release-0.2', or a tag like 'v0.2'.
+  _PULL_BASE_REF: 'main'

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -23,7 +23,7 @@ NOTE: On OSX you must have the gnu version of `sed` in your path: `brew install 
 
 ## Versioning
 
-1. Make sure that the `docs` include all necessary information included in the release (example [tag compare](https://github.com/kubernetes-sigs/secrets-store-csi-driver/compare/v0.0.21...master)).
+1. Make sure that the `docs` include all necessary information included in the release (example [tag compare](https://github.com/kubernetes-sigs/secrets-store-csi-driver/compare/v0.3.0...main)).
 1. Create a new release branch `release-X.X` using the UI (to avoid `git push`'ing directly to the repo).
 1. Wait for the [new branch](https://github.com/kubernetes-sigs/secrets-store-csi-driver/branches) to recieve [branch protection](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches).
 1. Update the version to the semantic version of the new release similar to [this](https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/251)
@@ -95,6 +95,6 @@ NOTE: On OSX you must have the gnu version of `sed` in your path: `brew install 
 ## Publishing
 
 1. Create a draft release in GitHub and associate it with the tag that was just created
-1. Collect release notes (example [tag compare](https://github.com/kubernetes-sigs/secrets-store-csi-driver/compare/v0.0.21...master))
+1. Collect release notes (example [tag compare](https://github.com/kubernetes-sigs/secrets-store-csi-driver/compare/v0.3.0...main))
 1. Write the release notes similar to [this](https://github.com/kubernetes-sigs/secrets-store-csi-driver/releases/tag/v0.0.12) and upload all the artifacts from the `deploy/` dir
 1. Publish release

--- a/docs/Release_Management.md
+++ b/docs/Release_Management.md
@@ -1,28 +1,33 @@
 # Release Management
 
 ## Overview
+
 This document describes **Kubernetes Secrets Store CSI Driver** project release management, which talks about versioning, branching and cadence.
 
 ## Legend
 
 - **X.Y.Z** refers to the version (git tag) of Secrets Store CSI Driver that is released. This is the version of the Secrets Store CSI Driver image.
- 
+
 - **Milestone** should be designed to include feature sets to accommodate monthly release cycles including test gates. GitHub milestones are used by maintainers to manage each release. PRs and Issues for each release should be created as part of a corresponding milestone.
 
 - **Test gates** should include soak tests and upgrade tests from the last minor version.
 
 ## Versioning
+
 This project strictly follows [semantic versioning](https://semver.org/spec/v2.0.0.html). All releases will be of the form _vX.Y.Z_ where X is the major version, Y is the minor version and Z is the patch version.
 
 ### Patch releases
+
 - Patch releases provide users with bug fixes and security fixes. They do not contain new features.
 
 ### Minor releases
+
 - Minor releases contain security and bug fixes as well as _**new features**_.
 
 - They are backwards compatible.
 
 ### Major releases
+
 - Major releases contain breaking changes. Breaking changes refer to schema changes and behavior changes of Secrets Store CSI Driver that may require a clean install during upgrade and it may introduce changes that could break backward compatibility.
 
 - Ideally we will avoid making multiple major releases to be always backward compatible, unless project evolves in important new directions and such release is necessary.
@@ -30,14 +35,15 @@ This project strictly follows [semantic versioning](https://semver.org/spec/v2.0
 - Secrets Store CSI Driver is currently tracking towards first stable release(v1.0.0) with [this](https://github.com/kubernetes-sigs/secrets-store-csi-driver/milestone/5) milestone.
 
 ## Release Cadence and Branching
+
 - Secrets Store CSI Driver follows `monthly` release schedule.
 
 - A new release should be created in _`second week`_ of each month. This schedule not only allows us to do bug fixes, but also provides an opportunity to address underline image vulnerabilities etc. if any.
 
-- The new version is decided as per above guideline and release branch should be created from `master` with name `release-<version>`. For eg. `release-0.1`. Then build the image from release branch.
+- The new version is decided as per above guideline and release branch should be created from `main` with name `release-<version>`. For eg. `release-0.1`. Then build the image from release branch.
 
-- Any `fixes` or `patches` should be merged to master and then `cherry pick` to the release branch.
+- Any `fixes` or `patches` should be merged to main and then `cherry pick` to the release branch.
 
 ## Acknowledgement
 
-This document builds on the ideas and implementations of release processes from projects like [Gatekeeper](https://github.com/open-policy-agent/gatekeeper/blob/master/docs/Release_Management.md), [Helm](https://helm.sh/docs/topics/release_policy/#helm) and Kubernetes. 
+This document builds on the ideas and implementations of release processes from projects like [Gatekeeper](https://github.com/open-policy-agent/gatekeeper/blob/master/docs/Release_Management.md), [Helm](https://helm.sh/docs/topics/release_policy/#helm) and Kubernetes.

--- a/docs/book/src/getting-started/installation.md
+++ b/docs/book/src/getting-started/installation.md
@@ -41,7 +41,7 @@ Notably the following feature must be explicitly enabled:
 | [Sync as Kubernetes secret](../topics/sync-as-kubernetes-secret.md) | `syncSecret.enabled=true`   |
 | [Secret Auto rotation](../topics/secret-auto-rotation.md)           | `enableSecretRotation=true` |
 
-For a list of customizable values that can be injected when invoking helm install, please see the [Helm chart configurations](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/charts/secrets-store-csi-driver#configuration).
+For a list of customizable values that can be injected when invoking helm install, please see the [Helm chart configurations](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/charts/secrets-store-csi-driver#configuration).
 
 ### [Alternatively] Deployment using yamls
 

--- a/docs/book/src/getting-started/usage.md
+++ b/docs/book/src/getting-started/usage.md
@@ -16,7 +16,7 @@ spec:
   parameters:                                 # provider-specific parameters
 ```
 
-Here is a sample [`SecretProviderClass` custom resource](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/test/bats/tests/vault/vault_v1alpha1_secretproviderclass.yaml)
+Here is a sample [`SecretProviderClass` custom resource](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/test/bats/tests/vault/vault_v1alpha1_secretproviderclass.yaml)
 
 ### Update your Deployment Yaml
 
@@ -32,7 +32,7 @@ volumes:
         secretProviderClass: "my-provider"
 ```
 
-Here is a sample [deployment yaml](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/test/bats/tests/vault/pod-vault-inline-volume-secretproviderclass.yaml) using the Secrets Store CSI driver.
+Here is a sample [deployment yaml](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/test/bats/tests/vault/pod-vault-inline-volume-secretproviderclass.yaml) using the Secrets Store CSI driver.
 
 ## Secret Content is Mounted on Pod Start
 

--- a/docs/book/src/providers.md
+++ b/docs/book/src/providers.md
@@ -7,7 +7,7 @@ This project features a pluggable provider interface developers can implement th
 Here is a list of criteria for supported provider:
 
 1. Code audit of the provider implementation to ensure it adheres to the required provider-driver interface - [Implementing a Provider for Secrets Store CSI Driver](#implementing-a-provider-for-secrets-store-csi-driver)
-2. Add provider to the [e2e test suite](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/test/bats) to demonstrate it functions as expected. Please use existing providers e2e tests as a reference.
+2. Add provider to the [e2e test suite](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/test/bats) to demonstrate it functions as expected. Please use existing providers e2e tests as a reference.
 3. If any update is made by a provider (not limited to security updates), the provider is expected to update the provider's e2e test in this repo.
 
 ## Removal from Supported Providers
@@ -28,9 +28,9 @@ The driver as of `v0.0.14` adds an option to use gRPC to communicate with the pr
 
 To implement a secrets-store-csi-driver provider, you can develop a new provider gRPC server using the stub file available for Go.
 
-- Use the functions and data structures in the stub file: [service.pb.go](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/provider/v1alpha1/service.pb.go) to develop the server code
+- Use the functions and data structures in the stub file: [service.pb.go](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/provider/v1alpha1/service.pb.go) to develop the server code
   - The stub file and proto file are shared and hosted in the driver. Vendor-in the stub file and proto file in the provider
-  - [fake server example](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/provider/fake/fake_server.go)
+  - [fake server example](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/provider/fake/fake_server.go)
 - Provider runs as a *daemonset* and is deployed on the same host(s) as the secrets-store-csi-driver pods
 - Provider Unix Domain Socket volume path. The default volume path for providers is [/etc/kubernetes/secrets-store-csi-providers](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/v0.0.14/deploy/secrets-store-csi-driver.yaml#L88-L89). Add the Unix Domain Socket to the dir in the format `/etc/kubernetes/secrets-store-csi-providers/<provider name>.sock`
 - The `<provider name>` in `<provider name>.sock` must match the regular expression `^[a-zA-Z0-9_-]{0,30}$`


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Updates doc references from `master` to `main` as part of the rename.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Ref https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/617

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
