### PR TITLE
ci: bump kubernetes version to v1.25.0

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        KUBERNETES_VERSION: ["v1.21.10", "v1.22.7", "v1.23.5", "v1.24.0"]
+        KUBERNETES_VERSION: ["v1.22.13", "v1.23.10", "v1.24.4", "v1.25.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
         # pinning to the sha aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 from https://github.com/engineerd/setup-kind/releases/tag/v0.5.0
         uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0
         with:
-          version: "v0.14.0"
+          version: "v0.15.0"
           image: "kindest/node:${{ matrix.KUBERNETES_VERSION }}"
       - name: Test
         run: |


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
- Removes `v1.21` as it's EOL and adds `v1.25` to the staging image test matrix.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
