### PR TITLE
security: fix CVE-2021-3995, CVE-2021-3996

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ E2E_PROVIDER_IMAGE_NAME ?= e2e-provider
 # Release version is the current supported release for the driver
 # Update this version when the helm chart is being updated for release
 RELEASE_VERSION := v1.0.1
-IMAGE_VERSION ?= v1.0.1
+IMAGE_VERSION ?= v1.0.1.1
 
 # Use a custom version for E2E tests if we are testing in CI
 ifdef CI

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,8 @@ RUN export GOOS=$TARGETOS && \
 FROM $BASEIMAGE
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi
 # upgrading libgmp10 due to CVE-2021-43618
-RUN clean-install ca-certificates mount libgmp10
+# upgrading bsdutils due to CVE-2021-3995 and CVE-2021-3996
+RUN clean-install ca-certificates mount libgmp10 bsdutils
 
 LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@
 REGISTRY?=docker.io/deislabs
 IMAGE_NAME=driver
 CRD_IMAGE_NAME=driver-crds
-IMAGE_VERSION?=v1.0.1
+IMAGE_VERSION?=v1.0.1.1
 BUILD_TIMESTAMP := $(shell date +%Y-%m-%d-%H:%M)
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
```bash
gcr.io/k8s-staging-csi-secrets-store/driver:v1.0.0-e2e-73bc8002 (debian 11.1)
=============================================================================
Total: 2 (MEDIUM: 2, HIGH: 0, CRITICAL: 0)

+----------+------------------+----------+-------------------+------------------+--------------------------------------+
| LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION   |                TITLE                 |
+----------+------------------+----------+-------------------+------------------+--------------------------------------+
| bsdutils | CVE-2021-3995    | MEDIUM   | 2.36.1-8          | 2.36.1-8+deb11u1 | util-linux: Unauthorized unmount     |
|          |                  |          |                   |                  | of FUSE filesystems belonging        |
|          |                  |          |                   |                  | to users with similar uid...         |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3995 |
+          +------------------+          +                   +                  +--------------------------------------+
|          | CVE-2021-3996    |          |                   |                  | util-linux: Unauthorized unmount     |
|          |                  |          |                   |                  | of filesystems in libmount           |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3996 |
+----------+------------------+----------+-------------------+------------------+--------------------------------------+

```

ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-secrets-store-csi-driver-image-scan/1485794234760957952

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
