### PR TITLE
docs: add detail about pprof and metrics endpoint

### DIFF
--- a/docs/book/src/topics/metrics.md
+++ b/docs/book/src/topics/metrics.md
@@ -18,6 +18,13 @@ Prometheus is the only exporter that's currently supported with the driver.
 | total_rotation_reconcile_error  | Total number of rotation reconciles with error                            | `os_type=<runtime os>`<br>`rotated=<true or false>`<br>`error_type=<error code>`  |
 | rotation_reconcile_duration_sec | Distribution of how long it took to rotate secrets-store content for pods | `os_type=<runtime os>`                                                            |
 
+Metrics are served from port 8095, but this port is not exposed outside the pod by default. Use kubectl port-forward to access the metrics over localhost:
+
+```bash
+kubectl port-forward ds/csi-secrets-store -n kube-system 8095:8095 &
+curl localhost:8095/metrics
+```
+
 ### Sample Metrics output
 
 ```shell

--- a/docs/book/src/troubleshooting.md
+++ b/docs/book/src/troubleshooting.md
@@ -21,6 +21,15 @@ kubectl describe pod <application pod>
 
 > It is always a good idea to include relevant logs from csi driver pod when opening a new [issue](https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues).
 
+## pprof
+
+Starting the `secrets-store` container in driver with `--enable-pprof=true` will enable a debug http endpoint at `--pprof-port` (default: 6065). Accessing this will also require `port-forward`:
+
+```bash
+kubectl port-forward csi-secrets-store-secrets-store-csi-driver-7x44t secrets-store 6065:6065 &
+curl localhost:6065/debug/pprof
+```
+
 ## Common Errors
 
 ### `SecretProviderClass` not found


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Adds `port-forward` commands and flag for enabling pprof/metrics.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
