### PR TITLE
chore: use structured logging and update imports order

### DIFF
--- a/controllers/secretproviderclasspodstatus_controller.go
+++ b/controllers/secretproviderclasspodstatus_controller.go
@@ -23,24 +23,11 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2"
-
 	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/client/clientset/versioned/scheme"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/fileutil"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/k8sutil"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/secretutil"
-
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -50,7 +37,16 @@ import (
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const (
@@ -107,7 +103,7 @@ func (r *SecretProviderClassPodStatusReconciler) RunPatcher(ctx context.Context)
 }
 
 func (r *SecretProviderClassPodStatusReconciler) Patcher(ctx context.Context) error {
-	klog.V(10).Infof("patcher started")
+	klog.V(10).Info("patcher started")
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
@@ -203,7 +199,7 @@ func (r *SecretProviderClassPodStatusReconciler) Patcher(ctx context.Context) er
 		}
 	}
 
-	klog.V(10).Infof("patcher completed")
+	klog.V(10).Info("patcher completed")
 	return nil
 }
 
@@ -469,7 +465,7 @@ func (r *SecretProviderClassPodStatusReconciler) patchSecretWithOwnerRef(ctx con
 		// add to map for tracking
 		secretOwnerMap[ownerRefs[i].Name] = ownerRefs[i].UID
 		needsPatch = true
-		klog.V(5).Infof("Adding %s/%s as owner ref for %s/%s", ownerRefs[i].APIVersion, ownerRefs[i].Name, namespace, name)
+		klog.V(5).InfoS("Adding owner ref for secret", "ownerRefAPIVersion", ownerRefs[i].APIVersion, "ownerRefName", ownerRefs[i].Name, "secret", klog.ObjectRef{Namespace: namespace, Name: name})
 		secretOwnerRefs = append(secretOwnerRefs, ownerRefs[i])
 	}
 

--- a/controllers/secretproviderclasspodstatus_controller_test.go
+++ b/controllers/secretproviderclasspodstatus_controller_test.go
@@ -21,21 +21,18 @@ import (
 	"sync"
 	"testing"
 
-	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
 
 	. "github.com/onsi/gomega"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
 )
 
 var (

--- a/pkg/k8s/store.go
+++ b/pkg/k8s/store.go
@@ -20,15 +20,14 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/client-go/informers/internalinterfaces"
-	"k8s.io/client-go/kubernetes"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	coreInformers "k8s.io/client-go/informers/core/v1"
+	"sigs.k8s.io/secrets-store-csi-driver/controllers"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreInformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/informers/internalinterfaces"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"sigs.k8s.io/secrets-store-csi-driver/controllers"
 )
 
 // Informer holds the shared index informers

--- a/pkg/k8s/store_test.go
+++ b/pkg/k8s/store_test.go
@@ -21,17 +21,14 @@ import (
 	"testing"
 	"time"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/secrets-store-csi-driver/controllers"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"k8s.io/client-go/kubernetes/fake"
-
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestGetNodePublishSecretRefSecret(t *testing.T) {

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -32,7 +32,7 @@ const prometheusExporter = "prometheus"
 
 func InitMetricsExporter() error {
 	mb := strings.ToLower(*metricsBackend)
-	klog.Infof("metrics backend: %s", mb)
+	klog.InfoS("initializing metrics backend", "backend", mb)
 	switch mb {
 	// Prometheus is the only exporter for now
 	case prometheusExporter:

--- a/pkg/metrics/prometheus_exporter.go
+++ b/pkg/metrics/prometheus_exporter.go
@@ -17,9 +17,8 @@ limitations under the License.
 package metrics
 
 import (
-	otProm "go.opentelemetry.io/otel/exporters/metric/prometheus"
-
 	"github.com/prometheus/client_golang/prometheus"
+	otProm "go.opentelemetry.io/otel/exporters/metric/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 

--- a/pkg/rotation/reconciler_test.go
+++ b/pkg/rotation/reconciler_test.go
@@ -25,32 +25,26 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/client-go/tools/record"
-
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/util/workqueue"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	v1 "k8s.io/api/core/v1"
-
-	. "github.com/onsi/gomega"
-
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	"k8s.io/client-go/kubernetes/fake"
-
 	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
 	"sigs.k8s.io/secrets-store-csi-driver/controllers"
 	secretsStoreFakeClient "sigs.k8s.io/secrets-store-csi-driver/pkg/client/clientset/versioned/fake"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/k8s"
 	secretsstore "sigs.k8s.io/secrets-store-csi-driver/pkg/secrets-store"
 	providerfake "sigs.k8s.io/secrets-store-csi-driver/provider/fake"
+
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var (

--- a/pkg/secrets-store/controllerserver.go
+++ b/pkg/secrets-store/controllerserver.go
@@ -17,12 +17,12 @@ limitations under the License.
 package secretsstore
 
 import (
+	"context"
+
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
-
-	"context"
 )
 
 type controllerServer struct {
@@ -63,7 +63,7 @@ func (cs *controllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacit
 // ControllerGetCapabilities implements the default GRPC callout.
 // Default supports all capabilities
 func (cs *controllerServer) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
-	klog.V(5).Infof("Using default ControllerGetCapabilities")
+	klog.V(5).Info("Using default ControllerGetCapabilities")
 
 	return &csi.ControllerGetCapabilitiesResponse{
 		Capabilities: []*csi.ControllerServiceCapability{

--- a/pkg/secrets-store/identityserver.go
+++ b/pkg/secrets-store/identityserver.go
@@ -61,7 +61,7 @@ func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPlugin
 }
 
 func (ids *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
-	klog.V(5).Infof("using default plugin capabilities in identity server")
+	klog.V(5).Info("using default plugin capabilities in identity server")
 
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{

--- a/pkg/secrets-store/nodeserver.go
+++ b/pkg/secrets-store/nodeserver.go
@@ -137,7 +137,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 				return nil, err
 			}
 		}
-		klog.Infof("skipping calling provider as it's mock")
+		klog.Info("skipping calling provider as it's mock")
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 

--- a/pkg/secrets-store/provider_client.go
+++ b/pkg/secrets-store/provider_client.go
@@ -27,15 +27,15 @@ import (
 	"sync"
 	"time"
 
+	internalerrors "sigs.k8s.io/secrets-store-csi-driver/pkg/errors"
+	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/fileutil"
+	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"k8s.io/klog/v2"
-
-	internalerrors "sigs.k8s.io/secrets-store-csi-driver/pkg/errors"
-	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/fileutil"
-	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
 )
 
 // ServiceConfig is used when building CSIDriverProvider clients. The configured
@@ -242,7 +242,7 @@ func MountContent(ctx context.Context, client v1alpha1.CSIDriverProviderClient, 
 	}
 
 	if len(resp.GetFiles()) > 0 {
-		klog.V(5).Infof("writing mount response files")
+		klog.V(5).Info("writing mount response files")
 		if err := fileutil.Validate(resp.GetFiles()); err != nil {
 			return nil, internalerrors.FileWriteError, err
 		}
@@ -252,7 +252,7 @@ func MountContent(ctx context.Context, client v1alpha1.CSIDriverProviderClient, 
 	} else {
 		// when no files are returned we assume that the plugin has not migrated
 		// grpc responses for writing files yet.
-		klog.V(5).Infof("mount response has no files")
+		klog.V(5).Info("mount response has no files")
 	}
 
 	return objectVersions, "", nil

--- a/pkg/secrets-store/provider_client_test.go
+++ b/pkg/secrets-store/provider_client_test.go
@@ -27,15 +27,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/test_utils/tmpdir"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/fileutil"
 	"sigs.k8s.io/secrets-store-csi-driver/provider/fake"
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func fakeServer(t *testing.T, path, provider string) (*fake.MockCSIProviderServer, func()) {

--- a/pkg/secrets-store/secrets-store.go
+++ b/pkg/secrets-store/secrets-store.go
@@ -18,6 +18,7 @@ package secretsstore
 
 import (
 	"context"
+	"os"
 
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/version"
 
@@ -41,7 +42,8 @@ func NewSecretsStoreDriver(driverName, nodeID, endpoint, providerVolumePath stri
 
 	ns, err := newNodeServer(providerVolumePath, nodeID, mount.New(""), providerClients, client, NewStatsReporter())
 	if err != nil {
-		klog.Fatalf("failed to initialize node server, error: %+v", err)
+		klog.ErrorS(err, "failed to initialize node server")
+		os.Exit(1)
 	}
 
 	return &SecretsStore{

--- a/pkg/util/fileutil/filesystem_test.go
+++ b/pkg/util/fileutil/filesystem_test.go
@@ -22,9 +22,10 @@ import (
 	"sort"
 	"testing"
 
+	"sigs.k8s.io/secrets-store-csi-driver/pkg/test_utils/tmpdir"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"sigs.k8s.io/secrets-store-csi-driver/pkg/test_utils/tmpdir"
 )
 
 func TestGetMountedFiles(t *testing.T) {

--- a/pkg/util/secretutil/secret_test.go
+++ b/pkg/util/secretutil/secret_test.go
@@ -22,11 +22,10 @@ import (
 	"reflect"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/provider/fake/fake_server.go
+++ b/provider/fake/fake_server.go
@@ -23,9 +23,9 @@ import (
 	"net"
 	"os"
 
-	"google.golang.org/grpc"
-
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
+
+	"google.golang.org/grpc"
 )
 
 type MockCSIProviderServer struct {

--- a/test/e2eprovider/e2e_provider.go
+++ b/test/e2eprovider/e2e_provider.go
@@ -46,16 +46,19 @@ func main() {
 
 	mockProviderServer, err := server.NewE2EProviderServer(*endpoint)
 	if err != nil {
-		klog.Fatalf("failed to get new mock e2e provider server, err: %+v", err)
+		klog.ErrorS(err, "failed to get new mock e2e provider server")
+		os.Exit(1)
 	}
 
 	if err := os.Remove(mockProviderServer.GetSocketPath()); err != nil && !os.IsNotExist(err) {
-		klog.Fatalf("failed to remove %s, error: %s", mockProviderServer.GetSocketPath(), err.Error())
+		klog.ErrorS(err, "failed to remove unix domain socket", "socketPath", mockProviderServer.GetSocketPath())
+		os.Exit(1)
 	}
 
 	err = mockProviderServer.Start()
 	if err != nil {
-		klog.Fatalf("failed to start mock e2e provider server, err: %+v", err)
+		klog.ErrorS(err, "failed to start mock e2e provider server")
+		os.Exit(1)
 	}
 
 	// endpoint to enable rotation response.

--- a/test/e2eprovider/server/server_test.go
+++ b/test/e2eprovider/server/server_test.go
@@ -26,8 +26,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 var (

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -24,10 +24,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kubernetes-csi/csi-test/v4/pkg/sanity"
-
 	secretsstore "sigs.k8s.io/secrets-store-csi-driver/pkg/secrets-store"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/version"
+
+	"github.com/kubernetes-csi/csi-test/v4/pkg/sanity"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Updates all the logs to use structured logging with klog
- Replaced `Fatalf` with `ErrorS` followed by `os.Exit(1)` as recommended in https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#change-log-functions-to-structured-equivalent
- Fix imports structure across all the packages. The format used in this project is
  ```bash
   import (
     std packages
    
     internal packages

     external packages
   )
   ```
**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
