### PR TITLE
chore: enable additional linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,15 +8,20 @@ linters:
   disable-all: true
   enable:
     - deadcode
+    - durationcheck
+    - exportloopref
+    - exhaustive
     - gofmt
     - goimports
     - gosimple
     - govet
     - gosec
     - ineffassign
+    - makezero
     - misspell
     - revive
     - structcheck
+    - typecheck
     - unused
     - varcheck
   # Run with --fast=false for more extensive checks (enables all linters)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

Details: https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/636
It passed: make lint-full, there are a few items is not list in this PR, for example goconst and gocyclo, which needs code change as well, once this PR is merged, I can pick up them up and fix the code changes.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->

**Special notes for your reviewer**:
