### PR TITLE
test: add k8s test matrix for staging e2e

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,6 +21,10 @@ on:
 jobs:
   e2e-test:
     runs-on: ubuntu-20.04
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        KUBERNETES_VERSION: ["v1.19.11", "v1.20.7", "v1.21.2", "v1.22.1"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -37,6 +41,7 @@ jobs:
         uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0
         with:
           version: "v0.11.1"
+          image: "kindest/node:${{ matrix.KUBERNETES_VERSION }}"
       - name: Test
         run: |
           # GH action sets this var by default. We need to explicitly unset it so that build commit hash is not appended to image tag.


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Enables k8s version matrix for the e2e workflow

Test run: https://github.com/aramase/secrets-store-csi-driver/actions/runs/1309023862

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
