### PR TITLE
chore: update debian-base to bullseye-v1.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ E2E_PROVIDER_IMAGE_NAME ?= e2e-provider
 # Release version is the current supported release for the driver
 # Update this version when the helm chart is being updated for release
 RELEASE_VERSION := v1.2.2
-IMAGE_VERSION ?= v1.2.2
+IMAGE_VERSION ?= v1.2.2.0
 
 # Use a custom version for E2E tests if we are testing in CI
 ifdef CI

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE=k8s.gcr.io/build-image/debian-base:bullseye-v1.4.0
+ARG BASEIMAGE=k8s.gcr.io/build-image/debian-base:bullseye-v1.4.1
 
 FROM golang:1.18 as builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver
@@ -28,9 +28,7 @@ RUN export GOOS=$TARGETOS && \
 
 FROM $BASEIMAGE
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi
-# upgrading gpgv due to CVE-2022-34903
-# upgrading libgnutls30 due to CVE-2021-4209
-RUN clean-install ca-certificates mount gpgv libgnutls30
+RUN clean-install ca-certificates mount
 
 LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@
 REGISTRY?=docker.io/deislabs
 IMAGE_NAME=driver
 CRD_IMAGE_NAME=driver-crds
-IMAGE_VERSION?=v1.2.2
+IMAGE_VERSION?=v1.2.2.0
 BUILD_TIMESTAMP := $(shell date +%Y-%m-%d-%H:%M)
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
- update debian-base to bullseye-v1.4.1

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
