### PR TITLE
docs: update supported feature by current providers

### DIFF
--- a/docs/book/src/providers.md
+++ b/docs/book/src/providers.md
@@ -38,11 +38,11 @@ To implement a secrets-store-csi-driver provider, you can develop a new provider
 
 See [design doc](https://docs.google.com/document/d/10-RHUJGM0oMN88AZNxjOmGz0NsWAvOYrWUEV-FbLWyw/edit?usp=sharing) for more details.
 
-## Features supported by current providers:
+## Features supported by current providers
 
-| Features \ Providers               | Azure | GCP   | AWS   | Vault |
-| ---------------------------------- | ----- | ----- | ----- | ----- |
-| Sync as Kubernetes secret          | Yes   | Yes   | Yes   | Yes   |
-| Rotation                           | Yes   | Yes   | Yes   | No    |
-| Windows                            | Yes   | No    | No    | No    |
-| Helm Chart                         | Yes   | No    | No    | Yes   |
+| Features \ Providers      | Azure | GCP | AWS | Vault |
+| ------------------------- | ----- | --- | --- | ----- |
+| Sync as Kubernetes secret | Yes   | Yes | Yes | Yes   |
+| Rotation                  | Yes   | Yes | Yes | Yes   |
+| Windows                   | Yes   | No  | No  | No    |
+| Helm Chart                | Yes   | No  | No  | Yes   |


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Rotation feature works with the vault provider. 

@tam7t has added an e2e test in [PR](https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/758) for the vault provider.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
