### PR TITLE
security: fix CVE-2022-0778, CVE-2021-4160

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ E2E_PROVIDER_IMAGE_NAME ?= e2e-provider
 # Release version is the current supported release for the driver
 # Update this version when the helm chart is being updated for release
 RELEASE_VERSION := v1.1.1
-IMAGE_VERSION ?= v1.1.1
+IMAGE_VERSION ?= v1.1.1.0
 
 # Use a custom version for E2E tests if we are testing in CI
 ifdef CI

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,8 @@ FROM $BASEIMAGE
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi
 # upgrading libgmp10 due to CVE-2021-43618
 # upgrading bsdutils due to CVE-2021-3995 and CVE-2021-3996
-RUN clean-install ca-certificates mount libgmp10 bsdutils
+# upgrading libssl1.1 due to CVE-2022-0778 and CVE-2021-4160
+RUN clean-install ca-certificates mount libgmp10 bsdutils libssl1.1
 
 LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@
 REGISTRY?=docker.io/deislabs
 IMAGE_NAME=driver
 CRD_IMAGE_NAME=driver-crds
-IMAGE_VERSION?=v1.1.1
+IMAGE_VERSION?=v1.1.1.1
 BUILD_TIMESTAMP := $(shell date +%Y-%m-%d-%H:%M)
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
```bash
gcr.io/k8s-staging-csi-secrets-store/driver:v1.1.0-e2e-6a68de14 (debian 11.1)
=============================================================================
Total: 2 (MEDIUM: 1, HIGH: 1, CRITICAL: 0)

+-----------+------------------+----------+-------------------+------------------+--------------------------------------+
|  LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION   |                TITLE                 |
+-----------+------------------+----------+-------------------+------------------+--------------------------------------+
| libssl1.1 | CVE-2022-0778    | HIGH     | 1.1.1k-1+deb11u1  | 1.1.1k-1+deb11u2 | The BN_mod_sqrt() function,          |
|           |                  |          |                   |                  | which computes a modular             |
|           |                  |          |                   |                  | square root, contains a bug...       |
|           |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2022-0778 |
+           +------------------+----------+                   +                  +--------------------------------------+
|           | CVE-2021-4160    | MEDIUM   |                   |                  | openssl: Carry propagation           |
|           |                  |          |                   |                  | bug in the MIPS32 and                |
|           |                  |          |                   |                  | MIPS64 squaring procedure            |
|           |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-4160 |
+-----------+------------------+----------+-------------------+------------------+--------------------------------------+
```

ref: https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_secrets-store-csi-driver/898/pull-secrets-store-csi-driver-image-scan/1503850881517359104/build-log.txt

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
