### PR TITLE
Support imagePullSecrets  in secrets-store-csi-driver-upgrade-crds

### DIFF
--- a/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
+++ b/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
@@ -91,6 +91,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "sscd.fullname" . }}-upgrade-crds
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       restartPolicy: Never
       containers:
       - name: crds-upgrade


### PR DESCRIPTION
without this change custom registry with authorization fails

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
