### PR TITLE
docs: add supported kubernetes versions

### DIFF
--- a/docs/Release_Management.md
+++ b/docs/Release_Management.md
@@ -44,6 +44,18 @@ This project strictly follows [semantic versioning](https://semver.org/spec/v2.0
 
 - Any `fixes` or `patches` should be merged to main and then `cherry pick` to the release branch.
 
+## Supported Releases
+
+Applicable fixes, including security fixes, may be cherry-picked into the release branch, depending on severity and feasibility. Patch releases are cut from that branch as needed.
+
+We expect users to stay reasonably up-to-date with the versions of Secrets Store CSI Driver they use in production, but understand that it may take time to upgrade. We expect users to be running approximately the latest patch release of a given minor release and encourage users to upgrade as soon as possible.
+
+We expect to "support" n (current) and n-1 major.minor releases. "Support" means we expect users to be running that version in production. For example, when v1.3.0 comes out, v1.1.x will no longer be supported for patches and we encourage users to upgrade to a supported version as soon as possible.
+
+## Supported Kubernetes Versions
+
+Secrets Store CSI Driver will maintain support for all actively supported Kubernetes minor releases per [Kubernetes Supported Versions policy](https://kubernetes.io/releases/version-skew-policy/). If you choose to use Secrets Store CSI Driver with a version of Kubernetes that it does not support, you are using it at your own risk.
+
 ## Acknowledgement
 
 This document builds on the ideas and implementations of release processes from projects like [Gatekeeper](https://github.com/open-policy-agent/gatekeeper/blob/master/docs/Release_Management.md), [Helm](https://helm.sh/docs/topics/release_policy/#helm) and Kubernetes.

--- a/docs/book/src/getting-started/installation.md
+++ b/docs/book/src/getting-started/installation.md
@@ -13,10 +13,7 @@ The helm chart repository URL has changed to `https://kubernetes-sigs.github.io/
 
 #### Supported kubernetes versions
 
-Recommended Kubernetes version:
-
-- **v1.16.0+** (For Linux)
-- **v1.18.0+** (For Windows)
+Secrets Store CSI Driver will maintain support for all actively supported Kubernetes minor releases per [Kubernetes Supported Versions policy](https://kubernetes.io/releases/version-skew-policy/). Check out the [Kubernetes releases](https://kubernetes.io/releases/) page for the latest supported Kubernetes releases.
 
 ### Deployment using Helm
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Adds supported kubernetes versions for the driver

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

This change was inspired by the supported kubernetes version note in [gatekeeper](https://github.com/open-policy-agent/gatekeeper)