### PR TITLE
ci: fix markdown link check workflow failures

### DIFF
--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -2,11 +2,15 @@ name: Check Markdown links
 
 on:
   push:
+    paths:
+      - "**.md"
     branches:
     - main
   pull_request:
     branches:
     - main
+    paths: 
+    - "**.md"
   schedule:
     - cron: "0 9 * * *"
 
@@ -25,3 +29,4 @@ jobs:
         use-quiet-mode: 'yes'
         # this will show detailed HTTP status for checked links
         use-verbose-mode: 'yes'
+        config-file: .markdownlinkcheck.json

--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -1,0 +1,22 @@
+{
+    "httpHeaders": [
+        {
+            "comment": "Workaround as suggested here: https://github.com/tcort/markdown-link-check/issues/201",
+            "urls": [
+                "https://docs.github.com/"
+            ],
+            "headers": {
+                "Accept-Encoding": "zstd, br, gzip, deflate"
+            }
+        }
+    ],
+    "timeout": "5s",
+    "retryOn429": true,
+    "retryCount": 5,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [
+        200,
+        206
+    ]
+}
+

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -18,5 +18,5 @@
 - [Load tests](./load-tests.md)
 - [Testing](./testing.md)
 - [Known Limitations](./known-limitations.md)
-- [Release Managment](./release-management.md)
+- [Release Management](./release-management.md)
 - [Design docs](./design-docs.md)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**What this PR does / why we need it**:
Links to https://docs.github.com/ raises a 403, which fails our markdown link checker.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
See https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/136

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
