### PR TITLE
Automated cherry pick of #914: security: fix CVEs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,11 @@ COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets
 # upgrading libgmp10 due to CVE-2021-43618
 # upgrading bsdutils due to CVE-2021-3995 and CVE-2021-3996
 # upgrading libssl1.1 due to CVE-2022-0778 and CVE-2021-4160
-RUN clean-install ca-certificates mount libgmp10 bsdutils libssl1.1
+# upgrading libc-bin due to CVE-2021-33574, CVE-2022-23218, CVE-2022-23219 and CVE-2021-43396
+# upgrading libc6 due to CVE-2021-33574, CVE-2022-23218, CVE-2022-23219 and CVE-2021-43396
+# upgrading libsystemd0 due to CVE-2021-3997
+# upgrading libudev1 due to CVE-2021-3997
+RUN clean-install ca-certificates mount libgmp10 bsdutils libssl1.1 libc-bin libc6 libsystemd0 libudev1
 
 LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"


### PR DESCRIPTION
Cherry pick of #914 on release-1.1.

#914: security: fix CVEs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.