### PR TITLE
chore: mark `v1alpha1` api version as deprecated

### DIFF
--- a/apis/v1alpha1/secretproviderclass_types.go
+++ b/apis/v1alpha1/secretproviderclass_types.go
@@ -70,6 +70,7 @@ type SecretProviderClassStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="secrets-store.csi.x-k8s.io/v1alpha1 is deprecated. Use secrets-store.csi.x-k8s.io/v1 instead."
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/apis/v1alpha1/secretproviderclasspodstatus_types.go
+++ b/apis/v1alpha1/secretproviderclasspodstatus_types.go
@@ -41,6 +41,7 @@ type SecretProviderClassObject struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -102,7 +102,10 @@ spec:
         type: object
     served: true
     storage: true
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: secrets-store.csi.x-k8s.io/v1alpha1 is deprecated. Use secrets-store.csi.x-k8s.io/v1
+      instead.
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SecretProviderClass is the Schema for the secretproviderclasses

--- a/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+++ b/config/crd/bases/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
@@ -61,7 +61,8 @@ spec:
         type: object
     served: true
     storage: true
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SecretProviderClassPodStatus is the Schema for the secretproviderclassespodstatus

--- a/manifest_staging/charts/secrets-store-csi-driver/crds/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/crds/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -102,7 +102,10 @@ spec:
         type: object
     served: true
     storage: true
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: secrets-store.csi.x-k8s.io/v1alpha1 is deprecated. Use secrets-store.csi.x-k8s.io/v1
+      instead.
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SecretProviderClass is the Schema for the secretproviderclasses

--- a/manifest_staging/charts/secrets-store-csi-driver/crds/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/crds/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
@@ -61,7 +61,8 @@ spec:
         type: object
     served: true
     storage: true
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SecretProviderClassPodStatus is the Schema for the secretproviderclassespodstatus

--- a/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -102,7 +102,10 @@ spec:
         type: object
     served: true
     storage: true
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: secrets-store.csi.x-k8s.io/v1alpha1 is deprecated. Use secrets-store.csi.x-k8s.io/v1
+      instead.
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SecretProviderClass is the Schema for the secretproviderclasses

--- a/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
+++ b/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
@@ -61,7 +61,8 @@ spec:
         type: object
     served: true
     storage: true
-  - name: v1alpha1
+  - deprecated: true
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: SecretProviderClassPodStatus is the Schema for the secretproviderclassespodstatus


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Marks `v1alpha1` as deprecated with a warning message for `SecretProviderClass`

```shell
➜ k apply -f ~/yamls/v1alpha1-csi-linux.yaml                                             
Warning: secrets-store.csi.x-k8s.io/v1alpha1 is deprecated. Use secrets-store.csi.x-k8s.io/v1 instead.
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
