### PR TITLE
test: cleanup provider tests (part 1)

### DIFF
--- a/test/bats/aws.bats
+++ b/test/bats/aws.bats
@@ -61,33 +61,6 @@ teardown_file() {
     assert_success
 }
 
-@test "secretproviderclasses crd is established" {
-    kubectl wait --namespace $NAMESPACE --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.x-k8s.io
-
-    run kubectl get crd/secretproviderclasses.secrets-store.csi.x-k8s.io
-    assert_success
-}
-
-@test "Test rbac roles and role bindings exist" {
-  run kubectl get clusterrole/secretproviderclasses-role
-  assert_success
-
-  run kubectl get clusterrole/secretproviderrotation-role
-  assert_success
-
-  run kubectl get clusterrole/secretprovidersyncing-role
-  assert_success
-
-  run kubectl get clusterrolebinding/secretproviderclasses-rolebinding
-  assert_success
-
-  run kubectl get clusterrolebinding/secretproviderrotation-rolebinding
-  assert_success
-
-  run kubectl get clusterrolebinding/secretprovidersyncing-rolebinding
-  assert_success
-}
-
 @test "deploy aws secretproviderclass crd" {
     envsubst < $BATS_TEST_DIR/BasicTestMountSPC.yaml | kubectl --namespace $NAMESPACE apply -f -
 

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -68,33 +68,6 @@ setup() {
   assert_success
 }
 
-@test "secretproviderclasses crd is established" {
-  kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.x-k8s.io
-
-  run kubectl get crd/secretproviderclasses.secrets-store.csi.x-k8s.io
-  assert_success
-}
-
-@test "Test rbac roles and role bindings exist" {
-  run kubectl get clusterrole/secretproviderclasses-role
-  assert_success
-
-  run kubectl get clusterrole/secretproviderrotation-role
-  assert_success
-
-  run kubectl get clusterrole/secretprovidersyncing-role
-  assert_success
-
-  run kubectl get clusterrolebinding/secretproviderclasses-rolebinding
-  assert_success
-
-  run kubectl get clusterrolebinding/secretproviderrotation-rolebinding
-  assert_success
-
-  run kubectl get clusterrolebinding/secretprovidersyncing-rolebinding
-  assert_success
-}
-
 @test "deploy azure secretproviderclass crd" {
   envsubst < $BATS_TESTS_DIR/azure_v1_secretproviderclass.yaml | kubectl apply -f -
 

--- a/test/bats/gcp.bats
+++ b/test/bats/gcp.bats
@@ -26,33 +26,6 @@ export SECRET_VALUE=${SECRET_VALUE:-"aHVudGVyMg=="}
   assert_success
 }
 
-@test "secretproviderclasses crd is established" {
-  kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.x-k8s.io
-
-  run kubectl get crd/secretproviderclasses.secrets-store.csi.x-k8s.io
-  assert_success
-}
-
-@test "Test rbac roles and role bindings exist" {
-  run kubectl get clusterrole/secretproviderclasses-role
-  assert_success
-
-  run kubectl get clusterrole/secretproviderrotation-role
-  assert_success
-
-  run kubectl get clusterrole/secretprovidersyncing-role
-  assert_success
-
-  run kubectl get clusterrolebinding/secretproviderclasses-rolebinding
-  assert_success
-
-  run kubectl get clusterrolebinding/secretproviderrotation-rolebinding
-  assert_success
-
-  run kubectl get clusterrolebinding/secretprovidersyncing-rolebinding
-  assert_success
-}
-
 @test "deploy gcp secretproviderclass crd" {
   envsubst < $BATS_TESTS_DIR/gcp_v1_secretproviderclass.yaml | kubectl apply --namespace=$NAMESPACE -f -
 

--- a/test/bats/vault.bats
+++ b/test/bats/vault.bats
@@ -57,33 +57,6 @@ EOF
     ttl=20m
 }
 
-@test "secretproviderclasses crd is established" {
-  kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.x-k8s.io
-
-  run kubectl get crd/secretproviderclasses.secrets-store.csi.x-k8s.io
-  assert_success
-}
-
-@test "Test rbac roles and role bindings exist" {
-  run kubectl get clusterrole/secretproviderclasses-role
-  assert_success
-
-  run kubectl get clusterrole/secretproviderrotation-role
-  assert_success
-
-  run kubectl get clusterrole/secretprovidersyncing-role
-  assert_success
-
-  run kubectl get clusterrolebinding/secretproviderclasses-rolebinding
-  assert_success
-
-  run kubectl get clusterrolebinding/secretproviderrotation-rolebinding
-  assert_success
-
-  run kubectl get clusterrolebinding/secretprovidersyncing-rolebinding
-  assert_success
-}
-
 @test "deploy vault secretproviderclass crd" {
   kubectl apply -f $BATS_TESTS_DIR/vault_v1_secretproviderclass.yaml
   kubectl wait --for condition=established --timeout=60s crd/secretproviderclasses.secrets-store.csi.x-k8s.io


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
- Trim down the supported provider test suite. The `e2e-provider` test will contain all the required tests.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
