### PR TITLE
security: fix CVE-2021-43618

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,8 @@ RUN export GOOS=$TARGETOS && \
 
 FROM $BASEIMAGE
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi
-RUN clean-install ca-certificates mount
+# upgrading libgmp10 due to CVE-2021-43618
+RUN clean-install ca-certificates mount libgmp10
 
 LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:

```bash
➜ trivy --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
2022-01-04T13:40:52.026-0800	WARN	The root command will be removed. Please migrate to 'trivy image' command. See https://github.com/aquasecurity/trivy/discussions/1515
2022-01-04T13:40:52.073-0800	INFO	Need to update DB
2022-01-04T13:40:52.073-0800	INFO	Downloading DB...
25.32 MiB / 25.32 MiB [-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 24.18 MiB p/s 1s
2022-01-04T13:40:57.118-0800	INFO	Detected OS: debian
2022-01-04T13:40:57.118-0800	INFO	Detecting Debian vulnerabilities...
2022-01-04T13:40:57.128-0800	INFO	Number of language-specific files: 0

k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0 (debian 11.1)
================================================================
Total: 1 (MEDIUM: 0, HIGH: 1, CRITICAL: 0)

+----------+------------------+----------+-------------------+------------------------+---------------------------------------+
| LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |     FIXED VERSION      |                 TITLE                 |
+----------+------------------+----------+-------------------+------------------------+---------------------------------------+
| libgmp10 | CVE-2021-43618   | HIGH     | 2:6.2.1+dfsg-1    | 2:6.2.1+dfsg-1+deb11u1 | gmp: Integer overflow and resultant   |
|          |                  |          |                   |                        | buffer overflow via crafted input     |
|          |                  |          |                   |                        | -->avd.aquasec.com/nvd/cve-2021-43618 |
+----------+------------------+----------+-------------------+------------------------+---------------------------------------+
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
