### PR TITLE
ci: add markdown-link-check workflow

### DIFF
--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -1,0 +1,27 @@
+name: Check Markdown links
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  schedule:
+    - cron: "0 9 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    # pinning to the sha 9710f0fec812ce0a3b98bef4c9d842fc1f39d976 from https://github.com/gaurav-nelson/github-action-markdown-link-check/releases/tag/1.0.13
+    - uses: gaurav-nelson/github-action-markdown-link-check@9710f0fec812ce0a3b98bef4c9d842fc1f39d976
+      with:
+        # this will only show errors in the output
+        use-quiet-mode: 'yes'
+        # this will show detailed HTTP status for checked links
+        use-verbose-mode: 'yes'

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Join us to help define the direction and implementation of this project!
 
 ## Demo
 
-![Secrets Store CSI Driver Demo](/img/demo.gif "Secrets Store CSI Driver Azure Key Vault Provider Demo")
+![Secrets Store CSI Driver Demo](img/demo.gif "Secrets Store CSI Driver Azure Key Vault Provider Demo")
 
 ## Getting Started
 

--- a/docs/MEMBERSHIP.md
+++ b/docs/MEMBERSHIP.md
@@ -6,18 +6,19 @@
 
 ## Overview
 
-Hello! We're excited to have you contribute to Secrets Store CSI Driver sig-auth subproject! This document outlines the various roles for the Secrets Store CSI Driver sig-auth subproject, along with the responsibilites and privileges that come with them. Community members generally start at the first level of membership and advance up it as their involvement in the project grows. Our project members are happy to help you advance along the contributor ladder.
+Hello! We're excited to have you contribute to Secrets Store CSI Driver sig-auth subproject! This document outlines the various roles for the Secrets Store CSI Driver sig-auth subproject, along with the responsibilities and privileges that come with them. Community members generally start at the first level of membership and advance up it as their involvement in the project grows. Our project members are happy to help you advance along the contributor ladder.
 
 Each of the contributor roles below is organized into lists of three types of things:
+
 * "Responsibilities" are things that a contributor is expected to do
 * "Requirements" are qualifications a contributor needs to meet to be in that role
 * "Privileges" are things a contributor on that level is entitled to
 
 ### Community Participant
 
-Description: A Community Participant participates in the community and contributes their time, thoughts, etc. 
+Description: A Community Participant participates in the community and contributes their time, thoughts, etc.
 
-* Responsibilities include: 
+* Responsibilities include:
   * Following the [CNCF CoC](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
 * How users can get involved with the community:
   * Participating in discussions in GitHub, Slack, and meetings
@@ -51,11 +52,11 @@ Description: A Contributor contributes directly to the project and adds value to
 
 ### Reviewer
 
-Description: Reviewers are Contributors who are able to review code for quality and correctness on the Secrets Store CSI Driver. They are knowledgeable about the codebase and software engineering principles. A Reviewer has the rights, responsiblities, and requirements of a Contributor, plus:
+Description: Reviewers are Contributors who are able to review code for quality and correctness on the Secrets Store CSI Driver. They are knowledgeable about the codebase and software engineering principles. A Reviewer has the rights, responsibilities, and requirements of a Contributor, plus:
 
 * Responsibilities include:
   * Running tests for PRs from members who aren’t part of Kubernetes org
-    * This involves running ok-to-test after assessing the PR briefly 
+    * This involves running ok-to-test after assessing the PR briefly
   * Project quality control via code reviews
     * Focusing on code quality and correctness, including testing and factoring
     * May also review for more holistic issues, but not a requirement
@@ -81,10 +82,9 @@ Description: Reviewers are Contributors who are able to review code for quality 
 
 **Note:** Acceptance of code contributions requires at least one approver in addition to the assigned reviewers.
 
-
 ### Approver
 
-Description: Code approvers are able to both review and approve code contributions. While code review is focused on code quality and correctness, approval is focused on holistic acceptance of a contribution including: backwards / forwards compatibility, adhering to API and flag conventions, subtle performance and correctness issues, interactions with other parts of the system, etc. An Approver has the rights, responsiblities, and requirements of a reviewer, plus:
+Description: Code approvers are able to both review and approve code contributions. While code review is focused on code quality and correctness, approval is focused on holistic acceptance of a contribution including: backwards / forwards compatibility, adhering to API and flag conventions, subtle performance and correctness issues, interactions with other parts of the system, etc. An Approver has the rights, responsibilities, and requirements of a reviewer, plus:
 
 * Responsibilities include:
   * Approvers entry in the [OWNERS](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/v0.0.22/OWNERS#L1) file
@@ -111,7 +111,7 @@ Description: Code approvers are able to both review and approve code contributio
 
 Description: Maintainers are very established contributors who are responsible for the entire project. As such, they have the ability to review and approve PRs against any area of the project, and are expected to participate in making decisions about the strategy and priorities of the project.
 
-A Maintainer has the rights, responsiblities, and requirements of an Approver, plus:
+A Maintainer has the rights, responsibilities, and requirements of an Approver, plus:
 
 * Responsibilities include:
   * Reviewing and approving PRs that involve multiple parts of the project
@@ -122,14 +122,14 @@ A Maintainer has the rights, responsiblities, and requirements of an Approver, p
   * Determining strategy and policy for the project
   * Participating in, and leading, community meetings
 * Requirements
-  * Experience as an Approver for at least 6 months   
+  * Experience as an Approver for at least 6 months
   * Demonstrates a broad knowledge of the project across multiple areas
   * Is able to exercise judgement for the good of the project, independent of their employer, social circles, or teams
   * Mentors other Contributors
   
 * Additional privileges:
   * Represent the project in public as a Maintainer
-  * Communicate with the CNCF on behalf of the project   
+  * Communicate with the CNCF on behalf of the project
   * Have a vote in Maintainer decisions
 
 Process of becoming a maintainer:
@@ -152,8 +152,7 @@ It is important for contributors to be and stay active to set an example and sho
 
 ### Involuntary Removal or Demotion
 
-Involuntary removal/demotion of a contributor happens when responsibilites and requirements aren't being met. This may include repeated pattern of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the [CNCF CoC](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
-
+Involuntary removal/demotion of a contributor happens when responsibilities and requirements aren't being met. This may include repeated pattern of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the [CNCF CoC](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
 
 Involuntary removal or demotion is handled through a vote by a majority of the current Maintainers.
 
@@ -165,9 +164,8 @@ Contact the Maintainers about changing to Emeritus status, or reducing your cont
 
 ## Contact
 
-For inquiries, please reach out to [Secret Store CSI Driver Maintainers](TBD)
-
+For inquiries, please reach out to Secret Store CSI Driver Maintainers in [#csi-secrets-store](https://kubernetes.slack.com/messages/csi-secrets-store) channel on [Kubernetes Slack](https://kubernetes.slack.com/)
 
 ## Docs used for reference
 
-- [Community membership](https://github.com/kubernetes/community/blob/master/community-membership.md)
+* [Community membership](https://github.com/kubernetes/community/blob/master/community-membership.md)

--- a/docs/book/src/concepts.md
+++ b/docs/book/src/concepts.md
@@ -6,7 +6,7 @@
 
 The diagram below illustrates how Secrets Store CSI volume works:
 
-![diagram](../images/diagram.png)
+![diagram](./images/diagram.png)
 
 Similar to Kubernetes secrets, on pod start and restart, the Secrets Store CSI driver communicates with the provider using gRPC to retrieve the secret content from the external Secrets Store specified in the `SecretProviderClass` custom resource. Then the volume is mounted in the pod as `tmpfs` and the secret contents are written to the volume.
 

--- a/docs/book/src/getting-started/usage.md
+++ b/docs/book/src/getting-started/usage.md
@@ -16,7 +16,7 @@ spec:
   parameters:                                 # provider-specific parameters
 ```
 
-Here is a sample [`SecretProviderClass` custom resource](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/test/bats/tests/vault/vault_v1alpha1_secretproviderclass.yaml)
+Here is a sample [`SecretProviderClass` custom resource](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/release-1.0/test/bats/tests/vault/vault_v1_secretproviderclass.yaml)
 
 ### Update your Deployment Yaml
 

--- a/sample/ingress-controller-tls/README.md
+++ b/sample/ingress-controller-tls/README.md
@@ -1,9 +1,0 @@
-# Using Secrets Store CSI to Enable NGINX Ingress Controller with TLS
-
-The Secrets Store CSI Driver can be used to enable applications to work with NGINX Ingress Controller with TLS stored in an External Secrets Store. 
-For more information on securing an Ingress with TLS, refer to: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-
-Checkout provider samples on how to get started -
-
-- [Using Secrets Store CSI and Azure Key Vault Provider](https://azure.github.io/secrets-store-csi-driver-provider-azure/configurations/ingress-tls/)
-- [Using Secrets Store CSI and HashiCorp Vault Provider](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/blob/master/sample/ingress-controller-tls/README.md)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Adds workflow for checking dead links in docs
  - This will run as part of pull requests (non-blocking), periodically at 9AM everyday and on push to the main branch.
- Remove `sample` dir as it contains provider specific links and require maintenance. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #806 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
