### PR TITLE
chore: remove deprecated minimumProviderVersions in helm chart

### DIFF
--- a/cmd/secrets-store-csi-driver/main.go
+++ b/cmd/secrets-store-csi-driver/main.go
@@ -62,13 +62,12 @@ var (
 	// https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/823.
 	// The default should be moved to /var/ in https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/870
 	additionalProviderPaths = flag.String("additional-provider-volume-paths", "/var/run/secrets-store-csi-providers", "Comma separated list of additional paths to communicate with providers")
-	// this will be removed in a future release
-	metricsAddr          = flag.String("metrics-addr", ":8095", "The address the metric endpoint binds to")
-	enableSecretRotation = flag.Bool("enable-secret-rotation", false, "Enable secret rotation feature [alpha]")
-	rotationPollInterval = flag.Duration("rotation-poll-interval", 2*time.Minute, "Secret rotation poll interval duration")
-	enableProfile        = flag.Bool("enable-pprof", false, "enable pprof profiling")
-	profilePort          = flag.Int("pprof-port", 6065, "port for pprof profiling")
-	maxCallRecvMsgSize   = flag.Int("max-call-recv-msg-size", 1024*1024*4, "maximum size in bytes of gRPC response from plugins")
+	metricsAddr             = flag.String("metrics-addr", ":8095", "The address the metric endpoint binds to")
+	enableSecretRotation    = flag.Bool("enable-secret-rotation", false, "Enable secret rotation feature [alpha]")
+	rotationPollInterval    = flag.Duration("rotation-poll-interval", 2*time.Minute, "Secret rotation poll interval duration")
+	enableProfile           = flag.Bool("enable-pprof", false, "enable pprof profiling")
+	profilePort             = flag.Int("pprof-port", 6065, "port for pprof profiling")
+	maxCallRecvMsgSize      = flag.Int("max-call-recv-msg-size", 1024*1024*4, "maximum size in bytes of gRPC response from plugins")
 
 	// Enable optional healthcheck for provider clients that exist in memory
 	providerHealthCheck         = flag.Bool("provider-health-check", false, "Enable health check for configured providers")

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -78,9 +78,6 @@ spec:
             - "--nodeid=$(KUBE_NODE_NAME)"
             - "--provider-volume={{ .Values.windows.providersDir }}"
             - "--additional-provider-volume-paths={{ join "," .Values.windows.additionalProvidersDirs }}"
-            {{- if and (semverCompare ">= v0.0.9-0" .Values.windows.image.tag) .Values.minimumProviderVersions }}
-            - "--min-provider-version={{ .Values.minimumProviderVersions }}"
-            {{- end }}
             {{- if and (semverCompare ">= v0.0.15-0" .Values.windows.image.tag) .Values.enableSecretRotation }}
             - "--enable-secret-rotation={{ .Values.enableSecretRotation }}"
             {{- end }}

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -78,9 +78,6 @@ spec:
             - "--nodeid=$(KUBE_NODE_NAME)"
             - "--provider-volume={{ .Values.linux.providersDir }}"
             - "--additional-provider-volume-paths={{ join "," .Values.linux.additionalProvidersDirs }}"
-            {{- if and (semverCompare ">= v0.0.8-0" .Values.linux.image.tag) .Values.minimumProviderVersions }}
-            - "--min-provider-version={{ .Values.minimumProviderVersions }}"
-            {{- end }}
             {{- if and (semverCompare ">= v0.0.15-0" .Values.linux.image.tag) .Values.enableSecretRotation }}
             - "--enable-secret-rotation={{ .Values.enableSecretRotation }}"
             {{- end }}


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
/kind cleanup

- Remove old `minimumProviderVersions` flag from helm charts
- Removes the wrong comment in main

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
