### PR TITLE
validate additionalProviderPaths does not contain providerPath

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -76,7 +76,7 @@ spec:
             {{- end }}
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
-            - "--provider-volume={{ .Values.windows.providersDir }}"            
+            - "--provider-volume={{ .Values.windows.providersDir }}"
             - "--additional-provider-volume-paths={{ join "," .Values.windows.additionalProvidersDirs }}"
             {{- if and (semverCompare ">= v0.0.9-0" .Values.windows.image.tag) .Values.minimumProviderVersions }}
             - "--min-provider-version={{ .Values.minimumProviderVersions }}"
@@ -131,11 +131,14 @@ spec:
               mountPath: C:\csi
             - name: mountpoint-dir
               mountPath: {{ .Values.windows.kubeletRootDir }}\pods
+            {{- $providersDir := .Values.windows.providersDir }}
             - name: providers-dir
-              mountPath: "{{ .Values.windows.providersDir }}"
+              mountPath: "{{ $providersDir }}"
             {{- range $i, $path := .Values.windows.additionalProvidersDirs }}
+            {{- if ne $providersDir $path }}
             - name: providers-dir-{{ $i }}
               mountPath: "{{ $path }}"
+            {{- end }}
             {{- end }}
             {{- if .Values.windows.volumeMounts }}
               {{- toYaml .Values.windows.volumeMounts | nindent 12}}
@@ -177,15 +180,18 @@ spec:
           hostPath:
             path: {{ .Values.windows.kubeletRootDir }}\plugins\csi-secrets-store\
             type: DirectoryOrCreate
+        {{- $providersDir := .Values.windows.providersDir }}
         - name: providers-dir
           hostPath:
-            path: "{{ .Values.windows.providersDir }}"
+            path: "{{ $providersDir }}"
             type: DirectoryOrCreate
         {{- range $i, $path := .Values.windows.additionalProvidersDirs }}
+        {{- if ne $path $providersDir }}
         - name: providers-dir-{{ $i }}
           hostPath:
             path: "{{ $path }}"
             type: DirectoryOrCreate
+        {{- end }}
         {{- end }}
         {{- if .Values.windows.volumes }}
           {{- toYaml .Values.windows.volumes | nindent 8}}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -134,11 +134,14 @@ spec:
             - name: mountpoint-dir
               mountPath: {{ .Values.linux.kubeletRootDir }}/pods
               mountPropagation: Bidirectional
+            {{- $providersDir := .Values.linux.providersDir }}
             - name: providers-dir
-              mountPath: {{ .Values.linux.providersDir }}
+              mountPath: {{ $providersDir }}
             {{- range $i, $path := .Values.linux.additionalProvidersDirs }}
+            {{- if ne $path $providersDir }}
             - name: providers-dir-{{ $i }}
               mountPath: "{{ $path }}"
+            {{- end }}
             {{- end }}
             {{- if .Values.linux.volumeMounts }}
               {{- toYaml .Values.linux.volumeMounts | nindent 12}}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -183,15 +183,18 @@ spec:
           hostPath:
             path: {{ .Values.linux.kubeletRootDir }}/plugins/csi-secrets-store/
             type: DirectoryOrCreate
+        {{- $providersDir := .Values.linux.providersDir }}
         - name: providers-dir
           hostPath:
-            path: {{ .Values.linux.providersDir }}
+            path: {{ $providersDir }}
             type: DirectoryOrCreate
         {{- range $i, $path := .Values.linux.additionalProvidersDirs }}
+        {{- if ne $path $providersDir }}
         - name: providers-dir-{{ $i }}
           hostPath:
             path: "{{ $path }}"
             type: DirectoryOrCreate
+        {{- end}}
         {{- end }}
         {{- if .Values.linux.volumes }}
           {{- toYaml .Values.linux.volumes | nindent 8}}


### PR DESCRIPTION
Signed-off-by: Paul Czarkowski <username.taken@gmail.com>

**What this PR does / why we need it**:

Checks if additionalProviderPaths matches providerPaths to avoid duplicate volume mounts,

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #897 


