### PR TITLE
docs: update docs for v1.0.0 and CRD version upgrades

### DIFF
--- a/docs/book/src/concepts.md
+++ b/docs/book/src/concepts.md
@@ -38,7 +38,7 @@ The `SecretProviderClass` is a namespaced resource in Secrets Store CSI Driver t
 `SecretProviderClass` custom resource should have the following components:
 
 ```yaml
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: my-provider
@@ -99,7 +99,7 @@ The `SecretProviderClassPodStatus` is created by the CSI driver in the same name
 Here is an example of a `SecretProviderClassPodStatus` resource:
 
 ```yaml
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClassPodStatus
 metadata:
   creationTimestamp: "2021-01-21T19:20:11Z"

--- a/docs/book/src/getting-started/upgrades.md
+++ b/docs/book/src/getting-started/upgrades.md
@@ -1,7 +1,24 @@
 # Upgrades
 
-<aside class="note warning">
-<h1>Warning</h1>
+This page includes instructions for upgrading the driver to the latest version.
+
+```bash
+helm upgrade csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver --namespace=NAMESPACE
+```
+
+Set `NAMESPACE` to the same namespace where the driver was originally installed,
+(i.e. `kube-system`)
+
+If you are upgrading from one of the following versions there may be additional
+steps that you should take.
+
+## pre `v1.0.0`
+
+Versions `v1.0.0-rc.1` and later use the `v1` version of the `SecretProviderClass` and `SecretProviderClassPodStatus`
+`CustomResourceDefinition`s. `secrets-store.csi.x-k8s.io/v1alpha1` versioned `CRD`s will continue to work, but consider
+updating your YAMLs to `secrets-store.csi.x-k8s.io/v1`.
+
+## pre `v0.3.0`
 
 The helm chart repository URL has changed to `https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts`.
 
@@ -14,18 +31,6 @@ helm repo update
 ```
 
 </aside>
-
-This page includes instructions for upgrading the driver to the latest version.
-
-```bash
-helm upgrade csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver --namespace=NAMESPACE
-```
-
-Set `NAMESPACE` to the same namespace where the driver was originally installed,
-(i.e. `kube-system`)
-
-If you are upgrading from one of the following versions there may be additional
-steps that you should take.
 
 ## pre `v0.1.0`
 

--- a/docs/book/src/getting-started/usage.md
+++ b/docs/book/src/getting-started/usage.md
@@ -7,7 +7,7 @@ To use the Secrets Store CSI driver, create a `SecretProviderClass` custom resou
 A `SecretProviderClass` custom resource should have the following components:
 
 ```yaml
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: my-provider

--- a/docs/book/src/topics/sync-as-kubernetes-secret.md
+++ b/docs/book/src/topics/sync-as-kubernetes-secret.md
@@ -6,7 +6,7 @@
 - `SecretProviderClass`
 
 ```yaml
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: azure-sync


### PR DESCRIPTION
**What this PR does / why we need it**:

In preparation for v1.0.0 release, update the upgrade instructions.