### PR TITLE
docs: add command reference

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -7,6 +7,7 @@
     - [Usage](./getting-started/usage.md)
     - [Upgrades](./getting-started/upgrades.md)
 - [Topics](./topics/topics.md)
+    - [Command Reference](./topics/command-reference.md)
     - [Metrics](./topics/metrics.md)
     - [Secret Auto Rotation](./topics/secret-auto-rotation.md)
     - [Sync as Kubernetes Secret](./topics/sync-as-kubernetes-secret.md)

--- a/docs/book/src/topics/command-reference.md
+++ b/docs/book/src/topics/command-reference.md
@@ -1,0 +1,24 @@
+# Command Reference
+
+The Secrets Store CSI Driver can be provided with the following command line arguments.
+
+The `secrets-store` container in the DaemonSet can be configured using the following command line arguments:
+
+## List of command line options
+
+| Parameter                        | Description                                                            | Default                                     |
+|----------------------------------|------------------------------------------------------------------------|---------------------------------------------|
+| `--endpoint`                         | CSI endpoint                                                           | `unix://tmp/csi.sock`                         |
+| `--drivername`                       | Name of the driver                                                     | `secrets-store.csi.k8s.io`                    |
+| `--nodeid`                           | Node ID                                                                |                                             |
+| `--log-format-json`                  | Set log formatter to json                                              | `false`                                       |
+| `--provider-volume`                  | Volume path for provider                                               | `/etc/kubernetes/secrets-store-csi-providers` |
+| `--additional-provider-volume-paths` | Comma separated list of additional paths to communicate with providers | `/var/run/secrets-store-csi-providers`        |
+| `--metrics-addr`                     | The address the metric endpoint binds to                               | `:8095`                                       |
+| `--enable-secret-rotation`           | Enable secret rotation feature [alpha]                                 | `false`                                       |
+| `--rotation-poll-interval`           | Secret rotation poll interval duration                                 | `2m`                                            |
+| `--enable-pprof`                     | Enable pprof profiling                                                 | `false`                                       |
+| `--pprof-port`                       | Port for pprof profiling                                               | `6065`                                        |
+| `--max-call-recv-msg-size`           | Maximum size in bytes of gRPC response from plugins                    | `4194304`                                     |
+| `--provider-health-check`            	| Enable health check for configured providers                           	| `false`                                       	|
+| `--provider-health-check-interval`   	| Provider healthcheck interval duration                                 	|  `2m`                                           	|


### PR DESCRIPTION
**What this PR does / why we need it**: This is raised to add a new subpage under topics around command reference

**Which issue(s) this PR fixes**:
Fixes #855 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**: 
- Do let me know if **Command Reference** title works else we can update with **Command Line Arguments** or **Configuration Options**
