### PR TITLE
chore: remove deprecated --prometheus-port flag

### DIFF
--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -26,7 +26,6 @@ import (
 
 var (
 	metricsBackend = flag.String("metrics-backend", "Prometheus", "Backend used for metrics")
-	_              = flag.Int("prometheus-port", 8888, "Prometheus port for metrics backend [DEPRECATED]. Use --metrics-addr instead.")
 )
 
 const prometheusExporter = "prometheus"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Removes the deprecated `prometheus-port` flag. Use `--metrics-addr` instead.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
