### PR TITLE
Automated cherry pick of #826: security: fix CVE-2021-43618

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,8 @@ RUN export GOOS=$TARGETOS && \
 
 FROM $BASEIMAGE
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi
-RUN clean-install ca-certificates mount
+# upgrading libgmp10 due to CVE-2021-43618
+RUN clean-install ca-certificates mount libgmp10
 
 LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"


### PR DESCRIPTION
Cherry pick of #826 on release-1.0.

#826: security: fix CVE-2021-43618

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.