### PR TITLE
feat: create or update secretproviderclasspodstatus post mount

### DIFF
--- a/cmd/secrets-store-csi-driver/main.go
+++ b/cmd/secrets-store-csi-driver/main.go
@@ -196,7 +196,7 @@ func main() {
 		go rec.Run(ctx.Done())
 	}
 
-	driver := secretsstore.NewSecretsStoreDriver(*driverName, *nodeID, *endpoint, *providerVolumePath, providerClients, mgr.GetClient())
+	driver := secretsstore.NewSecretsStoreDriver(*driverName, *nodeID, *endpoint, *providerVolumePath, providerClients, mgr.GetClient(), mgr.GetAPIReader())
 	driver.Run(ctx)
 }
 

--- a/controllers/secretproviderclasspodstatus_controller_test.go
+++ b/controllers/secretproviderclasspodstatus_controller_test.go
@@ -129,11 +129,11 @@ func TestSecretExists(t *testing.T) {
 	labels := map[string]string{"environment": "test"}
 	annotations := map[string]string{"kubed.appscode.com/sync": "app=test"}
 
-	initObjects := []runtime.Object{
+	initObjects := []client.Object{
 		newSecret("my-secret", "default", labels, annotations),
 	}
 
-	client := fake.NewFakeClientWithScheme(scheme, initObjects...)
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 	reconciler := newReconciler(client, scheme, "node1")
 
 	exists, err := reconciler.secretExists(context.TODO(), "my-secret", "default")
@@ -165,11 +165,11 @@ func TestPatchSecretWithOwnerRef(t *testing.T) {
 	labels := map[string]string{"environment": "test"}
 	annotations := map[string]string{"kubed.appscode.com/sync": "app=test"}
 
-	initObjects := []runtime.Object{
+	initObjects := []client.Object{
 		newSecret("my-secret", "default", labels, annotations),
 		spcPodStatus,
 	}
-	client := fake.NewFakeClientWithScheme(scheme, initObjects...)
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 	reconciler := newReconciler(client, scheme, "node1")
 
 	// adding ref twice to test de-duplication of owner references when being set in the secret
@@ -191,10 +191,10 @@ func TestCreateK8sSecret(t *testing.T) {
 	labels := map[string]string{"environment": "test"}
 	annotations := map[string]string{"kubed.appscode.com/sync": "app=test"}
 
-	initObjects := []runtime.Object{
+	initObjects := []client.Object{
 		newSecret("my-secret", "default", labels, annotations),
 	}
-	client := fake.NewFakeClientWithScheme(scheme, initObjects...)
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 	reconciler := newReconciler(client, scheme, "node1")
 
 	// secret already exists
@@ -218,7 +218,7 @@ func TestGenerateEvent(t *testing.T) {
 	scheme, err := setupScheme()
 	g.Expect(err).NotTo(HaveOccurred())
 
-	client := fake.NewFakeClientWithScheme(scheme)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 	reconciler := newReconciler(client, scheme, "node1")
 
 	obj := &v1.ObjectReference{
@@ -242,13 +242,13 @@ func TestPatcherForStaticPod(t *testing.T) {
 	scheme, err := setupScheme()
 	g.Expect(err).NotTo(HaveOccurred())
 
-	initObjects := []runtime.Object{
+	initObjects := []client.Object{
 		newSecretProviderClassPodStatus("pod1-default-spc1", "default", "node1"),
 		newSecretProviderClass("spc1", "default"),
 		newPod("pod1", "default", nil),
 		newSecret("secret1", "default", nil, nil),
 	}
-	client := fake.NewFakeClientWithScheme(scheme, initObjects...)
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 	reconciler := newReconciler(client, scheme, "node1")
 
 	err = reconciler.Patcher(context.TODO())
@@ -272,7 +272,7 @@ func TestPatcherForPodWithOwner(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	tr := true
 
-	initObjects := []runtime.Object{
+	initObjects := []client.Object{
 		newSecretProviderClassPodStatus("pod1-default-spc1", "default", "node1"),
 		newSecretProviderClass("spc1", "default"),
 		newPod("pod1", "default", []metav1.OwnerReference{
@@ -287,7 +287,7 @@ func TestPatcherForPodWithOwner(t *testing.T) {
 		}),
 		newSecret("secret1", "default", nil, nil),
 	}
-	client := fake.NewFakeClientWithScheme(scheme, initObjects...)
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 	reconciler := newReconciler(client, scheme, "node1")
 
 	err = reconciler.Patcher(context.TODO())

--- a/pkg/rotation/reconciler.go
+++ b/pkg/rotation/reconciler.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/fileutil"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/k8sutil"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/secretutil"
+	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/spcpsutil"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/version"
 
 	v1 "k8s.io/api/core/v1"
@@ -405,7 +406,7 @@ func (r *Reconciler) reconcile(ctx context.Context, spcps *v1alpha1.SecretProvid
 		for k, v := range newObjectVersions {
 			ov = append(ov, v1alpha1.SecretProviderClassObject{ID: strings.TrimSpace(k), Version: strings.TrimSpace(v)})
 		}
-		spcps.Status.Objects = ov
+		spcps.Status.Objects = spcpsutil.OrderSecretProviderClassObjectByID(ov)
 
 		updateFn := func() (bool, error) {
 			err = r.updateSecretProviderClassPodStatus(ctx, spcps)

--- a/pkg/rotation/reconciler_test.go
+++ b/pkg/rotation/reconciler_test.go
@@ -440,13 +440,13 @@ func TestReconcileError(t *testing.T) {
 			kubeClient := fake.NewSimpleClientset(test.podToAdd, test.secretToAdd)
 			crdClient := secretsStoreFakeClient.NewSimpleClientset(test.secretProviderClassPodStatusToProcess, test.secretProviderClassToAdd)
 
-			initObjects := []runtime.Object{
+			initObjects := []client.Object{
 				test.podToAdd,
 				test.secretToAdd,
 				test.secretProviderClassPodStatusToProcess,
 				test.secretProviderClassToAdd,
 			}
-			client := controllerfake.NewFakeClientWithScheme(scheme, initObjects...)
+			client := controllerfake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 			testReconciler, err := newTestReconciler(client, scheme, kubeClient, crdClient, test.rotationPollInterval, test.socketPath)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -581,16 +581,16 @@ func TestReconcileNoError(t *testing.T) {
 		kubeClient := fake.NewSimpleClientset(podToAdd, test.nodePublishSecretRefSecretToAdd, secretToBeRotated)
 		crdClient := secretsStoreFakeClient.NewSimpleClientset(secretProviderClassPodStatusToProcess, secretProviderClassToAdd)
 
-		initObjects := []runtime.Object{
+		initObjects := []client.Object{
 			podToAdd,
 			secretToBeRotated,
 			test.nodePublishSecretRefSecretToAdd,
 			secretProviderClassPodStatusToProcess,
 			secretProviderClassToAdd,
 		}
-		client := controllerfake.NewFakeClientWithScheme(scheme, initObjects...)
+		ctrlClient := controllerfake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
-		testReconciler, err := newTestReconciler(client, scheme, kubeClient, crdClient, 60*time.Second, socketPath)
+		testReconciler, err := newTestReconciler(ctrlClient, scheme, kubeClient, crdClient, 60*time.Second, socketPath)
 		g.Expect(err).NotTo(HaveOccurred())
 		err = testReconciler.secretStore.Run(wait.NeverStop)
 		g.Expect(err).NotTo(HaveOccurred())
@@ -629,12 +629,12 @@ func TestReconcileNoError(t *testing.T) {
 		// test with pod being terminated
 		podToAdd.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 		kubeClient = fake.NewSimpleClientset(podToAdd, test.nodePublishSecretRefSecretToAdd)
-		initObjects = []runtime.Object{
+		initObjects = []client.Object{
 			podToAdd,
 			test.nodePublishSecretRefSecretToAdd,
 		}
-		client = controllerfake.NewFakeClientWithScheme(scheme, initObjects...)
-		testReconciler, err = newTestReconciler(client, scheme, kubeClient, crdClient, 60*time.Second, socketPath)
+		ctrlClient = controllerfake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+		testReconciler, err = newTestReconciler(ctrlClient, scheme, kubeClient, crdClient, 60*time.Second, socketPath)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(err).NotTo(HaveOccurred())
 
@@ -645,12 +645,12 @@ func TestReconcileNoError(t *testing.T) {
 		podToAdd.DeletionTimestamp = nil
 		podToAdd.Status.Phase = v1.PodSucceeded
 		kubeClient = fake.NewSimpleClientset(podToAdd, test.nodePublishSecretRefSecretToAdd)
-		initObjects = []runtime.Object{
+		initObjects = []client.Object{
 			podToAdd,
 			test.nodePublishSecretRefSecretToAdd,
 		}
-		client = controllerfake.NewFakeClientWithScheme(scheme, initObjects...)
-		testReconciler, err = newTestReconciler(client, scheme, kubeClient, crdClient, 60*time.Second, socketPath)
+		ctrlClient = controllerfake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+		testReconciler, err = newTestReconciler(ctrlClient, scheme, kubeClient, crdClient, 60*time.Second, socketPath)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(err).NotTo(HaveOccurred())
 
@@ -736,12 +736,12 @@ func TestPatchSecret(t *testing.T) {
 			kubeClient := fake.NewSimpleClientset(test.secretToAdd)
 			crdClient := secretsStoreFakeClient.NewSimpleClientset()
 
-			initObjects := []runtime.Object{
+			initObjects := []client.Object{
 				test.secretToAdd,
 			}
-			client := controllerfake.NewFakeClientWithScheme(scheme, initObjects...)
+			ctrlClient := controllerfake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
-			testReconciler, err := newTestReconciler(client, scheme, kubeClient, crdClient, 60*time.Second, "")
+			testReconciler, err := newTestReconciler(ctrlClient, scheme, kubeClient, crdClient, 60*time.Second, "")
 			g.Expect(err).NotTo(HaveOccurred())
 			err = testReconciler.secretStore.Run(wait.NeverStop)
 			g.Expect(err).NotTo(HaveOccurred())

--- a/pkg/secrets-store/secrets-store.go
+++ b/pkg/secrets-store/secrets-store.go
@@ -37,10 +37,10 @@ type SecretsStore struct {
 	ids *identityServer
 }
 
-func NewSecretsStoreDriver(driverName, nodeID, endpoint, providerVolumePath string, providerClients *PluginClientBuilder, client client.Client) *SecretsStore {
+func NewSecretsStoreDriver(driverName, nodeID, endpoint, providerVolumePath string, providerClients *PluginClientBuilder, client client.Client, reader client.Reader) *SecretsStore {
 	klog.InfoS("Initializing Secrets Store CSI Driver", "driver", driverName, "version", version.BuildVersion, "buildTime", version.BuildTime)
 
-	ns, err := newNodeServer(providerVolumePath, nodeID, mount.New(""), providerClients, client, NewStatsReporter())
+	ns, err := newNodeServer(providerVolumePath, nodeID, mount.New(""), providerClients, client, reader, NewStatsReporter())
 	if err != nil {
 		klog.ErrorS(err, "failed to initialize node server")
 		os.Exit(1)
@@ -54,13 +54,14 @@ func NewSecretsStoreDriver(driverName, nodeID, endpoint, providerVolumePath stri
 	}
 }
 
-func newNodeServer(providerVolumePath, nodeID string, mounter mount.Interface, providerClients *PluginClientBuilder, client client.Client, statsReporter StatsReporter) (*nodeServer, error) {
+func newNodeServer(providerVolumePath, nodeID string, mounter mount.Interface, providerClients *PluginClientBuilder, client client.Client, reader client.Reader, statsReporter StatsReporter) (*nodeServer, error) {
 	return &nodeServer{
 		providerVolumePath: providerVolumePath,
 		mounter:            mounter,
 		reporter:           statsReporter,
 		nodeID:             nodeID,
 		client:             client,
+		reader:             reader,
 		providerClients:    providerClients,
 	}, nil
 }

--- a/pkg/secrets-store/utils_test.go
+++ b/pkg/secrets-store/utils_test.go
@@ -15,3 +15,149 @@ limitations under the License.
 */
 
 package secretsstore
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var (
+	testPodName    = "pod-0"
+	testNamespace  = "default"
+	testPodUID     = "d8771ddf-935a-4199-a20b-f35f71c1d9e7"
+	testSPCName    = "spc-0"
+	testTargetPath = "/var/lib/kubelet/d8771ddf-935a-4199-a20b-f35f71c1d9e7/volumes/kubernetes.io~csi/secrets-store-inline/mount"
+)
+
+func setupScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	return scheme, nil
+}
+
+func newSecretProviderClassPodStatus(name, namespace, node string) *v1alpha1.SecretProviderClassPodStatus {
+	return &v1alpha1.SecretProviderClassPodStatus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			Labels:          map[string]string{v1alpha1.InternalNodeLabel: node},
+			UID:             "72a0ecb8-c6e5-41e1-8da1-25e37ec61b26",
+			ResourceVersion: "73659",
+		},
+		Status: v1alpha1.SecretProviderClassPodStatusStatus{
+			PodName:                 "pod1",
+			TargetPath:              "/var/lib/kubelet/pods/d8771ddf-935a-4199-a20b-f35f71c1d9e7/volumes/kubernetes.io~csi/secrets-store-inline/mount",
+			SecretProviderClassName: "spc1",
+			Mounted:                 true,
+		},
+	}
+}
+
+func TestCreateOrUpdateSecretProviderClassPodStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		nodeID string
+		// initial objects to add to the fake client
+		initObjects []client.Object
+		objects     map[string]string
+	}{
+		{
+			name:        "create",
+			nodeID:      "test-node",
+			initObjects: []client.Object{},
+			objects: map[string]string{
+				"b": "v1",
+				"a": "v2",
+			},
+		},
+		{
+			name:   "update",
+			nodeID: "test-node",
+			initObjects: []client.Object{
+				newSecretProviderClassPodStatus(fmt.Sprintf("%s-%s-%s", testPodName, testNamespace, testSPCName), testNamespace, "old-node"),
+			},
+			objects: map[string]string{
+				"b": "v1",
+				"a": "v2",
+			},
+		},
+	}
+
+	want := &v1alpha1.SecretProviderClassPodStatus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s-%s", testPodName, testNamespace, testSPCName),
+			Namespace: testNamespace,
+			Labels:    map[string]string{v1alpha1.InternalNodeLabel: "test-node"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       testPodName,
+					UID:        types.UID(testPodUID),
+				},
+			},
+		},
+		Status: v1alpha1.SecretProviderClassPodStatusStatus{
+			PodName:                 testPodName,
+			TargetPath:              testTargetPath,
+			SecretProviderClassName: testSPCName,
+			Mounted:                 true,
+			Objects: []v1alpha1.SecretProviderClassObject{
+				{
+					ID:      "a",
+					Version: "v2",
+				},
+				{
+					ID:      "b",
+					Version: "v1",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme, _ := setupScheme()
+			cb := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.initObjects...)
+			client := cb.Build()
+
+			err := createOrUpdateSecretProviderClassPodStatus(context.TODO(), client, client, testPodName, testNamespace, testPodUID, testSPCName, testTargetPath, tt.nodeID, true, tt.objects)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			got := &v1alpha1.SecretProviderClassPodStatus{}
+			if err := client.Get(context.TODO(), types.NamespacedName{
+				Name:      want.Name,
+				Namespace: want.Namespace,
+			}, got); err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(got.GetLabels(), want.GetLabels()) {
+				t.Errorf("ObjectMeta.GetLabels() got: %v, want: %v", got.GetLabels(), want.GetLabels())
+			}
+			if !reflect.DeepEqual(got.GetOwnerReferences(), want.GetOwnerReferences()) {
+				t.Errorf("ObjectMeta.GetOwnerReferences() got: %v, want: %v", got.GetOwnerReferences(), want.GetOwnerReferences())
+			}
+			if !reflect.DeepEqual(got.Status, want.Status) {
+				t.Errorf("Status got: %v, want: %v", got.Status, want.Status)
+			}
+		})
+	}
+}

--- a/pkg/util/spcpsutil/spcps.go
+++ b/pkg/util/spcpsutil/spcps.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spcpsutil
+
+import (
+	"sort"
+
+	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
+)
+
+// OrderSecretProviderClassObjectByID sorts SecretProviderClassObjects by ID
+func OrderSecretProviderClassObjectByID(objects []v1alpha1.SecretProviderClassObject) []v1alpha1.SecretProviderClassObject {
+	// sort the objects on ID to keep the order in status consistent across updates
+	sort.Slice(objects, func(i, j int) bool {
+		return objects[i].ID < objects[j].ID
+	})
+	return objects
+}

--- a/pkg/util/spcpsutil/spcps_test.go
+++ b/pkg/util/spcpsutil/spcps_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spcpsutil
+
+import (
+	"reflect"
+	"testing"
+
+	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
+)
+
+func TestOrderSecretProviderClassObjectByID(t *testing.T) {
+	tests := []struct {
+		name string
+		objs []v1alpha1.SecretProviderClassObject
+		want []v1alpha1.SecretProviderClassObject
+	}{
+		{
+			name: "empty",
+			objs: []v1alpha1.SecretProviderClassObject{},
+			want: []v1alpha1.SecretProviderClassObject{},
+		},
+		{
+			name: "one object",
+			objs: []v1alpha1.SecretProviderClassObject{
+				{
+					ID:      "a",
+					Version: "v1",
+				},
+			},
+			want: []v1alpha1.SecretProviderClassObject{
+				{
+					ID:      "a",
+					Version: "v1",
+				},
+			},
+		},
+		{
+			name: "two objects",
+			objs: []v1alpha1.SecretProviderClassObject{
+				{
+					ID:      "a",
+					Version: "v1",
+				},
+				{
+					ID:      "b",
+					Version: "v2",
+				},
+			},
+			want: []v1alpha1.SecretProviderClassObject{
+				{
+					ID:      "a",
+					Version: "v1",
+				},
+				{
+					ID:      "b",
+					Version: "v2",
+				},
+			},
+		},
+		{
+			name: "unsorted",
+			objs: []v1alpha1.SecretProviderClassObject{
+				{
+					ID:      "c",
+					Version: "v1",
+				},
+				{
+					ID:      "a",
+					Version: "v2",
+				},
+				{
+					ID:      "b",
+					Version: "v3",
+				},
+			},
+			want: []v1alpha1.SecretProviderClassObject{
+				{
+					ID:      "a",
+					Version: "v2",
+				},
+				{
+					ID:      "b",
+					Version: "v3",
+				},
+				{
+					ID:      "c",
+					Version: "v1",
+				},
+			},
+		},
+		{
+			name: "nested ids",
+			objs: []v1alpha1.SecretProviderClassObject{
+				{
+					ID:      "secret/secret1",
+					Version: "v1",
+				},
+				{
+					ID:      "secret/secret3",
+					Version: "v2",
+				},
+				{
+					ID:      "secret/secret2",
+					Version: "v3",
+				},
+			},
+			want: []v1alpha1.SecretProviderClassObject{
+				{
+					ID:      "secret/secret1",
+					Version: "v1",
+				},
+				{
+					ID:      "secret/secret2",
+					Version: "v3",
+				},
+				{
+					ID:      "secret/secret3",
+					Version: "v2",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := OrderSecretProviderClassObjectByID(tt.objs); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("OrderSecretProviderClassObjectByID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -37,7 +37,7 @@ const (
 )
 
 func TestSanity(t *testing.T) {
-	driver := secretsstore.NewSecretsStoreDriver("secrets-store.csi.k8s.io", "somenodeid", endpoint, providerVolumePath, nil, nil)
+	driver := secretsstore.NewSecretsStoreDriver("secrets-store.csi.k8s.io", "somenodeid", endpoint, providerVolumePath, nil, nil, nil)
 	go func() {
 		driver.Run(context.Background())
 	}()


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
-  Create or Update `SecretProviderClassPodStatus`. For pods scheduled by statefulsets the pod name is deterministic. In a scenario where this pod with name `pod-0` gets rescheduled to a new and there is a delay in garbage collection we would skip the `SecretProviderClassPodStatus` creation as it already exists. However when the garbage collection happens, the SPCPS will be deleted as it's still referencing the old owner (UID) with the same pod name which no longer exists. Using update in addition will update the node label and owner correctly post mount. 
- Replaces deprecated `fake.NewFakeClientWithScheme` with `fake.NewClientBuilder`
- Sorts the object version before setting in `SecretProviderClassPodStatus` for a more deterministic output

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
