### PR TITLE
docs: add project status to docs

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -17,3 +17,4 @@
 - [Load tests](./load-tests.md)
 - [Testing](./testing.md)
 - [Known Limitations](./known-limitations.md)
+- [Release Managment](./release-management.md)

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -13,15 +13,35 @@ Join us to help define the direction and implementation of this project!
 - Use [GitHub Issues](https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues) to file bugs, request features, or ask questions asynchronously.
 - Join [biweekly community meetings](https://docs.google.com/document/d/1q74nboAg0GSPcom3kLWCIoWg43Qg3mr306KNL58f2hg/edit?usp=sharing) to discuss development, issues, use cases, etc.
 
+## Project Status
+
+| Driver                                                                                    | Compatible Kubernetes | `secrets-store.csi.k8s.io` Versions |
+|-------------------------------------------------------------------------------------------|-----------------------|-------------------------------------|
+| [v1.0.0](https://github.com/kubernetes-sigs/secrets-store-csi-driver/releases/tag/v1.0.0) | 1.19+                 | `v1`, `v1alpha1`                    |
+| [v0.3.0](https://github.com/kubernetes-sigs/secrets-store-csi-driver/releases/tag/v0.3.0) | 1.19+                 | `v1alpha1`                          |
+
+See
+[Release Management](./release-management.md)
+for additional details on versioning. We aim to release a new minor version every month and intend to support the latest
+2 minor versions of the driver.
+
 ## Features
 
+### Driver Core Functionality (Stable)
+
+- Multiple external [secrets store providers](./providers.md)
+- Pod portability with the `SecretProviderClass` `CustomResourceDefinition`
 - Mounts secrets/keys/certs to pod using a CSI volume
-- Supports mounting multiple secrets store objects as a single volume
-- Supports multiple secrets stores as providers. Multiple providers can run in the same cluster simultaneously
-- Supports pod portability with the SecretProviderClass CRD
-- Supports windows containers (Kubernetes version v1.18+)
-- Supports sync with Kubernetes Secrets (Secrets Store CSI Driver v0.0.10+)
-- Support auto rotation of mounted contents and synced Kubernetes secret (Secrets Store CSI Driver v0.0.15+)
+- Mount multiple secrets store objects as a single volume
+- Windows containers
+
+### Alpha Functionality
+
+These features are not stable. If you use these be sure to consult the
+[upgrade instructions](./getting-started/upgrades.md) with each upgrade.
+
+- [Auto rotation](./topics/secret-auto-rotation.md) of mounted contents and synced Kubernetes secret
+- [Sync with Kubernetes Secrets](./topics/sync-as-kubernetes-secret.md)
 
 ## Supported Providers
 

--- a/docs/book/src/release-management.md
+++ b/docs/book/src/release-management.md
@@ -32,8 +32,6 @@ This project strictly follows [semantic versioning](https://semver.org/spec/v2.0
 
 - Ideally we will avoid making multiple major releases to be always backward compatible, unless project evolves in important new directions and such release is necessary.
 
-- Secrets Store CSI Driver is currently tracking towards first stable release(v1.0.0) with [this](https://github.com/kubernetes-sigs/secrets-store-csi-driver/milestone/5) milestone.
-
 ## Release Cadence and Branching
 
 - Secrets Store CSI Driver follows `monthly` release schedule.

--- a/docs/book/src/topics/sync-as-kubernetes-secret.md
+++ b/docs/book/src/topics/sync-as-kubernetes-secret.md
@@ -74,7 +74,7 @@ In some cases, you may want to create a Kubernetes Secret to mirror the mounted 
 A `SecretProviderClass` custom resource should have the following components:
 
 ```yaml
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: my-provider


### PR DESCRIPTION
**What this PR does / why we need it**: Add details of project status to landing page.

- callout which features are considered GA
- callout which version are supported

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #588

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
