### PR TITLE
helm: check rbac.pspEnabled for keep-crds upgrade hook

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/templates/keep-crds-upgrade-hook.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/keep-crds-upgrade-hook.yaml
@@ -37,6 +37,7 @@ roleRef:
   name: {{ template "sscd.fullname" . }}-keep-crds
   apiGroup: rbac.authorization.k8s.io
 ---
+{{- if .Values.rbac.pspEnabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -56,6 +57,7 @@ spec:
     rule: RunAsAny
   volumes:
   - secret
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Places `PodSecurityPolicy` for keep-crds upgrade job in `rbac.pspEnabled` conditional

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/816

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
