### PR TITLE
chore: update debian-base to bullseye-v1.1.0

### DIFF
--- a/docker/BASEIMAGE
+++ b/docker/BASEIMAGE
@@ -1,5 +1,5 @@
-linux/amd64=us.gcr.io/k8s-artifacts-prod/build-image/debian-base:bullseye-v1.0.0
-linux/arm64=us.gcr.io/k8s-artifacts-prod/build-image/debian-base:bullseye-v1.0.0
+linux/amd64=k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
+linux/arm64=k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/1903=mcr.microsoft.com/windows/nanoserver:1903
 windows/amd64/1909=mcr.microsoft.com/windows/nanoserver:1909

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE=us.gcr.io/k8s-artifacts-prod/build-image/debian-base:bullseye-v1.0.0
+ARG BASEIMAGE=k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
 
 FROM golang:1.17 as builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver
@@ -28,9 +28,7 @@ RUN export GOOS=$TARGETOS && \
 
 FROM $BASEIMAGE
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi
-# upgrading libssl1.1 due to CVE-2021-3711
-# upgrading libgssapi-krb5-2 and libk5crypto3 due to CVE-2021-37750
-RUN clean-install ca-certificates mount libssl1.1 libgssapi-krb5-2 libk5crypto3
+RUN clean-install ca-certificates mount
 
 LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
