### PR TITLE
chore: use `corev1` as import alias instead of `v1`

### DIFF
--- a/controllers/secretproviderclasspodstatus_controller_test.go
+++ b/controllers/secretproviderclasspodstatus_controller_test.go
@@ -24,7 +24,7 @@ import (
 	secretsstorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -50,8 +50,8 @@ func setupScheme() (*runtime.Scheme, error) {
 	return scheme, nil
 }
 
-func newSecret(name, namespace string, labels map[string]string, annotations map[string]string) *v1.Secret {
-	return &v1.Secret{
+func newSecret(name, namespace string, labels map[string]string, annotations map[string]string) *corev1.Secret {
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			Namespace:       namespace,
@@ -98,8 +98,8 @@ func newSecretProviderClass(name, namespace string) *secretsstorev1.SecretProvid
 	}
 }
 
-func newPod(name, namespace string, owners []metav1.OwnerReference) *v1.Pod {
-	return &v1.Pod{
+func newPod(name, namespace string, owners []metav1.OwnerReference) *corev1.Pod {
+	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			Namespace:       namespace,
@@ -176,7 +176,7 @@ func TestPatchSecretWithOwnerRef(t *testing.T) {
 	err = reconciler.patchSecretWithOwnerRef(context.TODO(), "my-secret", "default", ref, ref)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	secret := &v1.Secret{}
+	secret := &corev1.Secret{}
 	err = client.Get(context.TODO(), types.NamespacedName{Name: "my-secret", Namespace: "default"}, secret)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(secret.GetOwnerReferences()).To(HaveLen(1))
@@ -198,12 +198,12 @@ func TestCreateK8sSecret(t *testing.T) {
 	reconciler := newReconciler(client, scheme, "node1")
 
 	// secret already exists
-	err = reconciler.createK8sSecret(context.TODO(), "my-secret", "default", nil, labels, annotations, v1.SecretTypeOpaque)
+	err = reconciler.createK8sSecret(context.TODO(), "my-secret", "default", nil, labels, annotations, corev1.SecretTypeOpaque)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	err = reconciler.createK8sSecret(context.TODO(), "my-secret2", "default", nil, labels, annotations, v1.SecretTypeOpaque)
+	err = reconciler.createK8sSecret(context.TODO(), "my-secret2", "default", nil, labels, annotations, corev1.SecretTypeOpaque)
 	g.Expect(err).NotTo(HaveOccurred())
-	secret := &v1.Secret{}
+	secret := &corev1.Secret{}
 	err = client.Get(context.TODO(), types.NamespacedName{Name: "my-secret2", Namespace: "default"}, secret)
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -221,14 +221,14 @@ func TestGenerateEvent(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 	reconciler := newReconciler(client, scheme, "node1")
 
-	obj := &v1.ObjectReference{
+	obj := &corev1.ObjectReference{
 		Name:      "pod1",
 		Namespace: "default",
 		UID:       "481ab824-1f07-4611-bc08-c41f5cbb5a8d",
 	}
 
-	reconciler.generateEvent(obj, v1.EventTypeWarning, "reason", "message")
-	reconciler.generateEvent(obj, v1.EventTypeWarning, "reason2", "message2")
+	reconciler.generateEvent(obj, corev1.EventTypeWarning, "reason", "message")
+	reconciler.generateEvent(obj, corev1.EventTypeWarning, "reason2", "message2")
 
 	event := <-fakeRecorder.Events
 	g.Expect(event).To(Equal("Warning reason message"))
@@ -255,7 +255,7 @@ func TestPatcherForStaticPod(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// check the spcps has been added as owner to the secret
-	secret := &v1.Secret{}
+	secret := &corev1.Secret{}
 	err = client.Get(context.TODO(), types.NamespacedName{Name: "secret1", Namespace: "default"}, secret)
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -294,7 +294,7 @@ func TestPatcherForPodWithOwner(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// check the spcps has been added as owner to the secret
-	secret := &v1.Secret{}
+	secret := &corev1.Secret{}
 	err = client.Get(context.TODO(), types.NamespacedName{Name: "secret1", Namespace: "default"}, secret)
 	g.Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/k8s/secret.go
+++ b/pkg/k8s/secret.go
@@ -19,7 +19,7 @@ package k8s
 import (
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
@@ -31,15 +31,15 @@ type SecretLister struct {
 }
 
 // GetWithKey returns secret with key from the informer cache
-func (sl *SecretLister) GetWithKey(key string) (*v1.Secret, error) {
+func (sl *SecretLister) GetWithKey(key string) (*corev1.Secret, error) {
 	sec, exists, err := sl.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}
 	if !exists {
-		return nil, apierrors.NewNotFound(schema.GroupResource{Group: v1.GroupName, Resource: "secrets"}, key)
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: corev1.GroupName, Resource: "secrets"}, key)
 	}
-	secret, ok := sec.(*v1.Secret)
+	secret, ok := sec.(*corev1.Secret)
 	if !ok {
 		return nil, fmt.Errorf("failed to cast %T to %s", sec, "secret")
 	}

--- a/pkg/k8s/store.go
+++ b/pkg/k8s/store.go
@@ -22,7 +22,7 @@ import (
 
 	"sigs.k8s.io/secrets-store-csi-driver/controllers"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreInformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/informers/internalinterfaces"
@@ -43,7 +43,7 @@ type Lister struct {
 // Store for secrets with label 'secrets-store.csi.k8s.io/used'
 type Store interface {
 	// GetNodePublishSecretRefSecret returns the NodePublishSecretRef secret matching name and namespace
-	GetNodePublishSecretRefSecret(name, namespace string) (*v1.Secret, error)
+	GetNodePublishSecretRefSecret(name, namespace string) (*corev1.Secret, error)
 	// Run initializes and runs the informers
 	Run(stopCh <-chan struct{}) error
 }
@@ -72,7 +72,7 @@ func (s k8sStore) Run(stopCh <-chan struct{}) error {
 }
 
 // GetNodePublishSecretRefSecret returns the NodePublishSecretRef secret matching name and namespace
-func (s k8sStore) GetNodePublishSecretRefSecret(name, namespace string) (*v1.Secret, error) {
+func (s k8sStore) GetNodePublishSecretRefSecret(name, namespace string) (*corev1.Secret, error) {
 	return s.listers.NodePublishSecretRefSecret.GetWithKey(fmt.Sprintf("%s/%s", namespace, name))
 }
 
@@ -92,7 +92,7 @@ func (i *Informer) run(stopCh <-chan struct{}) error {
 func newNodePublishSecretRefSecretInformer(kubeClient kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 	return coreInformers.NewFilteredSecretInformer(
 		kubeClient,
-		v1.NamespaceAll,
+		corev1.NamespaceAll,
 		resyncPeriod,
 		cache.Indexers{},
 		usedFilterForSecret(),

--- a/pkg/k8s/store_test.go
+++ b/pkg/k8s/store_test.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/secrets-store-csi-driver/controllers"
 
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -46,7 +46,7 @@ func TestGetNodePublishSecretRefSecret(t *testing.T) {
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
-	secretToAdd := &v1.Secret{
+	secretToAdd := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "secret1",
 			Namespace: "default",

--- a/pkg/rotation/reconciler_test.go
+++ b/pkg/rotation/reconciler_test.go
@@ -33,7 +33,7 @@ import (
 	providerfake "sigs.k8s.io/secrets-store-csi-driver/provider/fake"
 
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -90,9 +90,9 @@ func TestReconcileError(t *testing.T) {
 		rotationPollInterval                  time.Duration
 		secretProviderClassPodStatusToProcess *secretsstorev1.SecretProviderClassPodStatus
 		secretProviderClassToAdd              *secretsstorev1.SecretProviderClass
-		podToAdd                              *v1.Pod
+		podToAdd                              *corev1.Pod
 		socketPath                            string
-		secretToAdd                           *v1.Secret
+		secretToAdd                           *corev1.Secret
 		expectedObjectVersions                map[string]string
 		expectedErr                           bool
 		expectedErrorEvents                   bool
@@ -112,9 +112,9 @@ func TestReconcileError(t *testing.T) {
 				},
 			},
 			secretProviderClassToAdd: &secretsstorev1.SecretProviderClass{},
-			podToAdd:                 &v1.Pod{},
+			podToAdd:                 &corev1.Pod{},
 			socketPath:               getTempTestDir(t),
-			secretToAdd:              &v1.Secret{},
+			secretToAdd:              &corev1.Secret{},
 			expectedErr:              true,
 		},
 		{
@@ -149,9 +149,9 @@ func TestReconcileError(t *testing.T) {
 					},
 				},
 			},
-			podToAdd:    &v1.Pod{},
+			podToAdd:    &corev1.Pod{},
 			socketPath:  getTempTestDir(t),
-			secretToAdd: &v1.Secret{},
+			secretToAdd: &corev1.Secret{},
 			expectedErr: true,
 		},
 		{
@@ -188,21 +188,21 @@ func TestReconcileError(t *testing.T) {
 					Provider: "provider1",
 				},
 			},
-			podToAdd: &v1.Pod{
+			podToAdd: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod1",
 					Namespace: "default",
 					UID:       types.UID("foo"),
 				},
-				Spec: v1.PodSpec{
-					Volumes: []v1.Volume{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
 						{
 							Name: "csi-volume",
-							VolumeSource: v1.VolumeSource{
-								CSI: &v1.CSIVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
 									Driver:           "secrets-store.csi.k8s.io",
 									VolumeAttributes: map[string]string{"secretProviderClass": "spc1"},
-									NodePublishSecretRef: &v1.LocalObjectReference{
+									NodePublishSecretRef: &corev1.LocalObjectReference{
 										Name: "secret1",
 									},
 								},
@@ -212,7 +212,7 @@ func TestReconcileError(t *testing.T) {
 				},
 			},
 			socketPath:          getTempTestDir(t),
-			secretToAdd:         &v1.Secret{},
+			secretToAdd:         &corev1.Secret{},
 			expectedErr:         true,
 			expectedErrorEvents: true,
 		},
@@ -256,18 +256,18 @@ func TestReconcileError(t *testing.T) {
 					Provider: "provider1",
 				},
 			},
-			podToAdd: &v1.Pod{
+			podToAdd: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod1",
 					Namespace: "default",
 					UID:       types.UID("foo"),
 				},
-				Spec: v1.PodSpec{
-					Volumes: []v1.Volume{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
 						{
 							Name: "csi-volume",
-							VolumeSource: v1.VolumeSource{
-								CSI: &v1.CSIVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
 									Driver:           "secrets-store.csi.k8s.io",
 									VolumeAttributes: map[string]string{"secretProviderClass": "spc1"},
 								},
@@ -277,7 +277,7 @@ func TestReconcileError(t *testing.T) {
 				},
 			},
 			socketPath: getTempTestDir(t),
-			secretToAdd: &v1.Secret{
+			secretToAdd: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "object1",
 					Namespace:       "default",
@@ -329,18 +329,18 @@ func TestReconcileError(t *testing.T) {
 					Provider: "provider1",
 				},
 			},
-			podToAdd: &v1.Pod{
+			podToAdd: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod1",
 					Namespace: "default",
 					UID:       types.UID("foo"),
 				},
-				Spec: v1.PodSpec{
-					Volumes: []v1.Volume{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
 						{
 							Name: "csi-volume",
-							VolumeSource: v1.VolumeSource{
-								CSI: &v1.CSIVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
 									Driver:           "secrets-store.csi.k8s.io",
 									VolumeAttributes: map[string]string{"secretProviderClass": "spc1"},
 								},
@@ -350,7 +350,7 @@ func TestReconcileError(t *testing.T) {
 				},
 			},
 			socketPath: getTempTestDir(t),
-			secretToAdd: &v1.Secret{
+			secretToAdd: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "object1",
 					Namespace:       "default",
@@ -396,21 +396,21 @@ func TestReconcileError(t *testing.T) {
 					Provider: "wrongprovider",
 				},
 			},
-			podToAdd: &v1.Pod{
+			podToAdd: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pod1",
 					Namespace: "default",
 					UID:       types.UID("foo"),
 				},
-				Spec: v1.PodSpec{
-					Volumes: []v1.Volume{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
 						{
 							Name: "csi-volume",
-							VolumeSource: v1.VolumeSource{
-								CSI: &v1.CSIVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
 									Driver:           "secrets-store.csi.k8s.io",
 									VolumeAttributes: map[string]string{"secretProviderClass": "spc1"},
-									NodePublishSecretRef: &v1.LocalObjectReference{
+									NodePublishSecretRef: &corev1.LocalObjectReference{
 										Name: "secret1",
 									},
 								},
@@ -420,7 +420,7 @@ func TestReconcileError(t *testing.T) {
 				},
 			},
 			socketPath: getTempTestDir(t),
-			secretToAdd: &v1.Secret{
+			secretToAdd: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "secret1",
 					Namespace: "default",
@@ -481,12 +481,12 @@ func TestReconcileNoError(t *testing.T) {
 	tests := []struct {
 		name                            string
 		filteredWatchEnabled            bool
-		nodePublishSecretRefSecretToAdd *v1.Secret
+		nodePublishSecretRefSecretToAdd *corev1.Secret
 	}{
 		{
 			name:                 "filtered watch for nodePublishSecretRef",
 			filteredWatchEnabled: true,
-			nodePublishSecretRefSecretToAdd: &v1.Secret{
+			nodePublishSecretRefSecretToAdd: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "secret1",
 					Namespace: "default",
@@ -539,21 +539,21 @@ func TestReconcileNoError(t *testing.T) {
 				Provider: "provider1",
 			},
 		}
-		podToAdd := &v1.Pod{
+		podToAdd := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod1",
 				Namespace: "default",
 				UID:       types.UID("foo"),
 			},
-			Spec: v1.PodSpec{
-				Volumes: []v1.Volume{
+			Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
 					{
 						Name: "csi-volume",
-						VolumeSource: v1.VolumeSource{
-							CSI: &v1.CSIVolumeSource{
+						VolumeSource: corev1.VolumeSource{
+							CSI: &corev1.CSIVolumeSource{
 								Driver:           "secrets-store.csi.k8s.io",
 								VolumeAttributes: map[string]string{"secretProviderClass": "spc1"},
-								NodePublishSecretRef: &v1.LocalObjectReference{
+								NodePublishSecretRef: &corev1.LocalObjectReference{
 									Name: "secret1",
 								},
 							},
@@ -562,7 +562,7 @@ func TestReconcileNoError(t *testing.T) {
 				},
 			},
 		}
-		secretToBeRotated := &v1.Secret{
+		secretToBeRotated := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "foosecret",
 				Namespace:       "default",
@@ -612,12 +612,12 @@ func TestReconcileNoError(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// validate the secret provider class pod status versions have been updated
-		updatedSPCPodStatus, err := crdClient.SecretsstoreV1().SecretProviderClassPodStatuses(v1.NamespaceDefault).Get(context.TODO(), "pod1-default-spc1", metav1.GetOptions{})
+		updatedSPCPodStatus, err := crdClient.SecretsstoreV1().SecretProviderClassPodStatuses(corev1.NamespaceDefault).Get(context.TODO(), "pod1-default-spc1", metav1.GetOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(updatedSPCPodStatus.Status.Objects).To(Equal([]secretsstorev1.SecretProviderClassObject{{ID: "secret/object1", Version: "v2"}}))
 
 		// validate the secret data has been updated to the latest value
-		updatedSecret, err := kubeClient.CoreV1().Secrets(v1.NamespaceDefault).Get(context.TODO(), "foosecret", metav1.GetOptions{})
+		updatedSecret, err := kubeClient.CoreV1().Secrets(corev1.NamespaceDefault).Get(context.TODO(), "foosecret", metav1.GetOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(updatedSecret.Data["foo"]).To(Equal([]byte("newdata")))
 
@@ -645,7 +645,7 @@ func TestReconcileNoError(t *testing.T) {
 
 		// test with pod being in succeeded phase
 		podToAdd.DeletionTimestamp = nil
-		podToAdd.Status.Phase = v1.PodSucceeded
+		podToAdd.Status.Phase = corev1.PodSucceeded
 		kubeClient = fake.NewSimpleClientset(podToAdd, test.nodePublishSecretRefSecretToAdd)
 		initObjects = []client.Object{
 			podToAdd,
@@ -666,20 +666,20 @@ func TestPatchSecret(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		secretToAdd        *v1.Secret
+		secretToAdd        *corev1.Secret
 		secretName         string
 		expectedSecretData map[string][]byte
 		expectedErr        bool
 	}{
 		{
 			name:        "secret is not found",
-			secretToAdd: &v1.Secret{},
+			secretToAdd: &corev1.Secret{},
 			secretName:  "secret1",
 			expectedErr: true,
 		},
 		{
 			name: "secret is found and data already matches",
-			secretToAdd: &v1.Secret{
+			secretToAdd: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "secret1",
 					Namespace:       "default",
@@ -696,7 +696,7 @@ func TestPatchSecret(t *testing.T) {
 		},
 		{
 			name: "secret is found and data is updated to latest",
-			secretToAdd: &v1.Secret{
+			secretToAdd: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "secret1",
 					Namespace:       "default",
@@ -713,7 +713,7 @@ func TestPatchSecret(t *testing.T) {
 		},
 		{
 			name: "secret is found and new data is appended to existing",
-			secretToAdd: &v1.Secret{
+			secretToAdd: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "secret1",
 					Namespace:       "default",
@@ -748,7 +748,7 @@ func TestPatchSecret(t *testing.T) {
 			err = testReconciler.secretStore.Run(wait.NeverStop)
 			g.Expect(err).NotTo(HaveOccurred())
 
-			err = testReconciler.patchSecret(context.TODO(), test.secretName, v1.NamespaceDefault, test.expectedSecretData)
+			err = testReconciler.patchSecret(context.TODO(), test.secretName, corev1.NamespaceDefault, test.expectedSecretData)
 			if test.expectedErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -757,7 +757,7 @@ func TestPatchSecret(t *testing.T) {
 
 			if !test.expectedErr {
 				// check the secret data is what we expect it to
-				secret, err := kubeClient.CoreV1().Secrets(v1.NamespaceDefault).Get(context.TODO(), test.secretName, metav1.GetOptions{})
+				secret, err := kubeClient.CoreV1().Secrets(corev1.NamespaceDefault).Get(context.TODO(), test.secretName, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(secret.Data).To(Equal(test.expectedSecretData))
 			}

--- a/pkg/util/k8sutil/volume.go
+++ b/pkg/util/k8sutil/volume.go
@@ -19,12 +19,12 @@ limitations under the License.
 package k8sutil
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // SPCVolume finds the Secret Provider Class volume from a Pod, or returns nil
 // if a volume could not be found.
-func SPCVolume(pod *v1.Pod, spcName string) *v1.Volume {
+func SPCVolume(pod *corev1.Pod, spcName string) *corev1.Volume {
 	for i, vol := range pod.Spec.Volumes {
 		if vol.CSI == nil {
 			continue

--- a/pkg/util/k8sutil/volume_test.go
+++ b/pkg/util/k8sutil/volume_test.go
@@ -20,30 +20,30 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestSPCVolume(t *testing.T) {
 	tests := []struct {
 		name    string
-		pod     *v1.Pod
+		pod     *corev1.Pod
 		spcName string
-		want    *v1.Volume
+		want    *corev1.Volume
 	}{
 		{
 			name:    "No Volume",
-			pod:     &v1.Pod{},
+			pod:     &corev1.Pod{},
 			spcName: "foo",
 			want:    nil,
 		},
 		{
 			name: "No CSI Volume",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Volumes: []v1.Volume{
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
 						{
 							Name:         "non-csi-volume",
-							VolumeSource: v1.VolumeSource{},
+							VolumeSource: corev1.VolumeSource{},
 						},
 					},
 				},
@@ -53,13 +53,13 @@ func TestSPCVolume(t *testing.T) {
 		},
 		{
 			name: "CSI volume but wrong driver",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Volumes: []v1.Volume{
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
 						{
 							Name: "csi-volume",
-							VolumeSource: v1.VolumeSource{
-								CSI: &v1.CSIVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
 									Driver: "example-driver.k8s.io",
 								},
 							},
@@ -72,13 +72,13 @@ func TestSPCVolume(t *testing.T) {
 		},
 		{
 			name: "Wrong Volume",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Volumes: []v1.Volume{
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
 						{
 							Name: "csi-volume",
-							VolumeSource: v1.VolumeSource{
-								CSI: &v1.CSIVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
 									Driver:           "secrets-store.csi.k8s.io",
 									VolumeAttributes: map[string]string{"secretProviderClass": "spc1"},
 								},
@@ -92,13 +92,13 @@ func TestSPCVolume(t *testing.T) {
 		},
 		{
 			name: "Correct Volume",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Volumes: []v1.Volume{
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
 						{
 							Name: "csi-volume",
-							VolumeSource: v1.VolumeSource{
-								CSI: &v1.CSIVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
 									Driver:           "secrets-store.csi.k8s.io",
 									VolumeAttributes: map[string]string{"secretProviderClass": "spc1"},
 								},
@@ -108,10 +108,10 @@ func TestSPCVolume(t *testing.T) {
 				},
 			},
 			spcName: "spc1",
-			want: &v1.Volume{
+			want: &corev1.Volume{
 				Name: "csi-volume",
-				VolumeSource: v1.VolumeSource{
-					CSI: &v1.CSIVolumeSource{
+				VolumeSource: corev1.VolumeSource{
+					CSI: &corev1.CSIVolumeSource{
 						Driver:           "secrets-store.csi.k8s.io",
 						VolumeAttributes: map[string]string{"secretProviderClass": "spc1"},
 					},
@@ -120,13 +120,13 @@ func TestSPCVolume(t *testing.T) {
 		},
 		{
 			name: "Multiple Volumes",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Volumes: []v1.Volume{
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
 						{
 							Name: "csi-volume-0",
-							VolumeSource: v1.VolumeSource{
-								CSI: &v1.CSIVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
 									Driver:           "secrets-store.csi.k8s.io",
 									VolumeAttributes: map[string]string{"secretProviderClass": "spc0"},
 								},
@@ -134,8 +134,8 @@ func TestSPCVolume(t *testing.T) {
 						},
 						{
 							Name: "csi-volume",
-							VolumeSource: v1.VolumeSource{
-								CSI: &v1.CSIVolumeSource{
+							VolumeSource: corev1.VolumeSource{
+								CSI: &corev1.CSIVolumeSource{
 									Driver:           "secrets-store.csi.k8s.io",
 									VolumeAttributes: map[string]string{"secretProviderClass": "spc1"},
 								},
@@ -145,10 +145,10 @@ func TestSPCVolume(t *testing.T) {
 				},
 			},
 			spcName: "spc1",
-			want: &v1.Volume{
+			want: &corev1.Volume{
 				Name: "csi-volume",
-				VolumeSource: v1.VolumeSource{
-					CSI: &v1.CSIVolumeSource{
+				VolumeSource: corev1.VolumeSource{
+					CSI: &corev1.CSIVolumeSource{
 						Driver:           "secrets-store.csi.k8s.io",
 						VolumeAttributes: map[string]string{"secretProviderClass": "spc1"},
 					},


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
/kind cleanup
- Use `corev1` as import alias consistently across all packages as it's more descriptive.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
