### PR TITLE
chore: bump version to v1.0.0-rc.0 in release-1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,12 @@ E2E_PROVIDER_IMAGE_NAME ?= e2e-provider
 
 # Release version is the current supported release for the driver
 # Update this version when the helm chart is being updated for release
-RELEASE_VERSION := v0.3.0
-IMAGE_VERSION ?= v0.3.0
+RELEASE_VERSION := v1.0.0-rc.0
+IMAGE_VERSION ?= v1.0.0-rc.0
 
 # Use a custom version for E2E tests if we are testing in CI
 ifdef CI
-override IMAGE_VERSION := v0.3.0-e2e-$(BUILD_COMMIT)
+override IMAGE_VERSION := v1.0.0-e2e-$(BUILD_COMMIT)
 endif
 
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@
 REGISTRY?=docker.io/deislabs
 IMAGE_NAME=driver
 CRD_IMAGE_NAME=driver-crds
-IMAGE_VERSION?=v0.3.0
+IMAGE_VERSION?=v1.0.0-rc.0
 BUILD_TIMESTAMP := $(shell date +%Y-%m-%d-%H:%M)
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
