### PR TITLE
chore: use `errors.Wrap` instead of `fmt.Errorf`

### DIFF
--- a/pkg/k8s/secret.go
+++ b/pkg/k8s/secret.go
@@ -17,8 +17,7 @@ limitations under the License.
 package k8s
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -41,7 +40,7 @@ func (sl *SecretLister) GetWithKey(key string) (*corev1.Secret, error) {
 	}
 	secret, ok := sec.(*corev1.Secret)
 	if !ok {
-		return nil, fmt.Errorf("failed to cast %T to %s", sec, "secret")
+		return nil, errors.Errorf("failed to cast %T to secret", sec)
 	}
 	return secret, nil
 }

--- a/pkg/k8s/store.go
+++ b/pkg/k8s/store.go
@@ -22,6 +22,7 @@ import (
 
 	"sigs.k8s.io/secrets-store-csi-driver/controllers"
 
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreInformers "k8s.io/client-go/informers/core/v1"
@@ -83,7 +84,7 @@ func (i *Informer) run(stopCh <-chan struct{}) error {
 		i.NodePublishSecretRefSecret.HasSynced,
 	}
 	if !cache.WaitForCacheSync(stopCh, synced...) {
-		return fmt.Errorf("failed to sync informer caches")
+		return errors.New("failed to sync informer caches")
 	}
 	return nil
 }

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -18,9 +18,9 @@ package metrics
 
 import (
 	"flag"
-	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -38,6 +38,6 @@ func InitMetricsExporter() error {
 	case prometheusExporter:
 		return initPrometheusExporter()
 	default:
-		return fmt.Errorf("unsupported metrics backend %v", *metricsBackend)
+		return errors.Errorf("unsupported metrics backend %v", *metricsBackend)
 	}
 }

--- a/pkg/secrets-store/provider_client_test.go
+++ b/pkg/secrets-store/provider_client_test.go
@@ -18,7 +18,6 @@ package secretsstore
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -33,6 +32,7 @@ import (
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/pkg/secrets-store/server.go
+++ b/pkg/secrets-store/server.go
@@ -18,7 +18,6 @@ package secretsstore
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"os"
 	"runtime"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	pbSanitizer "github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
@@ -137,7 +137,7 @@ func parseEndpoint(ep string) (string, string, error) {
 			return s[0], s[1], nil
 		}
 	}
-	return "", "", fmt.Errorf("invalid endpoint: %v", ep)
+	return "", "", errors.Errorf("invalid endpoint: %v", ep)
 }
 
 // logInterceptor returns a new unary server interceptors that performs request

--- a/pkg/secrets-store/utils.go
+++ b/pkg/secrets-store/utils.go
@@ -18,7 +18,6 @@ package secretsstore
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -26,6 +25,7 @@ import (
 	secretsstorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/spcpsutil"
 
+	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -83,7 +83,7 @@ func getSecretProviderItem(ctx context.Context, c client.Client, name, namespace
 		Name:      name,
 	}
 	if err := c.Get(ctx, spcKey, spc); err != nil {
-		return nil, fmt.Errorf("failed to get secretproviderclass %s/%s, error: %w", namespace, name, err)
+		return nil, errors.Wrapf(err, "failed to get secretproviderclass %s/%s", namespace, name)
 	}
 	return spc, nil
 }
@@ -155,7 +155,7 @@ func createOrUpdateSecretProviderClassPodStatus(ctx context.Context, c client.Cl
 // getProviderFromSPC returns the provider as defined in SecretProviderClass
 func getProviderFromSPC(spc *secretsstorev1.SecretProviderClass) (string, error) {
 	if len(spc.Spec.Provider) == 0 {
-		return "", fmt.Errorf("provider not set in %s/%s", spc.Namespace, spc.Name)
+		return "", errors.Errorf("provider not set in %s/%s", spc.Namespace, spc.Name)
 	}
 	return string(spc.Spec.Provider), nil
 }
@@ -163,7 +163,7 @@ func getProviderFromSPC(spc *secretsstorev1.SecretProviderClass) (string, error)
 // getParametersFromSPC returns the parameters map as defined in SecretProviderClass
 func getParametersFromSPC(spc *secretsstorev1.SecretProviderClass) (map[string]string, error) {
 	if len(spc.Spec.Parameters) == 0 {
-		return nil, fmt.Errorf("parameters not set in %s/%s", spc.Namespace, spc.Name)
+		return nil, errors.Errorf("parameters not set in %s/%s", spc.Namespace, spc.Name)
 	}
 	return spc.Spec.Parameters, nil
 }

--- a/pkg/util/fileutil/writer.go
+++ b/pkg/util/fileutil/writer.go
@@ -17,10 +17,10 @@ limitations under the License.
 package fileutil
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
 )
 
@@ -31,7 +31,7 @@ func Validate(payloads []*v1alpha1.File) error {
 			return err
 		}
 		if filepath.Clean(payloads[i].Path) != payloads[i].Path {
-			return fmt.Errorf("invalid filepath: %q", payloads[i].Path)
+			return errors.Errorf("invalid filepath: %q", payloads[i].Path)
 		}
 	}
 
@@ -45,7 +45,7 @@ func WritePayloads(path string, payloads []*v1alpha1.File) error {
 	// cleanup any payload paths that may have been written by a previous
 	// version of the driver/provider.
 	if err := cleanupProviderFiles(path, payloads); err != nil {
-		return fmt.Errorf("cleanup failure: %w", err)
+		return errors.Wrap(err, "cleanup failure")
 	}
 
 	w, err := NewAtomicWriter(path, "secrets-store-csi-driver")

--- a/pkg/util/fileutil/writer_test.go
+++ b/pkg/util/fileutil/writer_test.go
@@ -18,8 +18,6 @@ package fileutil
 
 import (
 	"bytes"
-	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -29,6 +27,8 @@ import (
 
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/test_utils/tmpdir"
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
+
+	"github.com/pkg/errors"
 )
 
 func TestValidate_Success(t *testing.T) {
@@ -446,11 +446,11 @@ func readPayloads(path string, payloads []*v1alpha1.File) error {
 			// on windows only the 0200 bitmask is used by chmod
 			// https://golang.org/src/os/file.go?s=15847:15891#L522
 			if (info.Mode() & 0200) != (fs.FileMode(p.Mode) & 0200) {
-				return fmt.Errorf("unexpected file mode. got: %v, want: %v", info.Mode(), fs.FileMode(p.Mode))
+				return errors.Errorf("unexpected file mode. got: %v, want: %v", info.Mode(), fs.FileMode(p.Mode))
 			}
 		} else {
 			if info.Mode() != fs.FileMode(p.Mode) {
-				return fmt.Errorf("unexpected file mode. got: %v, want: %v", info.Mode(), fs.FileMode(p.Mode))
+				return errors.Errorf("unexpected file mode. got: %v, want: %v", info.Mode(), fs.FileMode(p.Mode))
 			}
 		}
 

--- a/provider/fake/fake_server.go
+++ b/provider/fake/fake_server.go
@@ -19,12 +19,12 @@ package fake
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net"
 	"os"
 
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
 
+	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 
@@ -109,16 +109,16 @@ func (m *MockCSIProviderServer) Mount(ctx context.Context, req *v1alpha1.MountRe
 		return &v1alpha1.MountResponse{}, m.returnErr
 	}
 	if err = json.Unmarshal([]byte(req.GetAttributes()), &attrib); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal attributes, error: %w", err)
+		return nil, errors.Wrap(err, "failed to unmarshal attributes")
 	}
 	if err = json.Unmarshal([]byte(req.GetSecrets()), &secret); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal secrets, error: %w", err)
+		return nil, errors.Wrap(err, "failed to unmarshal secrets")
 	}
 	if err = json.Unmarshal([]byte(req.GetPermission()), &filePermission); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal file permission, error: %w", err)
+		return nil, errors.Wrap(err, "failed to unmarshal file permission")
 	}
 	if len(req.GetTargetPath()) == 0 {
-		return nil, fmt.Errorf("missing target path")
+		return nil, errors.New("missing target path")
 	}
 	return &v1alpha1.MountResponse{
 		ObjectVersion: m.objects,

--- a/test/e2eprovider/go.mod
+++ b/test/e2eprovider/go.mod
@@ -6,6 +6,7 @@ replace sigs.k8s.io/secrets-store-csi-driver => ../..
 
 require (
 	github.com/google/go-cmp v0.5.6
+	github.com/pkg/errors v0.9.1
 	google.golang.org/grpc v1.40.0
 	k8s.io/klog/v2 v2.10.0
 	sigs.k8s.io/secrets-store-csi-driver v0.0.0-00010101000000-000000000000

--- a/test/e2eprovider/go.sum
+++ b/test/e2eprovider/go.sum
@@ -388,6 +388,7 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -18,7 +18,6 @@ package sanity
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,6 +27,7 @@ import (
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/version"
 
 	"github.com/kubernetes-csi/csi-test/v4/pkg/sanity"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -69,7 +69,7 @@ func createTargetDir(targetPath string) error {
 		return err
 	}
 	if !fileInfo.IsDir() {
-		return fmt.Errorf("target location %s is not a directory", targetPath)
+		return errors.Errorf("target location %s is not a directory", targetPath)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Uses `error.Wrap`, `errors.Errorf` and `errors.Wrapf` for consistently wrapping errors across the entire codebase. 
  - All occurences of `fmt.Errorf` have been replaced with the errors package. The autogenerated files have been skipped.
- As of go1.13, the error can also be wrapped using `fmt.Errorf` and `%w`. But using the errors package as it's easier for consistency and making it easier for all contributors.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
- We should factor this in our code reviews.

/kind cleanup