### PR TITLE
Automated cherry pick of #843: security: fix CVE-2021-3995, CVE-2021-3996

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ E2E_PROVIDER_IMAGE_NAME ?= e2e-provider
 # Release version is the current supported release for the driver
 # Update this version when the helm chart is being updated for release
 RELEASE_VERSION := v1.0.1
-IMAGE_VERSION ?= v1.0.1
+IMAGE_VERSION ?= v1.0.1.1
 
 # Use a custom version for E2E tests if we are testing in CI
 ifdef CI

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,8 @@ RUN export GOOS=$TARGETOS && \
 FROM $BASEIMAGE
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi
 # upgrading libgmp10 due to CVE-2021-43618
-RUN clean-install ca-certificates mount libgmp10
+# upgrading bsdutils due to CVE-2021-3995 and CVE-2021-3996
+RUN clean-install ca-certificates mount libgmp10 bsdutils
 
 LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@
 REGISTRY?=docker.io/deislabs
 IMAGE_NAME=driver
 CRD_IMAGE_NAME=driver-crds
-IMAGE_VERSION?=v1.0.1
+IMAGE_VERSION?=v1.0.1.1
 BUILD_TIMESTAMP := $(shell date +%Y-%m-%d-%H:%M)
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION
Cherry pick of #843 on release-1.0.

#843: security: fix CVE-2021-3995, CVE-2021-3996

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.