### PR TITLE
chore: bump version 1.0.0 rc.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ E2E_PROVIDER_IMAGE_NAME ?= e2e-provider
 
 # Release version is the current supported release for the driver
 # Update this version when the helm chart is being updated for release
-RELEASE_VERSION := v1.0.0-rc.0
-IMAGE_VERSION ?= v1.0.0-rc.0
+RELEASE_VERSION := v1.0.0-rc.1
+IMAGE_VERSION ?= v1.0.0-rc.1
 
 # Use a custom version for E2E tests if we are testing in CI
 ifdef CI

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@
 REGISTRY?=docker.io/deislabs
 IMAGE_NAME=driver
 CRD_IMAGE_NAME=driver-crds
-IMAGE_VERSION?=v1.0.0-rc.0
+IMAGE_VERSION?=v1.0.0-rc.1
 BUILD_TIMESTAMP := $(shell date +%Y-%m-%d-%H:%M)
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION
Steps 4 and 5 from https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/docs/RELEASE.md#versioning for `v1.0.0-rc.1` release