### PR TITLE
Automated cherry pick of #814: images: use k8s-staging-test-infra/gcb-docker-gcloud

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -13,7 +13,7 @@ options:
   # job builds a multi-arch docker image for amd64,arm64 and windows 1809, 1903, 1909, 2004.
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210722-085d930'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90'
     entrypoint: bash
     dir: ./docker
     env:


### PR DESCRIPTION
Cherry pick of #814 on release-1.0.

#814: images: use k8s-staging-test-infra/gcb-docker-gcloud

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.