### PR TITLE
chore: use `kubectl.kubernetes.io/default-container` annotation

### DIFF
--- a/.local/debug-driver.yaml
+++ b/.local/debug-driver.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         app: csi-secrets-store
       annotations:
-        kubectl.kubernetes.io/default-logs-container: secrets-store
+        kubectl.kubernetes.io/default-container: secrets-store
     spec:
       serviceAccountName: secrets-store-csi-driver
       containers:

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-logs-container: secrets-store
+        kubectl.kubernetes.io/default-container: secrets-store
 {{- if .Values.windows.podAnnotations }}
 {{ toYaml .Values.windows.podAnnotations | indent 8 }}
 {{- end }}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-logs-container: secrets-store
+        kubectl.kubernetes.io/default-container: secrets-store
 {{- if .Values.linux.podAnnotations }}
 {{ toYaml .Values.linux.podAnnotations | indent 8 }}
 {{- end }}

--- a/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver-windows.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         app: csi-secrets-store
       annotations:
-        kubectl.kubernetes.io/default-logs-container: secrets-store
+        kubectl.kubernetes.io/default-container: secrets-store
     spec:
       serviceAccountName: secrets-store-csi-driver
       containers:

--- a/manifest_staging/deploy/secrets-store-csi-driver.yaml
+++ b/manifest_staging/deploy/secrets-store-csi-driver.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         app: csi-secrets-store
       annotations:
-        kubectl.kubernetes.io/default-logs-container: secrets-store
+        kubectl.kubernetes.io/default-container: secrets-store
     spec:
       serviceAccountName: secrets-store-csi-driver
       containers:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
Deprecated annotation: `kubectl.kubernetes.io/default-logs-container`. Using `kubectl.kubernetes.io/default-container` instead. Ref: https://kubernetes.io/docs/reference/labels-annotations-taints/#kubectl-kubernetes-io-default-container

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
