### PR TITLE
fix: panic when using `--log-format-json` is set to true

### DIFF
--- a/cmd/secrets-store-csi-driver/main.go
+++ b/cmd/secrets-store-csi-driver/main.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/config"
 	json "k8s.io/component-base/logs/json"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -89,7 +90,8 @@ func main() {
 	flag.Parse()
 
 	if *logFormatJSON {
-		logger, _ := json.NewJSONLogger(nil, nil)
+		jsonFactory := json.Factory{}
+		logger, _ := jsonFactory.Create(config.FormatOptions{})
 		klog.SetLogger(logger)
 	}
 	if *enableProfile {


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Fixes a panic issue when `--log-format-json=true`

Validated the fix:
```bash
➜ go run cmd/secrets-store-csi-driver/main.go
{"ts":1645724627732.689,"caller":"metrics/exporter.go:35","msg":"initializing metrics backend","v":0,"backend":"prometheus"}
{"ts":1645724627734.4478,"caller":"secrets-store-csi-driver/main.go:181","msg":"starting manager\n","v":0}
{"ts":1645724627835.707,"caller":"secrets-store/secrets-store.go:46","msg":"Initializing Secrets Store CSI Driver","v":0,"driver":"secrets-store.csi.k8s.io","version":"local-dev","buildTime":""}
{"ts":1645724627842.8486,"caller":"secrets-store/server.go:120","msg":"Listening for connections","v":0,"address":"/tmp/csi.sock"}
^C{"ts":1645724630515.9495,"caller":"secrets-store-csi-driver/main.go:226","msg":"received shutdown signal\n","v":0}
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #887 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
