### PR TITLE
fix: multiple podLabels for linux.crds in helm charts

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
@@ -91,7 +91,7 @@ spec:
       {{- end }}
       {{- if .Values.linux.crds.podLabels }}
       labels:
-        {{ toYaml .Values.linux.crds.podLabels }}
+        {{- toYaml .Values.linux.crds.podLabels | nindent 8 }}
       {{- end }}
     spec:
       serviceAccountName: {{ template "sscd.fullname" . }}-upgrade-crds

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/keep-crds-upgrade-hook.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/keep-crds-upgrade-hook.yaml
@@ -91,7 +91,7 @@ spec:
       {{- end }}
       {{- if .Values.linux.crds.podLabels }}
       labels:
-        {{ toYaml .Values.linux.crds.podLabels }}
+        {{- toYaml .Values.linux.crds.podLabels | nindent 8 }}
       {{- end }}
     spec:
       serviceAccountName: {{ template "sscd.fullname" . }}-keep-crds


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
bugfix for multiple entries in `linux.crds.podLabels`

/kind bug

**What this PR does / why we need it**:

if there are more than one `linux.crds.podLabels`, the helm chart won't work.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

bugfix for this recently merged: #962 

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
