### PR TITLE
Automated cherry pick of #769: fix: update base image core for ltsc2022

### DIFF
--- a/docker/BASEIMAGE
+++ b/docker/BASEIMAGE
@@ -4,4 +4,4 @@ windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/1903=mcr.microsoft.com/windows/nanoserver:1903
 windows/amd64/1909=mcr.microsoft.com/windows/nanoserver:1909
 windows/amd64/2004=mcr.microsoft.com/windows/nanoserver:2004
-windows/amd64/2004=mcr.microsoft.com/windows/nanoserver:ltsc2022
+windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022


### PR DESCRIPTION
Cherry pick of #769 on release-1.0.

#769: fix: update base image core for ltsc2022

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.