### PR TITLE
feat: add unencrypted, plain values to be kept alongside secret infor…

### DIFF
--- a/apis/v1/secretproviderclass_types.go
+++ b/apis/v1/secretproviderclass_types.go
@@ -31,6 +31,8 @@ type SecretObjectData struct {
 	ObjectName string `json:"objectName,omitempty"`
 	// data field to populate
 	Key string `json:"key,omitempty"`
+	// non-secret value to use instead of object
+	PlainValue string `json:"plainValue,omitempty"`
 }
 
 // SecretObject defines the desired state of synced K8s secret objects

--- a/docs/book/src/topics/set-as-env-var.md
+++ b/docs/book/src/topics/set-as-env-var.md
@@ -20,6 +20,8 @@ spec:
     data: 
     - objectName: secretalias                    # name of the mounted content to sync. this could be the object name or object alias 
       key: username
+    - plainValue: hello folks                    # publicly available information that is NOT kept secret 
+      key: greeting
   parameters:
     usePodIdentity: "false"                      
     keyvaultName: "$KEYVAULT_NAME"               # the name of the KeyVault

--- a/docs/book/src/topics/sync-as-kubernetes-secret.md
+++ b/docs/book/src/topics/sync-as-kubernetes-secret.md
@@ -84,6 +84,8 @@ spec:
   - data:
     - key: username                           # data field to populate
       objectName: foo1                        # name of the mounted content to sync. this could be the object name or the object alias
+    - key: greeting
+      plainValue: hello folks                 # publicly available information that is NOT kept secret, e.g. for names or descriptions
     secretName: foosecret                     # name of the Kubernetes Secret object
     type: Opaque                              # type of the Kubernetes Secret object e.g. Opaque, kubernetes.io/tls
 ```

--- a/pkg/util/secretutil/secret_test.go
+++ b/pkg/util/secretutil/secret_test.go
@@ -219,10 +219,11 @@ func TestGetSecretData(t *testing.T) {
 		expectedError   bool
 	}{
 		{
-			name: "object name not set",
+			name: "object name and plain value not set",
 			secretObjData: []*secretsstorev1.SecretObjectData{
 				{
 					ObjectName: "",
+					PlainValue: "",
 				},
 			},
 			secretType:      corev1.SecretTypeOpaque,
@@ -267,6 +268,20 @@ func TestGetSecretData(t *testing.T) {
 			expectedError:   true,
 		},
 		{
+			name: "object name and plain value set",
+			secretObjData: []*secretsstorev1.SecretObjectData{
+				{
+					ObjectName: "obj1",
+					PlainValue: "value1",
+					Key:        "file1",
+				},
+			},
+			secretType:      corev1.SecretTypeOpaque,
+			currentFiles:    map[string]string{"obj1": ""},
+			expectedDataMap: make(map[string][]byte),
+			expectedError:   true,
+		},
+		{
 			name: "file matching object found in fs",
 			secretObjData: []*secretsstorev1.SecretObjectData{
 				{
@@ -303,6 +318,19 @@ func TestGetSecretData(t *testing.T) {
 			secretType:      corev1.SecretTypeOpaque,
 			currentFiles:    map[string]string{"obj1": ""},
 			expectedDataMap: map[string][]byte{"file1": []byte("test")},
+			expectedError:   false,
+		},
+		{
+			name: "plain value set",
+			secretObjData: []*secretsstorev1.SecretObjectData{
+				{
+					PlainValue: "plain value 1",
+					Key:        "   file1",
+				},
+			},
+			secretType:      corev1.SecretTypeOpaque,
+			currentFiles:    map[string]string{"obj1": ""},
+			expectedDataMap: map[string][]byte{"file1": []byte("plain value 1")},
 			expectedError:   false,
 		},
 	}


### PR DESCRIPTION
…mation

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
As described in the linked issues, there are use-cases for non-sensitive values that should be kept alongside sensitive values.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #938, fixes #948

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
This is my first contribution to this repository, therefore I would really appreciate any feedback, suggestions and change requests.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [X] includes documentation
- [X] adds unit tests
