### PR TITLE
ci: add workflow for e2e using staging images

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,12 +28,12 @@ jobs:
         uses: mig4/setup-bats@af9a00deb21b5d795cabfeaa8d9060410377686d
         with:
           bats-version: 1.4.1      
-      - name: Setup kind
+      - name: Setup Kind
         # pinning to the sha aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 from https://github.com/engineerd/setup-kind/releases/tag/v0.5.0
         uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0
         with:
           version: "v0.11.1"
       - name: Test
         run: |
-          unset CI
+          unset CI # Actions sets this var by default. We need to explicitly unset it so that build commit hash is not appended to driver image tag.
           REGISTRY=${{ github.event.inputs.registry }} IMAGE_NAME=${{ github.event.inputs.driverImageName }} IMAGE_VERSION=${{ github.event.inputs.driverImageVersion }} make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,3 +9,5 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+      - name: Run e2e tests
+        run: make test

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5,3 +5,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - run: echo "hello"
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          fetch-depth: 0

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,28 +15,26 @@ on:
         required: true
         default: 'v0.3.0'
 jobs:
-  test:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: test make
-        run: |
-          make --version
-          echo ""
-          CI=false make e2e-mock-provider-container
-
-  # kind:
+  # test:
   #   runs-on: ubuntu-20.04
   #   steps:
-  #     - uses: actions/checkout@master
-  #     - uses: engineerd/setup-kind@v0.5.0
-  #     - name: Testing
+  #     - uses: actions/checkout@v2
+  #     - name: test make
   #       run: |
-  #         kubectl cluster-info
-  #         kubectl get pods -n kube-system
-  #         echo "current-context:" $(kubectl config current-context)
-  #         echo "environment-kubeconfig:" ${KUBECONFIG}
-  #         echo "Registry: ${{ github.event.inputs.registry }}"
-  #         echo "Driver image name: ${{ github.event.inputs.driverImageName }}"
-  #         echo "Driver image version: ${{ github.event.inputs.driverImageVersion }}"
-  #         make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider
+  #         CI=false make e2e-mock-provider-container
+
+  kind:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@master
+      - uses: engineerd/setup-kind@v0.5.0
+      - name: Testing
+        run: |
+          kubectl cluster-info
+          kubectl get pods -n kube-system
+          echo "current-context:" $(kubectl config current-context)
+          echo "environment-kubeconfig:" ${KUBECONFIG}
+          echo "Registry: ${{ github.event.inputs.registry }}"
+          echo "Driver image name: ${{ github.event.inputs.driverImageName }}"
+          echo "Driver image version: ${{ github.event.inputs.driverImageVersion }}"
+          CI=false make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,5 +9,14 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - name: Run e2e tests
-        run: make test
+  kind:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@master
+      - uses: engineerd/setup-kind@v0.5.0
+      - name: Testing
+        run: |
+          kubectl cluster-info
+          kubectl get pods -n kube-system
+          echo "current-context:" $(kubectl config current-context)
+          echo "environment-kubeconfig:" ${KUBECONFIG}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,9 +32,10 @@ jobs:
       - uses: engineerd/setup-kind@v0.5.0
         with:
           version: "v0.11.1"
-      - name: Install BATS
-        run: |
-          make bats
+      - name: Setup BATS
+        uses: mig4/setup-bats@af9a00deb21b5d795cabfeaa8d9060410377686d
+        with:
+          bats-version: 1.4.1
       - name: Testing
         run: |
           unset CI

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,4 +20,4 @@ jobs:
           kubectl get pods -n kube-system
           echo "current-context:" $(kubectl config current-context)
           echo "environment-kubeconfig:" ${KUBECONFIG}
-          make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider
+          CI=false make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,15 +3,15 @@ on:
   workflow_dispatch:
     inputs:
       registry:
-        description: 'Registry for image'     
+        description: 'Registry'
         required: true
         default: 'gcr.io/k8s-staging-csi-secrets-store'
-      driverImageName:
-        description: 'Image name for secret store CSI driver'
+      driverImage:
+        description: 'Secret Store CSI driver image'
         required: true
         default: 'driver'
       driverImageVersion:
-        description: 'Image version for'
+        description: 'Secret Store CSI driver image version'
         required: true
         default: 'v0.3.0'
 jobs:
@@ -36,4 +36,4 @@ jobs:
       - name: Test
         run: |
           unset CI
-          make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider
+          REGISTRY=${{ github.event.inputs.registry }} IMAGE_NAME=${{ github.event.inputs.driverImageName }} IMAGE_VERSION=${{ github.event.inputs.driverImageVersion }} make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,4 +38,5 @@ jobs:
           echo "Driver image name: ${{ github.event.inputs.driverImageName }}"
           echo "Driver image version: ${{ github.event.inputs.driverImageVersion }}"
           # CI=false make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider
+          helm version
           CI=false make e2e-mock-provider-container e2e-provider-deploy

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,3 +20,4 @@ jobs:
           kubectl get pods -n kube-system
           echo "current-context:" $(kubectl config current-context)
           echo "environment-kubeconfig:" ${KUBECONFIG}
+          make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -42,4 +42,9 @@ jobs:
           # GH action sets this var by default. We need to explicitly unset it so that build commit hash is not appended to image tag.
           unset CI
 
-          REGISTRY=${{ github.event.inputs.registry }} IMAGE_NAME=${{ github.event.inputs.driverImageName }} CRD_IMAGE_NAME=${{ github.event.inputs.crdImageName }} IMAGE_VERSION=${{ github.event.inputs.imageVersion }} make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider
+          make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider
+        env: 
+          REGISTRY: ${{ github.event.inputs.registry }}
+          IMAGE_NAME: ${{ github.event.inputs.driverImageName }} 
+          CRD_IMAGE_NAME: ${{ github.event.inputs.crdImageName }} 
+          IMAGE_VERSION: ${{ github.event.inputs.imageVersion }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,7 +18,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: test make
         run: |
           make e2e-mock-provider-container

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -41,5 +41,5 @@ jobs:
         run: |
           # GH action sets this var by default. We need to explicitly unset it so that build commit hash is not appended to image tag.
           unset CI
-          
-          REGISTRY=${{ github.event.inputs.registry }} IMAGE_NAME=${{ github.event.inputs.driverImageName }} CRD_IMAGE_NAME=${{ github.event.inputs.driverImageName }} IMAGE_VERSION=${{ github.event.inputs.imageVersion }} make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider
+
+          REGISTRY=${{ github.event.inputs.registry }} IMAGE_NAME=${{ github.event.inputs.driverImageName }} CRD_IMAGE_NAME=${{ github.event.inputs.crdImageName }} IMAGE_VERSION=${{ github.event.inputs.imageVersion }} make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,4 +37,5 @@ jobs:
           echo "Registry: ${{ github.event.inputs.registry }}"
           echo "Driver image name: ${{ github.event.inputs.driverImageName }}"
           echo "Driver image version: ${{ github.event.inputs.driverImageVersion }}"
-          CI=false make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider
+          # CI=false make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider
+          CI=false make e2e-mock-provider-container e2e-provider-deploy

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,9 +30,13 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: "v0.11.1"
+          image: "v1.21.1"
       - name: Testing
         run: |
           unset CI
+          kind version
           kubectl cluster-info
           kubectl get pods -n kube-system
           echo "current-context:" $(kubectl config current-context)

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,6 +32,9 @@ jobs:
       - uses: engineerd/setup-kind@v0.5.0
         with:
           version: "v0.11.1"
+      - name: Install BATS
+        run: |
+          make bats
       - name: Testing
         run: |
           unset CI

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,19 +1,10 @@
-name: e2e-test
-on: 
+name: e2e-mock-provider
+on:
   workflow_dispatch:
     inputs:
-      registry:
-        description: 'registry for image'     
+      puppy:
+        description: 'A kind of puppy.'
         required: true
-        default: 'gcr.io/k8s-staging-csi-secrets-store'
-      driverImageName:
-        description: 'image name'
-        required: true
-        default: 'driver'
-      driverImageVersion:
-        description: 'Image version'
-        required: true
-        default: 'v0.3.0'
 jobs:
   kind:
     runs-on: ubuntu-20.04
@@ -26,7 +17,8 @@ jobs:
           kubectl get pods -n kube-system
           echo "current-context:" $(kubectl config current-context)
           echo "environment-kubeconfig:" ${KUBECONFIG}
-          echo "Registry: ${{ github.event.inputs.registry }}"
-          echo "Driver image name: ${{ github.event.inputs.driverImageName }}"
-          echo "Driver image version: ${{ github.event.inputs.driverImageVersion }}"
+          echo "puppy ${{ github.event.inputs.puppy }}"
+          # echo "Registry: ${{ github.event.inputs.registry }}"
+          # echo "Driver image name: ${{ github.event.inputs.driverImageName }}"
+          # echo "Driver image version: ${{ github.event.inputs.driverImageVersion }}"
           make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,6 +32,7 @@ jobs:
       - uses: engineerd/setup-kind@v0.5.0
       - name: Testing
         run: |
+          unset CI
           kubectl cluster-info
           kubectl get pods -n kube-system
           echo "current-context:" $(kubectl config current-context)
@@ -39,6 +40,7 @@ jobs:
           echo "Registry: ${{ github.event.inputs.registry }}"
           echo "Driver image name: ${{ github.event.inputs.driverImageName }}"
           echo "Driver image version: ${{ github.event.inputs.driverImageVersion }}"
+          echo "Helm version -"
           helm version
           make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider
           # CI=false make e2e-mock-provider-container e2e-provider-deploy

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,17 +1,25 @@
-name: e2e-mock-provider-tests
+name: e2e_mock_provider_tests
 on: 
   workflow_dispatch:
     inputs:
       registry:
-        description: 'Registry'
+        description: 'Registry for pulling images'
         required: true
         default: 'gcr.io/k8s-staging-csi-secrets-store'
-      driverImage:
-        description: 'Secret Store CSI driver image'
+      driverImageName:
+        description: 'Secret Store CSI driver image name'
         required: true
         default: 'driver'
       driverImageVersion:
         description: 'Secret Store CSI driver image version'
+        required: true
+        default: 'v0.3.0'
+      crdImageName:
+        description: 'Secret Store CSI driver CRD image name'
+        required: true
+        default: 'driver-crds'
+      crdImageVersion:
+        description: 'Secret Store CSI driver CRD image version'
         required: true
         default: 'v0.3.0'
 jobs:
@@ -36,4 +44,4 @@ jobs:
       - name: Test
         run: |
           unset CI # Actions sets this var by default. We need to explicitly unset it so that build commit hash is not appended to driver image tag.
-          REGISTRY=${{ github.event.inputs.registry }} IMAGE_NAME=${{ github.event.inputs.driverImage }} IMAGE_VERSION=${{ github.event.inputs.driverImageVersion }} make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider
+          REGISTRY=${{ github.event.inputs.registry }} IMAGE_NAME=${{ github.event.inputs.driverImageName }} IMAGE_VERSION=${{ github.event.inputs.driverImageVersion }} make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,7 @@
+name: e2e-test
+on: [push]
+jobs:
+  e2e-mock-provider-test:
+    runs-on: ubuntu-20.04
+    steps:
+      - run: echo "hello"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -36,4 +36,4 @@ jobs:
       - name: Test
         run: |
           unset CI # Actions sets this var by default. We need to explicitly unset it so that build commit hash is not appended to driver image tag.
-          REGISTRY=${{ github.event.inputs.registry }} IMAGE_NAME=${{ github.event.inputs.driverImageName }} IMAGE_VERSION=${{ github.event.inputs.driverImageVersion }} make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider
+          REGISTRY=${{ github.event.inputs.registry }} IMAGE_NAME=${{ github.event.inputs.driverImage }} IMAGE_VERSION=${{ github.event.inputs.driverImageVersion }} make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,42 +1,44 @@
 name: e2e-mock-provider
-on: 
-  workflow_dispatch:
-    inputs:
-      registry:
-        description: 'registry for image'     
-        required: true
-        default: 'gcr.io/k8s-staging-csi-secrets-store'
-      driverImageName:
-        description: 'image name'
-        required: true
-        default: 'driver'
-      driverImageVersion:
-        description: 'Image version'
-        required: true
-        default: 'v0.3.0'
+on: push
+# on: 
+#   workflow_dispatch:
+#     inputs:
+#       registry:
+#         description: 'registry for image'     
+#         required: true
+#         default: 'gcr.io/k8s-staging-csi-secrets-store'
+#       driverImageName:
+#         description: 'image name'
+#         required: true
+#         default: 'driver'
+#       driverImageVersion:
+#         description: 'Image version'
+#         required: true
+#         default: 'v0.3.0'
 jobs:
-  # test:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: test make
-  #       run: |
-  #         CI=false make e2e-mock-provider-container
-
-  kind:
+  test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@master
-      - uses: engineerd/setup-kind@v0.5.0
-      - name: Testing
+      - uses: actions/checkout@v2
+      - name: test make
         run: |
-          kubectl cluster-info
-          kubectl get pods -n kube-system
-          echo "current-context:" $(kubectl config current-context)
-          echo "environment-kubeconfig:" ${KUBECONFIG}
-          echo "Registry: ${{ github.event.inputs.registry }}"
-          echo "Driver image name: ${{ github.event.inputs.driverImageName }}"
-          echo "Driver image version: ${{ github.event.inputs.driverImageVersion }}"
-          # CI=false make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider
-          helm version
-          CI=false make e2e-mock-provider-container e2e-provider-deploy
+          unset CI
+          make e2e-mock-provider-container
+
+  # kind:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@master
+  #     - uses: engineerd/setup-kind@v0.5.0
+  #     - name: Testing
+  #       run: |
+  #         kubectl cluster-info
+  #         kubectl get pods -n kube-system
+  #         echo "current-context:" $(kubectl config current-context)
+  #         echo "environment-kubeconfig:" ${KUBECONFIG}
+  #         echo "Registry: ${{ github.event.inputs.registry }}"
+  #         echo "Driver image name: ${{ github.event.inputs.driverImageName }}"
+  #         echo "Driver image version: ${{ github.event.inputs.driverImageVersion }}"
+  #         # CI=false make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider
+  #         helm version
+  #         CI=false make e2e-mock-provider-container e2e-provider-deploy

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,16 +10,12 @@ on:
         description: 'Secret Store CSI driver image name'
         required: true
         default: 'driver'
-      driverImageVersion:
-        description: 'Secret Store CSI driver image version'
-        required: true
-        default: 'v0.3.0'
       crdImageName:
         description: 'Secret Store CSI driver CRD image name'
         required: true
         default: 'driver-crds'
-      crdImageVersion:
-        description: 'Secret Store CSI driver CRD image version'
+      imageVersion:
+        description: 'image version for Secret Store CSI driver and CRDs'
         required: true
         default: 'v0.3.0'
 jobs:
@@ -43,5 +39,7 @@ jobs:
           version: "v0.11.1"
       - name: Test
         run: |
-          unset CI # Actions sets this var by default. We need to explicitly unset it so that build commit hash is not appended to driver image tag.
-          REGISTRY=${{ github.event.inputs.registry }} IMAGE_NAME=${{ github.event.inputs.driverImageName }} IMAGE_VERSION=${{ github.event.inputs.driverImageVersion }} make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider
+          # GH action sets this var by default. We need to explicitly unset it so that build commit hash is not appended to image tag.
+          unset CI
+          
+          REGISTRY=${{ github.event.inputs.registry }} IMAGE_NAME=${{ github.event.inputs.driverImageName }} CRD_IMAGE_NAME=${{ github.event.inputs.driverImageName }} IMAGE_VERSION=${{ github.event.inputs.imageVersion }} make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,53 +1,39 @@
-name: e2e-mock-provider
-on: push
-# on: 
-#   workflow_dispatch:
-#     inputs:
-#       registry:
-#         description: 'registry for image'     
-#         required: true
-#         default: 'gcr.io/k8s-staging-csi-secrets-store'
-#       driverImageName:
-#         description: 'image name'
-#         required: true
-#         default: 'driver'
-#       driverImageVersion:
-#         description: 'Image version'
-#         required: true
-#         default: 'v0.3.0'
+name: e2e-mock-provider-tests
+on: 
+  workflow_dispatch:
+    inputs:
+      registry:
+        description: 'Registry for image'     
+        required: true
+        default: 'gcr.io/k8s-staging-csi-secrets-store'
+      driverImageName:
+        description: 'Image name for secret store CSI driver'
+        required: true
+        default: 'driver'
+      driverImageVersion:
+        description: 'Image version for'
+        required: true
+        default: 'v0.3.0'
 jobs:
-  # test:
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: test make
-  #       run: |
-  #         unset CI
-  #         make e2e-mock-provider-container
-
-  kind:
+  e2e-test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@master
-      - uses: engineerd/setup-kind@v0.5.0
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
-          version: "v0.11.1"
+          submodules: true
+          fetch-depth: 0  
       - name: Setup BATS
+        # pinning to the sha af9a00deb21b5d795cabfeaa8d9060410377686d from https://github.com/mig4/setup-bats/releases/tag/v1.2.0
         uses: mig4/setup-bats@af9a00deb21b5d795cabfeaa8d9060410377686d
         with:
-          bats-version: 1.4.1
-      - name: Testing
+          bats-version: 1.4.1      
+      - name: Setup kind
+        # pinning to the sha aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 from https://github.com/engineerd/setup-kind/releases/tag/v0.5.0
+        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0
+        with:
+          version: "v0.11.1"
+      - name: Test
         run: |
           unset CI
-          kind version
-          kubectl cluster-info
-          kubectl get pods -n kube-system
-          echo "current-context:" $(kubectl config current-context)
-          echo "environment-kubeconfig:" ${KUBECONFIG}
-          echo "Registry: ${{ github.event.inputs.registry }}"
-          echo "Driver image name: ${{ github.event.inputs.driverImageName }}"
-          echo "Driver image version: ${{ github.event.inputs.driverImageVersion }}"
-          echo "Helm version -"
-          helm version
           make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider
-          # CI=false make e2e-mock-provider-container e2e-provider-deploy

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: test make
         run: |
+          make --version
+          echo ""
           make e2e-mock-provider-container
 
   # kind:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,7 +32,6 @@ jobs:
       - uses: engineerd/setup-kind@v0.5.0
         with:
           version: "v0.11.1"
-          image: "v1.21.1"
       - name: Testing
         run: |
           unset CI

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,29 +16,29 @@ on: push
 #         required: true
 #         default: 'v0.3.0'
 jobs:
-  test:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: test make
-        run: |
-          unset CI
-          make e2e-mock-provider-container
-
-  # kind:
+  # test:
   #   runs-on: ubuntu-20.04
   #   steps:
-  #     - uses: actions/checkout@master
-  #     - uses: engineerd/setup-kind@v0.5.0
-  #     - name: Testing
+  #     - uses: actions/checkout@v2
+  #     - name: test make
   #       run: |
-  #         kubectl cluster-info
-  #         kubectl get pods -n kube-system
-  #         echo "current-context:" $(kubectl config current-context)
-  #         echo "environment-kubeconfig:" ${KUBECONFIG}
-  #         echo "Registry: ${{ github.event.inputs.registry }}"
-  #         echo "Driver image name: ${{ github.event.inputs.driverImageName }}"
-  #         echo "Driver image version: ${{ github.event.inputs.driverImageVersion }}"
-  #         # CI=false make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider
-  #         helm version
-  #         CI=false make e2e-mock-provider-container e2e-provider-deploy
+  #         unset CI
+  #         make e2e-mock-provider-container
+
+  kind:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@master
+      - uses: engineerd/setup-kind@v0.5.0
+      - name: Testing
+        run: |
+          kubectl cluster-info
+          kubectl get pods -n kube-system
+          echo "current-context:" $(kubectl config current-context)
+          echo "environment-kubeconfig:" ${KUBECONFIG}
+          echo "Registry: ${{ github.event.inputs.registry }}"
+          echo "Driver image name: ${{ github.event.inputs.driverImageName }}"
+          echo "Driver image version: ${{ github.event.inputs.driverImageVersion }}"
+          helm version
+          make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider
+          # CI=false make e2e-mock-provider-container e2e-provider-deploy

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           make --version
           echo ""
-          make e2e-mock-provider-container
+          CI=false make e2e-mock-provider-container
 
   # kind:
   #   runs-on: ubuntu-20.04

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,14 +1,20 @@
 name: e2e-test
-on: [push]
+on: 
+  workflow_dispatch:
+    inputs:
+      registry:
+        description: 'registry for image'     
+        required: true
+        default: 'gcr.io/k8s-staging-csi-secrets-store'
+      driverImageName:
+        description: 'image name'
+        required: true
+        default: 'driver'
+      driverImageVersion:
+        description: 'Image version'
+        required: true
+        default: 'v0.3.0'
 jobs:
-  e2e-mock-provider-test:
-    runs-on: ubuntu-20.04
-    steps:
-      - run: echo "hello"
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-          fetch-depth: 0
   kind:
     runs-on: ubuntu-20.04
     steps:
@@ -20,4 +26,7 @@ jobs:
           kubectl get pods -n kube-system
           echo "current-context:" $(kubectl config current-context)
           echo "environment-kubeconfig:" ${KUBECONFIG}
-          CI=false make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider
+          echo "Registry: ${{ github.event.inputs.registry }}"
+          echo "Driver image name: ${{ github.event.inputs.driverImageName }}"
+          echo "Driver image version: ${{ github.event.inputs.driverImageVersion }}"
+          make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,24 +1,40 @@
 name: e2e-mock-provider
-on:
+on: 
   workflow_dispatch:
     inputs:
-      puppy:
-        description: 'A kind of puppy.'
+      registry:
+        description: 'registry for image'     
         required: true
+        default: 'gcr.io/k8s-staging-csi-secrets-store'
+      driverImageName:
+        description: 'image name'
+        required: true
+        default: 'driver'
+      driverImageVersion:
+        description: 'Image version'
+        required: true
+        default: 'v0.3.0'
 jobs:
-  kind:
+  test:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
-      - uses: engineerd/setup-kind@v0.5.0
-      - name: Testing
+      - name: test make
         run: |
-          kubectl cluster-info
-          kubectl get pods -n kube-system
-          echo "current-context:" $(kubectl config current-context)
-          echo "environment-kubeconfig:" ${KUBECONFIG}
-          echo "puppy ${{ github.event.inputs.puppy }}"
-          # echo "Registry: ${{ github.event.inputs.registry }}"
-          # echo "Driver image name: ${{ github.event.inputs.driverImageName }}"
-          # echo "Driver image version: ${{ github.event.inputs.driverImageVersion }}"
-          make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider
+          make e2e-mock-provider-container
+
+  # kind:
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@master
+  #     - uses: engineerd/setup-kind@v0.5.0
+  #     - name: Testing
+  #       run: |
+  #         kubectl cluster-info
+  #         kubectl get pods -n kube-system
+  #         echo "current-context:" $(kubectl config current-context)
+  #         echo "environment-kubeconfig:" ${KUBECONFIG}
+  #         echo "Registry: ${{ github.event.inputs.registry }}"
+  #         echo "Driver image name: ${{ github.event.inputs.driverImageName }}"
+  #         echo "Driver image version: ${{ github.event.inputs.driverImageVersion }}"
+  #         make e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ E2E_PROVIDER_IMAGE_NAME ?= e2e-provider
 RELEASE_VERSION := v0.3.0
 IMAGE_VERSION ?= v0.3.0
 # Use a custom version for E2E tests if we are testing in CI
-# ifdef CI
-# override IMAGE_VERSION := v0.3.0-e2e-$(BUILD_COMMIT)
-# endif
+ifdef CI
+override IMAGE_VERSION := v0.3.0-e2e-$(BUILD_COMMIT)
+endif
 
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)
 CRD_IMAGE_TAG=$(REGISTRY)/$(CRD_IMAGE_NAME):$(IMAGE_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -417,7 +417,7 @@ e2e-deploy-manifest:
 
 .PHONY: e2e-helm-deploy
 e2e-helm-deploy:
-	helm install csi-secrets-store manifest_staging/charts/secrets-store-csi-driver --namespace kube-system --wait --timeout=5m -v=5 --debug \
+	helm install csi-secrets-store manifest_staging/charts/secrets-store-csi-driver --namespace kube-system --wait --timeout=5m -v=4 --debug \
 		--set linux.image.pullPolicy="IfNotPresent" \
 		--set windows.image.pullPolicy="IfNotPresent" \
 		--set linux.image.repository=$(REGISTRY)/$(IMAGE_NAME) \

--- a/Makefile
+++ b/Makefile
@@ -417,7 +417,7 @@ e2e-deploy-manifest:
 
 .PHONY: e2e-helm-deploy
 e2e-helm-deploy:
-	helm install csi-secrets-store manifest_staging/charts/secrets-store-csi-driver --namespace kube-system --wait --timeout=5m -v=6 --debug \
+	helm install csi-secrets-store manifest_staging/charts/secrets-store-csi-driver --namespace kube-system --wait --timeout=5m -v=5 --debug \
 		--set linux.image.pullPolicy="IfNotPresent" \
 		--set windows.image.pullPolicy="IfNotPresent" \
 		--set linux.image.repository=$(REGISTRY)/$(IMAGE_NAME) \

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,12 @@ E2E_PROVIDER_IMAGE_NAME ?= e2e-provider
 RELEASE_VERSION := v0.3.0
 IMAGE_VERSION ?= v0.3.0
 # Use a custom version for E2E tests if we are testing in CI
-# ifdef CI
-# override IMAGE_VERSION := v0.3.0-e2e-$(BUILD_COMMIT)
-# endif
-ifeq ($(CI),true)
+ifdef CI
 override IMAGE_VERSION := v0.3.0-e2e-$(BUILD_COMMIT)
 endif
+# ifeq ($(CI),true)
+# override IMAGE_VERSION := v0.3.0-e2e-$(BUILD_COMMIT)
+# endif
 
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)
 CRD_IMAGE_TAG=$(REGISTRY)/$(CRD_IMAGE_NAME):$(IMAGE_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ E2E_PROVIDER_IMAGE_NAME ?= e2e-provider
 RELEASE_VERSION := v0.3.0
 IMAGE_VERSION ?= v0.3.0
 # Use a custom version for E2E tests if we are testing in CI
-ifdef CI
-override IMAGE_VERSION := v0.3.0-e2e-$(BUILD_COMMIT)
-endif
+# ifdef CI
+# override IMAGE_VERSION := v0.3.0-e2e-$(BUILD_COMMIT)
+# endif
 
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)
 CRD_IMAGE_TAG=$(REGISTRY)/$(CRD_IMAGE_NAME):$(IMAGE_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,6 @@ IMAGE_VERSION ?= v0.3.0
 ifdef CI
 override IMAGE_VERSION := v0.3.0-e2e-$(BUILD_COMMIT)
 endif
-# ifeq ($(CI),true)
-# override IMAGE_VERSION := v0.3.0-e2e-$(BUILD_COMMIT)
-# endif
 
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)
 CRD_IMAGE_TAG=$(REGISTRY)/$(CRD_IMAGE_NAME):$(IMAGE_VERSION)
@@ -105,7 +102,7 @@ KUBERNETES_VERSION ?= 1.21.1
 # with kubectl wait needed for integration testing. When KUBERNETES_VERSION is updated to >= 1.22.1 this can likely be
 # removed.
 KUBECTL_VERSION ?= 1.22.1
-BATS_VERSION ?= 1.2.1
+BATS_VERSION ?= 1.4.1
 TRIVY_VERSION ?= 0.14.0
 PROTOC_VERSION ?= 3.15.2
 SHELLCHECK_VER ?= v0.7.2

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,10 @@ E2E_PROVIDER_IMAGE_NAME ?= e2e-provider
 RELEASE_VERSION := v0.3.0
 IMAGE_VERSION ?= v0.3.0
 # Use a custom version for E2E tests if we are testing in CI
-ifdef CI
+# ifdef CI
+# override IMAGE_VERSION := v0.3.0-e2e-$(BUILD_COMMIT)
+# endif
+ifeq ($(CI),true)
 override IMAGE_VERSION := v0.3.0-e2e-$(BUILD_COMMIT)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ E2E_PROVIDER_IMAGE_NAME ?= e2e-provider
 # Update this version when the helm chart is being updated for release
 RELEASE_VERSION := v0.3.0
 IMAGE_VERSION ?= v0.3.0
+
 # Use a custom version for E2E tests if we are testing in CI
 ifdef CI
 override IMAGE_VERSION := v0.3.0-e2e-$(BUILD_COMMIT)

--- a/Makefile
+++ b/Makefile
@@ -417,7 +417,7 @@ e2e-deploy-manifest:
 
 .PHONY: e2e-helm-deploy
 e2e-helm-deploy:
-	helm install csi-secrets-store manifest_staging/charts/secrets-store-csi-driver --namespace kube-system --wait --timeout=5m -v=4 --debug \
+	helm install csi-secrets-store manifest_staging/charts/secrets-store-csi-driver --namespace kube-system --wait --timeout=5m -v=6 --debug \
 		--set linux.image.pullPolicy="IfNotPresent" \
 		--set windows.image.pullPolicy="IfNotPresent" \
 		--set linux.image.repository=$(REGISTRY)/$(IMAGE_NAME) \

--- a/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
+++ b/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
@@ -78,7 +78,7 @@ metadata:
 {{ include "sscd.labels" . | indent 2 }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "2"
+    helm.sh/hook-weight: "1"
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
 spec:
   backoffLimit: 0

--- a/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
+++ b/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
@@ -78,7 +78,7 @@ metadata:
 {{ include "sscd.labels" . | indent 2 }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "1"
+    helm.sh/hook-weight: "2"
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
 spec:
   backoffLimit: 0

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -26,7 +26,7 @@ NOTE: On OSX you must have the gnu version of `sed` in your path: `brew install 
 
 1. Make sure that the `docs` include all necessary information included in the release (example [tag compare](https://github.com/kubernetes-sigs/secrets-store-csi-driver/compare/v0.3.0...main)).
 1. Create a new release branch `release-X.X` using the UI (to avoid `git push`'ing directly to the repo).
-1. Wait for the [new branch](https://github.com/kubernetes-sigs/secrets-store-csi-driver/branches) to recieve [branch protection](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches).
+1. Wait for the [new branch](https://github.com/kubernetes-sigs/secrets-store-csi-driver/branches) to receive [branch protection](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches).
 1. Update the version to the semantic version of the new release similar to [this](https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/251)
 1. Commit the changes and push to remote repository to create a pull request to the `release-X.X` branch
 
@@ -37,7 +37,8 @@ NOTE: On OSX you must have the gnu version of `sed` in your path: `brew install 
     ```
 
 1. Once the PR is merged to `release-X.X`, the [prow job](https://testgrid.k8s.io/sig-auth-secrets-store-csi-driver#secrets-store-csi-driver-push-image) is triggered to build and push the new version to staging repo (`gcr.io/k8s-staging-csi-secrets-store/driver`)
-1. Once the prow job completes, follow the [instructions](https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io#image-promoter) to promote the image to production repo
+1. After images are available in staging registry, head over to github [actions](https://github.com/kubernetes-sigs/secrets-store-csi-driver/actions) and select `e2e_mock_provider_tests` workflow. Click `Run workflow` and provide required inputs. This will run e2e tests against the staging images. Make sure this job is successful before proceeding to the next step.
+1. Once the e2e tests on staging images completes, follow the [instructions](https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io#image-promoter) to promote the image to production repo
     - Within the Prow job "Artifacts" tab there is a file `artifacts/build.log` which will include the Cloud Build URL:
 
     ```text

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -10,6 +10,7 @@ Versioning involves maintaining the following files:
 - secrets-store-csi-driver.yaml - the Linux driver deployment yaml that contains the latest release tag image of the project.
 - secrets-store-csi-driver-windows.yaml - the Windows driver deployment yaml that contains the latest release tag image of the project.
 - `deploy/` dir that contains all the secrets-store-csi-driver resources to be deployed to the cluster including the latest release tag image of the project.
+- `.github/workflows/e2e.yaml` file contains the default image tag released in staging and is used for e2e testing before releasing production images.
 
 The steps below explain how to update these files. In addition, the repository should be tagged with the semantic version identifying the release.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PRs adds github action to run e2e tests on demand. This will help run e2e tests on staging images before releasing them.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #688 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
