### PR TITLE
test: use helm upgrade --install for azure e2e

### DIFF
--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -49,7 +49,7 @@ setup() {
   # install the azure provider using the helm charts
   helm repo add csi-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
   helm repo update
-  helm install csi csi-provider-azure/csi-secrets-store-provider-azure --namespace $NAMESPACE \
+  helm upgrade --install csi csi-provider-azure/csi-secrets-store-provider-azure --namespace $NAMESPACE \
         --set "secrets-store-csi-driver.install=false" \
         --set "windows.enabled=$TEST_WINDOWS" \
         --set "logVerbosity=5" \


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
`helm upgrade` sub-command can upgrade an existing chart and install a new one, if the chart hasn’t been installed before. This will be used by the upgrade e2e tests.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
