### PR TITLE
security: fix CVE-2018-25032 and update to debian-base:bullseye-v1.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ E2E_PROVIDER_IMAGE_NAME ?= e2e-provider
 # Release version is the current supported release for the driver
 # Update this version when the helm chart is being updated for release
 RELEASE_VERSION := v1.1.2
-IMAGE_VERSION ?= v1.1.2
+IMAGE_VERSION ?= v1.1.2.0
 
 # Use a custom version for E2E tests if we are testing in CI
 ifdef CI

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE=k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
+ARG BASEIMAGE=k8s.gcr.io/build-image/debian-base:bullseye-v1.2.0
 
 FROM golang:1.18 as builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver
@@ -28,14 +28,8 @@ RUN export GOOS=$TARGETOS && \
 
 FROM $BASEIMAGE
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi
-# upgrading libgmp10 due to CVE-2021-43618
-# upgrading bsdutils due to CVE-2021-3995 and CVE-2021-3996
-# upgrading libssl1.1 due to CVE-2022-0778 and CVE-2021-4160
-# upgrading libc-bin due to CVE-2021-33574, CVE-2022-23218, CVE-2022-23219 and CVE-2021-43396
-# upgrading libc6 due to CVE-2021-33574, CVE-2022-23218, CVE-2022-23219 and CVE-2021-43396
-# upgrading libsystemd0 due to CVE-2021-3997
-# upgrading libudev1 due to CVE-2021-3997
-RUN clean-install ca-certificates mount libgmp10 bsdutils libssl1.1 libc-bin libc6 libsystemd0 libudev1
+# upgrading zlib1g due to CVE-2018-25032
+RUN clean-install ca-certificates mount zlib1g
 
 LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@
 REGISTRY?=docker.io/deislabs
 IMAGE_NAME=driver
 CRD_IMAGE_NAME=driver-crds
-IMAGE_VERSION?=v1.1.2
+IMAGE_VERSION?=v1.1.2.0
 BUILD_TIMESTAMP := $(shell date +%Y-%m-%d-%H:%M)
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
```bash
gcr.io/k8s-staging-csi-secrets-store/driver:v1.1.0-e2e-2beb3ecc (debian 11.1)
=============================================================================
Total: 1 (MEDIUM: 0, HIGH: 1, CRITICAL: 0)

+---------+------------------+----------+-------------------+-------------------------+---------------------------------------+
| LIBRARY | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |      FIXED VERSION      |                 TITLE                 |
+---------+------------------+----------+-------------------+-------------------------+---------------------------------------+
| zlib1g  | CVE-2018-25032   | HIGH     | 1:1.2.11.dfsg-2   | 1:1.2.11.dfsg-2+deb11u1 | zlib: A flaw in zlib-1.2.11           |
|         |                  |          |                   |                         | when compressing (not                 |
|         |                  |          |                   |                         | decompressing!) certain inputs.       |
|         |                  |          |                   |                         | -->avd.aquasec.com/nvd/cve-2018-25032 |
+---------+------------------+----------+-------------------+-------------------------+---------------------------------------+
```

ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-secrets-store-csi-driver-image-scan/1510805711464960001

- Update to `debian-base:bullseye:v1.2.0`

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
