### PR TITLE
security: fix CVE-2022-2068

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ E2E_PROVIDER_IMAGE_NAME ?= e2e-provider
 # Release version is the current supported release for the driver
 # Update this version when the helm chart is being updated for release
 RELEASE_VERSION := v1.2.0
-IMAGE_VERSION ?= v1.2.0
+IMAGE_VERSION ?= v1.2.0.0
 
 # Use a custom version for E2E tests if we are testing in CI
 ifdef CI

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,8 @@ RUN export GOOS=$TARGETOS && \
 FROM $BASEIMAGE
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi
 # upgrading dpkg due to CVE-2022-1664
-RUN clean-install ca-certificates mount dpkg
+# upgrading libssl1.1 due to CVE-2022-2068
+RUN clean-install ca-certificates mount dpkg libssl1.1
 
 LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@
 REGISTRY?=docker.io/deislabs
 IMAGE_NAME=driver
 CRD_IMAGE_NAME=driver-crds
-IMAGE_VERSION?=v1.2.0
+IMAGE_VERSION?=v1.2.0.0
 BUILD_TIMESTAMP := $(shell date +%Y-%m-%d-%H:%M)
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
```bash
e2e/driver:test-linux-amd64 (debian 11.3)

Total: 1 (MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌───────────┬───────────────┬──────────┬───────────────────┬──────────────────┬───────────────────────────────────────────────────────┐
│  Library  │ Vulnerability │ Severity │ Installed Version │  Fixed Version   │                         Title                         │
├───────────┼───────────────┼──────────┼───────────────────┼──────────────────┼───────────────────────────────────────────────────────┤
│ libssl1.1 │ CVE-2022-2068 │ MEDIUM   │ 1.1.1n-0+deb11u2  │ 1.1.1n-0+deb11u3 │ openssl: the c_rehash script allows command injection │
│           │               │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-2068             │
└───────────┴───────────────┴──────────┴───────────────────┴──────────────────┴───────────────────────────────────────────────────────┘
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
