### PR TITLE
test: log the secrets-store API version

### DIFF
--- a/test/bats/e2e-provider.bats
+++ b/test/bats/e2e-provider.bats
@@ -39,6 +39,8 @@ export API_VERSION=$(get_secrets_store_api_version)
 
   run kubectl get crd/secretproviderclasses.secrets-store.csi.x-k8s.io
   assert_success
+
+  log_secrets_store_api_version
 }
 
 @test "secretproviderclasspodstatuses crd is established" {

--- a/test/bats/helpers.bash
+++ b/test/bats/helpers.bash
@@ -132,3 +132,8 @@ get_secrets_store_api_version() {
   local api_version=$(kubectl api-resources --api-group='secrets-store.csi.x-k8s.io' --no-headers=true | awk '{ print $2 }' | uniq)
   echo "${api_version}"
 }
+
+# log the secrets-store API version
+log_secrets_store_api_version() {
+  echo "Testing secrets-store API version $API_VERSION" >&3
+}


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Logs the secrets-store API version being tested as part of e2e

Sample output:
```bats
➜ bats -t test/bats/test.bats                            
1..2
Testing secrets-store API version secrets-store.csi.x-k8s.io/v1
ok 1 secretproviderclasses crd is established
ok 2 secretproviderclasspodstatuses crd is established
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
