### PR TITLE
chore: add more linters and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,8 +11,10 @@ linters:
     - durationcheck
     - exportloopref
     - errcheck
+    - errorlint
     - exhaustive
     - goconst
+    - gocyclo
     - gofmt
     - goimports
     - gosimple
@@ -23,6 +25,7 @@ linters:
     - misspell
     - nilerr
     - revive
+    - staticcheck
     - structcheck
     - stylecheck
     - typecheck

--- a/controllers/secretproviderclasspodstatus_controller.go
+++ b/controllers/secretproviderclasspodstatus_controller.go
@@ -111,7 +111,7 @@ func (r *SecretProviderClassPodStatusReconciler) Patcher(ctx context.Context) er
 	// get a list of all spc pod status that belong to the node
 	err := r.reader.List(ctx, spcPodStatusList, r.ListOptionsLabelSelector())
 	if err != nil {
-		return fmt.Errorf("failed to list secret provider class pod status, err: %+v", err)
+		return fmt.Errorf("failed to list secret provider class pod status, err: %w", err)
 	}
 
 	spcPodStatuses := spcPodStatusList.Items
@@ -124,7 +124,7 @@ func (r *SecretProviderClassPodStatusReconciler) Patcher(ctx context.Context) er
 			spc = &val
 		} else {
 			if err := r.reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: spcName}, spc); err != nil {
-				return fmt.Errorf("failed to get spc %s, err: %+v", spcName, err)
+				return fmt.Errorf("failed to get spc %s, err: %w", spcName, err)
 			}
 			spcMap[namespace+"/"+spcName] = *spc
 		}
@@ -132,7 +132,7 @@ func (r *SecretProviderClassPodStatusReconciler) Patcher(ctx context.Context) er
 		pod := &corev1.Pod{}
 		err = r.reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: spcPodStatuses[i].Status.PodName}, pod)
 		if err != nil {
-			return fmt.Errorf("failed to fetch pod during patching, err: %+v", err)
+			return fmt.Errorf("failed to fetch pod during patching, err: %w", err)
 		}
 		var ownerRefs []metav1.OwnerReference
 		for _, ownerRef := range pod.GetOwnerReferences() {
@@ -289,7 +289,7 @@ func (r *SecretProviderClassPodStatusReconciler) Reconcile(ctx context.Context, 
 
 		if err = secretutil.ValidateSecretObject(*secretObj); err != nil {
 			klog.ErrorS(err, "failed to validate secret object in spc", "spc", klog.KObj(spc), "pod", klog.KObj(pod), "spcps", klog.KObj(spcPodStatus))
-			errs = append(errs, fmt.Errorf("failed to validate secret object in spc %s/%s, err: %+v", spc.Namespace, spc.Name, err))
+			errs = append(errs, fmt.Errorf("failed to validate secret object in spc %s/%s, err: %w", spc.Namespace, spc.Name, err))
 			continue
 		}
 		exists, err := r.secretExists(ctx, secretName, req.Namespace)
@@ -300,7 +300,7 @@ func (r *SecretProviderClassPodStatusReconciler) Reconcile(ctx context.Context, 
 			if apierrors.IsForbidden(err) {
 				klog.Warning(SyncSecretForbiddenWarning)
 			}
-			errs = append(errs, fmt.Errorf("failed to check if secret %s exists, err: %+v", secretName, err))
+			errs = append(errs, fmt.Errorf("failed to check if secret %s exists, err: %w", secretName, err))
 			continue
 		}
 
@@ -313,7 +313,7 @@ func (r *SecretProviderClassPodStatusReconciler) Reconcile(ctx context.Context, 
 			if datamap, err = secretutil.GetSecretData(secretObj.Data, secretType, files); err != nil {
 				r.generateEvent(pod, corev1.EventTypeWarning, secretCreationFailedReason, fmt.Sprintf("failed to get data in spc %s/%s for secret %s, err: %+v", req.Namespace, spcName, secretName, err))
 				klog.ErrorS(err, "failed to get data in spc for secret", "spc", klog.KObj(spc), "pod", klog.KObj(pod), "secret", klog.ObjectRef{Namespace: req.Namespace, Name: secretName}, "spcps", klog.KObj(spcPodStatus))
-				errs = append(errs, fmt.Errorf("failed to get data in spc %s/%s for secret %s, err: %+v", req.Namespace, spcName, secretName, err))
+				errs = append(errs, fmt.Errorf("failed to get data in spc %s/%s for secret %s, err: %w", req.Namespace, spcName, secretName, err))
 				continue
 			}
 

--- a/pkg/secrets-store/nodeserver.go
+++ b/pkg/secrets-store/nodeserver.go
@@ -209,7 +209,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	mounted = true
 	var objectVersions map[string]string
 	if objectVersions, errorReason, err = ns.mountSecretsStoreObjectContent(ctx, providerName, string(parametersStr), string(secretStr), targetPath, string(permissionStr), podName); err != nil {
-		return nil, fmt.Errorf("failed to mount secrets store objects for pod %s/%s, err: %v", podNamespace, podName, err)
+		return nil, fmt.Errorf("failed to mount secrets store objects for pod %s/%s, err: %w", podNamespace, podName, err)
 	}
 
 	// create or update the secret provider class pod status object
@@ -217,7 +217,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	// the pod with same name (pods created by statefulsets) is moved to a different node and the old SPCPS
 	// has not yet been garbage collected.
 	if err = createOrUpdateSecretProviderClassPodStatus(ctx, ns.client, ns.reader, podName, podNamespace, podUID, secretProviderClass, targetPath, ns.nodeID, true, objectVersions); err != nil {
-		return nil, fmt.Errorf("failed to create secret provider class pod status for pod %s/%s, err: %v", podNamespace, podName, err)
+		return nil, fmt.Errorf("failed to create secret provider class pod status for pod %s/%s, err: %w", podNamespace, podName, err)
 	}
 
 	klog.InfoS("node publish volume complete", "targetPath", targetPath, "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})

--- a/pkg/secrets-store/provider_client_test.go
+++ b/pkg/secrets-store/provider_client_test.go
@@ -426,7 +426,7 @@ func TestPluginClientBuilderErrorNotFound(t *testing.T) {
 	cb := NewPluginClientBuilder(path)
 	ctx := context.Background()
 
-	if _, err := cb.Get(ctx, "notfoundprovider"); errors.Unwrap(err) != ErrProviderNotFound {
+	if _, err := cb.Get(ctx, "notfoundprovider"); !errors.Is(err, ErrProviderNotFound) {
 		t.Errorf("Get(%s) = %v, want %v", "notfoundprovider", err, ErrProviderNotFound)
 	}
 
@@ -448,7 +448,7 @@ func TestPluginClientBuilderErrorInvalid(t *testing.T) {
 	cb := NewPluginClientBuilder(path)
 	ctx := context.Background()
 
-	if _, err := cb.Get(ctx, "bad/provider/name"); errors.Unwrap(err) != ErrInvalidProvider {
+	if _, err := cb.Get(ctx, "bad/provider/name"); !errors.Is(err, ErrInvalidProvider) {
 		t.Errorf("Get(%s) = %v, want %v", "bad/provider/name", err, ErrInvalidProvider)
 	}
 }

--- a/pkg/secrets-store/utils.go
+++ b/pkg/secrets-store/utils.go
@@ -83,7 +83,7 @@ func getSecretProviderItem(ctx context.Context, c client.Client, name, namespace
 		Name:      name,
 	}
 	if err := c.Get(ctx, spcKey, spc); err != nil {
-		return nil, fmt.Errorf("failed to get secretproviderclass %s/%s, error: %+v", namespace, name, err)
+		return nil, fmt.Errorf("failed to get secretproviderclass %s/%s, error: %w", namespace, name, err)
 	}
 	return spc, nil
 }

--- a/pkg/util/secretutil/secret.go
+++ b/pkg/util/secretutil/secret.go
@@ -166,13 +166,13 @@ func GetSecretData(secretObjData []*secretsstorev1.SecretObjectData, secretType 
 		}
 		content, err := os.ReadFile(file)
 		if err != nil {
-			return datamap, fmt.Errorf("failed to read file %s, err: %v", objectName, err)
+			return datamap, fmt.Errorf("failed to read file %s, err: %w", objectName, err)
 		}
 		datamap[dataKey] = content
 		if secretType == corev1.SecretTypeTLS {
 			c, err := GetCertPart(content, dataKey)
 			if err != nil {
-				return datamap, fmt.Errorf("failed to get cert data from file %s, err: %+v", file, err)
+				return datamap, fmt.Errorf("failed to get cert data from file %s, err: %w", file, err)
 			}
 			datamap[dataKey] = c
 		}

--- a/pkg/util/secretutil/secret_test.go
+++ b/pkg/util/secretutil/secret_test.go
@@ -337,7 +337,12 @@ func createTestFile(tmpDir, fileName string) (string, error) {
 	if fileName != "" {
 		filePath := fmt.Sprintf("%s/%s", tmpDir, fileName)
 		f, err := os.Create(filePath)
-		defer f.Close()
+		defer func() {
+			err = f.Close()
+			if err != nil {
+				return
+			}
+		}()
 		if err != nil {
 			return filePath, err
 		}

--- a/provider/fake/fake_server.go
+++ b/provider/fake/fake_server.go
@@ -109,13 +109,13 @@ func (m *MockCSIProviderServer) Mount(ctx context.Context, req *v1alpha1.MountRe
 		return &v1alpha1.MountResponse{}, m.returnErr
 	}
 	if err = json.Unmarshal([]byte(req.GetAttributes()), &attrib); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal attributes, error: %+v", err)
+		return nil, fmt.Errorf("failed to unmarshal attributes, error: %w", err)
 	}
 	if err = json.Unmarshal([]byte(req.GetSecrets()), &secret); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal secrets, error: %+v", err)
+		return nil, fmt.Errorf("failed to unmarshal secrets, error: %w", err)
 	}
 	if err = json.Unmarshal([]byte(req.GetPermission()), &filePermission); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal file permission, error: %+v", err)
+		return nil, fmt.Errorf("failed to unmarshal file permission, error: %w", err)
 	}
 	if len(req.GetTargetPath()) == 0 {
 		return nil, fmt.Errorf("missing target path")

--- a/test/e2eprovider/server/server.go
+++ b/test/e2eprovider/server/server.go
@@ -124,13 +124,13 @@ func (s *Server) Mount(ctx context.Context, req *v1alpha1.MountRequest) (*v1alph
 	}
 
 	if err = json.Unmarshal([]byte(req.GetAttributes()), &attrib); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal attributes, error: %+v", err)
+		return nil, fmt.Errorf("failed to unmarshal attributes, error: %w", err)
 	}
 	if err = json.Unmarshal([]byte(req.GetSecrets()), &secret); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal secrets, error: %+v", err)
+		return nil, fmt.Errorf("failed to unmarshal secrets, error: %w", err)
 	}
 	if err = json.Unmarshal([]byte(req.GetPermission()), &filePermission); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal file permission, error: %+v", err)
+		return nil, fmt.Errorf("failed to unmarshal file permission, error: %w", err)
 	}
 	if len(req.GetTargetPath()) == 0 {
 		return nil, fmt.Errorf("missing target path")


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the last linter check items
**Which issue(s) this PR fixes
Fixes #https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/636

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
Added //gocyclo:ignore for function reconcile, the reason is that this is the only function that violates  gocyclo check, also this function itself is pretty complicated, and I am new to this code base, dont want to break it for 1 simple linter check.