### PR TITLE
security: fix CVE-2022-1292

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,8 @@ FROM $BASEIMAGE
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi
 # upgrading zlib1g due to CVE-2018-25032
 # upgrading gzip and liblzma5 due to CVE-2022-1271
-RUN clean-install ca-certificates mount zlib1g gzip liblzma5
+# upgrading libssl1.1 due to CVE-2022-1292
+RUN clean-install ca-certificates mount zlib1g gzip liblzma5 libssl1.1
 
 LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Please label this pull request according to what type of issue you are addressing -->
**What this PR does / why we need it**:
```bash
e2e/driver:test-linux-amd64 (debian 11.3)

Total: 1 (MEDIUM: 0, HIGH: 0, CRITICAL: 1)

┌───────────┬───────────────┬──────────┬───────────────────┬──────────────────┬───────────────────────────────────────────────────┐
│  Library  │ Vulnerability │ Severity │ Installed Version │  Fixed Version   │                       Title                       │
├───────────┼───────────────┼──────────┼───────────────────┼──────────────────┼───────────────────────────────────────────────────┤
│ libssl1.1 │ CVE-2022-1292 │ CRITICAL │ 1.1.1n-0+deb11u1  │ 1.1.1n-0+deb11u2 │ openssl: c_rehash script allows command injection │
│           │               │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-1292         │
└───────────┴───────────────┴──────────┴───────────────────┴──────────────────┴───────────────────────────────────────────────────┘
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
