### PR TITLE
fix: increase hook-weight for crd upgrade jobs in helm charts

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
@@ -78,7 +78,7 @@ metadata:
 {{ include "sscd.labels" . | indent 2 }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "1"
+    helm.sh/hook-weight: "10"
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
 spec:
   backoffLimit: 0

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/keep-crds-upgrade-hook.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/keep-crds-upgrade-hook.yaml
@@ -78,7 +78,7 @@ metadata:
 {{ include "sscd.labels" . | indent 2 }}
   annotations:
     helm.sh/hook: pre-upgrade
-    helm.sh/hook-weight: "2"
+    helm.sh/hook-weight: "20"
     helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
 spec:
   backoffLimit: 0


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Helm chart upgrade fails because of the incorrect hook-weight.

Job resource from [/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/a5b207f5904874b20e00aa29416dda4e4162e2b2/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml#L81) and [/charts/secrets-store-csi-driver/templates/keep-crds-upgrade-hook.yaml](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/a5b207f5904874b20e00aa29416dda4e4162e2b2/charts/secrets-store-csi-driver/templates/keep-crds-upgrade-hook.yaml#L81) should have higher hook-weight (lower priority) than other resources like ClusterRole, ClusterRoleBinding, ServiceAccount, PodSecurityPolicy.

They have the same hook-weight and therefore Job is starting before ServiceAccount secrets-store-csi-secrets-store-csi-driver-upgrade-crds creation.

This PR increases the hook-weight for the Job resource. Therefore Job resource will be created after corresponding ServiceAccount.

**Which issue(s) this PR fixes**:
Fixes #967

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
After changing Job weight to "10" for crds-upgrade-hook.yaml and "20" for keep-crds-upgrade-hook.yaml, the chart was successfully upgraded:
```
% helm upgrade secrets-store-csi . --namespace kube-system --debug
upgrade.go:142: [debug] preparing upgrade for secrets-store-csi
upgrade.go:521: [debug] copying values from secrets-store-csi (v1) to new release.
upgrade.go:150: [debug] performing update for secrets-store-csi
upgrade.go:322: [debug] creating upgraded release for secrets-store-csi
client.go:299: [debug] Starting delete for "secrets-store-csi-secrets-store-csi-driver-upgrade-crds" ServiceAccount
client.go:128: [debug] creating 1 resource(s)
client.go:299: [debug] Starting delete for "secrets-store-csi-secrets-store-csi-driver-upgrade-crds" ClusterRole
client.go:128: [debug] creating 1 resource(s)
client.go:299: [debug] Starting delete for "secrets-store-csi-secrets-store-csi-driver-upgrade-crds" ClusterRoleBinding
client.go:128: [debug] creating 1 resource(s)
client.go:299: [debug] Starting delete for "secrets-store-csi-secrets-store-csi-driver-keep-crds" ServiceAccount
client.go:128: [debug] creating 1 resource(s)
client.go:299: [debug] Starting delete for "secrets-store-csi-secrets-store-csi-driver-keep-crds" ClusterRole
client.go:328: [debug] clusterroles.rbac.authorization.k8s.io "secrets-store-csi-secrets-store-csi-driver-keep-crds" not found
client.go:128: [debug] creating 1 resource(s)
client.go:299: [debug] Starting delete for "secrets-store-csi-secrets-store-csi-driver-keep-crds" ClusterRoleBinding
client.go:128: [debug] creating 1 resource(s)
client.go:299: [debug] Starting delete for "secrets-store-csi-driver-keep-crds" Job
client.go:128: [debug] creating 1 resource(s)
client.go:529: [debug] Watching for changes to Job secrets-store-csi-driver-keep-crds with timeout of 5m0s
client.go:557: [debug] Add/Modify event for secrets-store-csi-driver-keep-crds: ADDED
client.go:596: [debug] secrets-store-csi-driver-keep-crds: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
client.go:557: [debug] Add/Modify event for secrets-store-csi-driver-keep-crds: MODIFIED
client.go:299: [debug] Starting delete for "secrets-store-csi-driver-upgrade-crds" Job
client.go:128: [debug] creating 1 resource(s)
client.go:529: [debug] Watching for changes to Job secrets-store-csi-driver-upgrade-crds with timeout of 5m0s
client.go:557: [debug] Add/Modify event for secrets-store-csi-driver-upgrade-crds: ADDED
client.go:596: [debug] secrets-store-csi-driver-upgrade-crds: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
client.go:557: [debug] Add/Modify event for secrets-store-csi-driver-upgrade-crds: MODIFIED
client.go:299: [debug] Starting delete for "secrets-store-csi-secrets-store-csi-driver-upgrade-crds" ServiceAccount
client.go:299: [debug] Starting delete for "secrets-store-csi-secrets-store-csi-driver-upgrade-crds" ClusterRole
client.go:299: [debug] Starting delete for "secrets-store-csi-secrets-store-csi-driver-upgrade-crds" ClusterRoleBinding
client.go:299: [debug] Starting delete for "secrets-store-csi-secrets-store-csi-driver-keep-crds" ServiceAccount
client.go:299: [debug] Starting delete for "secrets-store-csi-secrets-store-csi-driver-keep-crds" ClusterRole
client.go:299: [debug] Starting delete for "secrets-store-csi-secrets-store-csi-driver-keep-crds" ClusterRoleBinding
client.go:299: [debug] Starting delete for "secrets-store-csi-driver-keep-crds" Job
client.go:299: [debug] Starting delete for "secrets-store-csi-driver-upgrade-crds" Job
client.go:218: [debug] checking 7 resources for changes
client.go:510: [debug] Patch ServiceAccount "secrets-store-csi-driver" in namespace kube-system
client.go:239: [debug] Created a new ClusterRole called "secretproviderclasses-admin-role" in 

client.go:239: [debug] Created a new ClusterRole called "secretproviderclasses-viewer-role" in 

client.go:510: [debug] Patch ClusterRole "secretproviderclasses-role" in namespace 
client.go:501: [debug] Looks like there are no changes for ClusterRoleBinding "secretproviderclasses-rolebinding"
client.go:510: [debug] Patch DaemonSet "secrets-store-csi-secrets-store-csi-driver" in namespace kube-system
client.go:501: [debug] Looks like there are no changes for CSIDriver "secrets-store.csi.k8s.io"
upgrade.go:157: [debug] updating status for upgraded release for secrets-store-csi
Release "secrets-store-csi" has been upgraded. Happy Helming!
```