### PR TITLE
chore: use TARGETARCH for image build and makefile update

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -111,7 +111,7 @@ build_and_push() {
     # charts to prod dir. So we can use manifest_staging charts for the image build.
     if find ../manifest_staging/charts/secrets-store-csi-driver/crds -mindepth 1 -maxdepth 1 | read -r; then
       if [[ "$os_name" != "windows" ]]; then
-        docker buildx build --no-cache --pull --push --platform "${os_name}/${arch}" --build-arg ARCH="${arch}" -t "${CRD_IMAGE_TAG}-${suffix}" \
+        docker buildx build --no-cache --pull --push --platform "${os_name}/${arch}" -t "${CRD_IMAGE_TAG}-${suffix}" \
         -f crd.Dockerfile ../manifest_staging/charts/secrets-store-csi-driver/crds
       fi
     fi

--- a/docker/crd.Dockerfile
+++ b/docker/crd.Dockerfile
@@ -14,10 +14,10 @@
 
 FROM alpine as builder
 ARG KUBE_VERSION=v1.21.2
-ARG ARCH
+ARG TARGETARCH
 
 RUN apk add --no-cache curl && \
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/${ARCH}/kubectl && \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/${TARGETARCH}/kubectl && \
     chmod +x kubectl
 
 FROM gcr.io/distroless/static


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Updates dockerfile to use `TARGETARCH` instead of `ARCH` arg
- Updates docker build to use `buildx` for validating builds. Using `--progress=plain` to have the same output as `docker build`.
- Makes docker buildx builder name customizable and consolidates builder creation with running qemu

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
