### PR TITLE
fix: use `os.Lstat` to resolve `os.Stat` issue in windows

### DIFF
--- a/pkg/secrets-store/provider_client.go
+++ b/pkg/secrets-store/provider_client.go
@@ -30,6 +30,7 @@ import (
 
 	internalerrors "sigs.k8s.io/secrets-store-csi-driver/pkg/errors"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/fileutil"
+	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/runtimeutil"
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
 
 	"google.golang.org/grpc"
@@ -133,6 +134,15 @@ func (p *PluginClientBuilder) Get(ctx context.Context, provider string) (v1alpha
 		if _, err := os.Stat(tryPath); err == nil {
 			socketPath = tryPath
 			break
+		}
+		// TODO: This is a workaround for Windows 20H2 issue for os.Stat(). See
+		// microsoft/Windows-Containers#97 for details.
+		// Once the issue is resolved, the following os.Lstat() is not needed.
+		if runtimeutil.IsRuntimeWindows() {
+			if _, err := os.Lstat(tryPath); err == nil {
+				socketPath = tryPath
+				break
+			}
 		}
 	}
 

--- a/pkg/secrets-store/server.go
+++ b/pkg/secrets-store/server.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
+
+	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/runtimeutil"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	pbSanitizer "github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
@@ -86,7 +87,7 @@ func (s *nonBlockingGRPCServer) serve(ctx context.Context, endpoint string, ids 
 	}
 
 	if proto == "unix" {
-		if runtime.GOOS != "windows" {
+		if !runtimeutil.IsRuntimeWindows() {
 			addr = "/" + addr
 		}
 		if err := os.Remove(addr); err != nil && !os.IsNotExist(err) {

--- a/pkg/secrets-store/utils.go
+++ b/pkg/secrets-store/utils.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"runtime"
 	"strings"
 
 	secretsstorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
+	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/runtimeutil"
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/spcpsutil"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -57,7 +57,7 @@ func (ns *nodeServer) ensureMountPoint(target string) (bool, error) {
 		return !notMnt, err
 	}
 
-	if runtime.GOOS == "windows" {
+	if runtimeutil.IsRuntimeWindows() {
 		// IsLikelyNotMountPoint always returns notMnt=true for windows as the
 		// target path is not a soft link to the global mount
 		// instead check if the dir exists for windows and if it's not empty

--- a/pkg/util/fileutil/atomic_writer.go
+++ b/pkg/util/fileutil/atomic_writer.go
@@ -27,9 +27,10 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/runtimeutil"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
@@ -195,7 +196,7 @@ func (w *AtomicWriter) Write(payload map[string]FileProjection) error {
 	}
 
 	// (9)
-	if runtime.GOOS == "windows" {
+	if runtimeutil.IsRuntimeWindows() {
 		os.Remove(dataDirPath)
 		err = os.Symlink(tsDirName, dataDirPath)
 		os.Remove(newDataDirPath)

--- a/pkg/util/fileutil/writer_test.go
+++ b/pkg/util/fileutil/writer_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/test_utils/tmpdir"
+	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/runtimeutil"
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
 )
 
@@ -442,7 +443,7 @@ func readPayloads(path string, payloads []*v1alpha1.File) error {
 		if err != nil {
 			return err
 		}
-		if runtime.GOOS == "windows" {
+		if runtimeutil.IsRuntimeWindows() {
 			// on windows only the 0200 bitmask is used by chmod
 			// https://golang.org/src/os/file.go?s=15847:15891#L522
 			if (info.Mode() & 0200) != (fs.FileMode(p.Mode) & 0200) {

--- a/pkg/util/runtimeutil/runtime.go
+++ b/pkg/util/runtimeutil/runtime.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtimeutil
+
+import "runtime"
+
+// IsRuntimeWindows returns true if the runtime is windows.
+func IsRuntimeWindows() bool {
+	return runtime.GOOS == "windows"
+}


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR introduces a fallback os.Lstat check in provider client for the provider socket. There is a known issue in windows using os.Stat() which happens randomly in 1809, 1903 but always fails in ltsc2022.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/931

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
