### PR TITLE
security: fix CVE-2022-34903

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,8 @@ RUN export GOOS=$TARGETOS && \
 
 FROM $BASEIMAGE
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi
-RUN clean-install ca-certificates mount
+# upgrading gpgv due to CVE-2022-34903
+RUN clean-install ca-certificates mount gpgv
 
 LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
```console
gcr.io/k8s-staging-csi-secrets-store/driver:v1.2.0-e2e-fa945789 (debian 11.3)
=============================================================================
Total: 1 (MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬───────────────────┬──────────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Installed Version │  Fixed Version   │                            Title                             │
├─────────┼────────────────┼──────────┼───────────────────┼──────────────────┼──────────────────────────────────────────────────────────────┤
│ gpgv    │ CVE-2022-34903 │ MEDIUM   │ 2.2.27-2+deb11u1  │ 2.2.27-2+deb11u2 │ GnuPG through 2.3.6, in unusual situations where an attacker │
│         │                │          │                   │                  │ possesses ...                                                │
│         │                │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-34903                   │
└─────────┴────────────────┴──────────┴───────────────────┴──────────────────┴──────────────────────────────────────────────────────────────┘
```

ref: https://storage.googleapis.com/kubernetes-jenkins/logs/periodic-secrets-store-csi-driver-image-scan/1544515647285760000/build-log.txt

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
