### PR TITLE
chore: add index.html

### DIFF
--- a/charts/index.html
+++ b/charts/index.html
@@ -1,0 +1,16 @@
+<html>
+
+<head>
+    <title>Secrets Store CSI Driver Helm Chart Repository</title>
+</head>
+
+<body>
+    <h1>Secrets Store CSI Driver Helm Chart Repository</h1>
+
+    <hr>
+    <pre>
+Checkout the <a href="https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html#installation">installation guide</a> to install the Secrets Store CSI Driver and providers.
+    </pre>
+</body>
+
+</html>


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
Adds `index.html` to gh-pages charts repository. Render in my fork: https://aramase.github.io/secrets-store-csi-driver/charts/

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
