### PR TITLE
tests: add e2e test for vault rotation

### DIFF
--- a/test/bats/tests/vault/pod-vault-rotation.yaml
+++ b/test/bats/tests/vault/pod-vault-rotation.yaml
@@ -1,0 +1,37 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: secrets-store-rotation
+spec:
+  containers:
+    - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      name: busybox
+      imagePullPolicy: IfNotPresent
+      command:
+        - "/bin/sleep"
+        - "10000"
+      volumeMounts:
+        - name: secrets-store-rotation
+          mountPath: "/mnt/secrets-store"
+          readOnly: true
+  volumes:
+    - name: secrets-store-rotation
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "vault-rotation"
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: vault-rotation
+spec:
+  provider: vault
+  parameters:
+    roleName: "csi"
+    vaultAddress: "http://vault.vault:8200"
+    objects: |
+      - secretPath: "secret/data/rotation"
+        objectName: "foo"
+        secretKey: "foo"


### PR DESCRIPTION
**What this PR does / why we need it**: For feature support matrix, ensure vault works with rotation.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/724

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
