### PR TITLE
fix: handles pfx certs in k8s secrets sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
+	golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b
 	golang.org/x/net v0.0.0-20220906165146-f3363e06e74c // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -605,6 +605,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b h1:huxqepDufQpLLIRXiVkTvnxrzJlpwmIWAObmcCcUFr0=
+golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/pkg/util/secretutil/secret_test.go
+++ b/pkg/util/secretutil/secret_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package secretutil
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"reflect"
@@ -128,43 +129,79 @@ jhw96ptOWs58zSr5PWhwLDjxX1FFzu7KdBnuRSzEsNbjDZ7rXFXDM9+ygGNnzqBN
 saCzOA1Px9jag43hgrDrFNUXkUtbwSfuNiRsAXS1ffa7mClSjlj4eA==
 -----END RSA PRIVATE KEY-----
 `
+	certPFXFile = `MIIKLgIBAzCCCeoGCSqGSIb3DQEHAaCCCdsEggnXMIIJ0zCCBgwGCSqGSIb3DQEHAaCCBf0EggX5MIIF9TCCBfEGCyqGSIb3DQEMCgECoIIE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAheO0APNqAEiwICB9AEggTYoYfSBSosTptP1JpW39c4U2GaZ4pipWv+n5WaxR0E9OGYf7qRf/ltRB6hh+1Rqxk6u2WSJVCJyZjJzmdiiw5xGxxI3x1LmRdQ+lbLDYwLAlaEH2p/4WDSezM2hA8dLZb6+BLgIm/nEQMyXAH78GLBuuesXbL47enJts9bTAp5CCjumrDvj2duqQPGvNTcsunPGQgUT24StmBiWtch09tpPeFnKsh9Pcy81mZfnWbuzdPdEA1DJlSxP2njZCxcA7Vs7Cr2CRrqCjBwxE76Qq7jy5lc9KQYexaUk55Cdpb3332YnVj0Eda1I3DHMOVWTJWDMuecd/vBKUsDSKcPel5JGmXRaVDmlU0CW9k6pU+oz0AJ8NrYN0OP0KbwTn66Bar4rp/4YW+zlcJKcyEaZBolvEm4/RU7IxlfOQtIE0ZdwRXtDQbJTei+RzdAC78TAOH/fGIlKpeY8KOT9EOQOqMM8iDqAZ/SVOPvalpD9v+lsJpPIQHFMXOpXSlJciwlj+eJpF5O1z2OegLIY8tgrIv1aAb31LkIY9iyG9ymfI7n76dwnKwIHmjBmU3yvOCIolfrReArqbRs/gjcmAE87QTnBTri5lSy1fG6fA/xyccnWseuTUVIUmpgVPWW0D2aWXEECNsD6QOwST9g/MDdajLgje38Pmkl84I1YQDwMkH+9/9djSKluMvg+UPnHL0lBqYnhulkZ0tSWu1D5Ja1/OvFeyqi+haURFBRmz2onk5YCCIEXd0cMWGEywX6sWSLtN/tAXENAD5bRvx5dRMmHqqsA0pWd5mg56uz08bMYp1eIPhY6fSXTrW41WwQhO3rePEt8jkXJDeL1KQPPUH/zvMYiIylYYb1xKLojbL0FWqGk6ZIokMmz5nIJWooSN62ZQVATPzBxzOMCPuxJAGZFkGtl7lDcRBrlntyMAJF2EvCo7bHgOsw5OiWaTf+rnCoPbDZUqRdwGWGIP5too1wT/ypX1s8Nim5xnKBvFcdtL+2U4SFwXed2hDRJyE6jbHUnPMG1TJhTZ0evH2OavyBAl/wTpp96vzbKLDbpZDLRm6dY7nH9LbJCTeEeziIh0IR0jlBI+3SFmtpdU8bIrg2pJ4Vy99biwNaB6B62hlROYBR9A4WiS3M8xbKcA9ho8fcPuZUif+Xt/17gCvRKbnUzZmw5w4yiwP1KXBTVeWClqHBj5XqTYmsgV3OlW/5uRTDHQQ2fjv/fmA5bOTWaMQIwEdUYGi1gZNQEpKahFu77s3ZvGSBN0NunDFmuKQlratf6y/byO3GDkGdMJ055tW4gdkrXuKne6bVVyoAgYvpFjI1rU7kFQzomkeLk/fKUSiFjV9AhJR24Rd5L+zzi8vUN5e03Hgb45AfM5gSI5jz1TZaoz1zSh3xoOY6xuC2If4BShCJesyYtUn3wO2KBjvvJYL8vrZCgintho/ROFJJ5RmL1GuQmAym2SKhhODGHUGuqPiG+tD98NXd9camiK+1MKarHRy8wHC7cUtai5BOyCIQ9YanRyIYgWyqIVNzWsDaY0vLNO6ZsLg+VGiOkmWTjHJzjtbURFfyFwHU7V1ionpUX0PHEoyQq2hSr6U0c0LBicen6UOl4chiwWF8LirEplZXrZFv2TBTn5huWrSNY1aQEWCg5L1heVsCWjGB3zATBgkqhkiG9w0BCRUxBgQEAQAAADBbBgkqhkiG9w0BCRQxTh5MAHsAMwA0AEQANQA2AEUANAAyAC0AMwA2AEQAMAAtADQANwAyADMALQBBADkARAA3AC0ANwA5AEYAQgBCADAANwAwADAANQAxAEEAfTBrBgkrBgEEAYI3EQExXh5cAE0AaQBjAHIAbwBzAG8AZgB0ACAARQBuAGgAYQBuAGMAZQBkACAAQwByAHkAcAB0AG8AZwByAGEAcABoAGkAYwAgAFAAcgBvAHYAaQBkAGUAcgAgAHYAMQAuADAwggO/BgkqhkiG9w0BBwagggOwMIIDrAIBADCCA6UGCSqGSIb3DQEHATAcBgoqhkiG9w0BDAEDMA4ECHc3nBaCC7rHAgIH0ICCA3gDApMGP8moWZ2pLEUkZwRG//ooc483goz/2jAveMGhc6Ytt5/Iyx+QFelCUw+XhZkUVqRpSgKmmFutO3rHPaJKT7xakuXibRyCAEyLg62PPyWtqiSn1ESsQa+cdCN7heVUN+IxENr7a10N+SXonQqQS6/ZEciPI6TKIzXkBz1spiU75GlD53ot/P9ZtDOcNLQM/eAf2Opieeu6UlBwjb/FbCaNJpK8YaOnniV51XX1K9NpHI0z0/S0x9Fn5sRVhTHxPRTEszowpEqgPVxe/M8NBSsG9BhO4kmeyBix8RCTJ/vUNAMq7sNS+4Iwg+SxQs0nGxPrQHUV+VByXLvoGkVMbSyu5PHXxRjUAhZkTuufbxmkqQfQXpJugfrEhLGc+8xa26AVCi9h1Di8VStHfseHrpcV3mxhMwhkEtlSgNIc9/F9v3eUNQzRRLpi2VlcPD8iIitmalmQVnJHWCHV4L8esuAIv4AMicnF0VnIrXLhey5lfR6HWEYRMS8l2yPsaNtGfriyn+lFZlnfqm9hAfJspodOy3zTkPU8Dvs7MBSzmZP7L4Le5IOR9TNES2dBllXs2eQNh59LeHC8N0MSp15krCDDhQbW8Pill85CR+CRqRKBseOpqRvzMnEOkpxCuFo2lBq2scI72V4B3iy9fKc7CxjBkxOiPlH8FWxxIkm97EEWd/jmv/djWhTwBsqwMBlC9eE8p5kMw7DlmhwkutPL9yMIF89BxT6bX9pnYmaTosP/lj2h3QgL5FrEh/VNoLoXdmm7u3h8qVL/hmn+opA6mm3d0eGWZYSjj1CakDbLlZja5lbbWbOwU15ENUTL0Xu5mEv4z7sIM4ZMbbKCP9bfG6eql4xCjrpvij7zqZ1vUcKk1kDQAprTDgxQ2s86gFEAjF8stqfnTUOVfaSZ62eVuIjjK1GEoY+3q4uz1R0jIajdV4Pcvp+x3+7LVUXynweXHsYmjN5Xx2j5wG8jTQMCV+Pt2Fl9XuynBupvVm51da+Om5FnhXbrETrxnuoZ/HMOuANAX+aXaqApiL0GpH1H9jsiY/6vSq+0yt6iMnI4sqqdIBdBXZcHHuvW6mADC+D3ink+6K1DQHgtzXXEtPLcFF/4ZVJR/22PbLo6U4oBng+BsFm6uyVbv7DcP19a6P5SV4d1hFIZTnnRqwSMqZwr624iRbYpcxUwOzAfMAcGBSsOAwIaBBTKwOqKaHaAv7/IagfaZcvmh80ydwQUqN+1nRELkWBn5ny2LDiwRt6YwUUCAgfQ`
+
+	certPFX = `-----BEGIN CERTIFICATE-----
+localKeyId: 01000000
+
+MIIDKjCCAhKgAwIBAgIQd2W5xPDLm+wNWNyuJSs93DANBgkqhkiG9w0BAQsFADAa
+MRgwFgYDVQQDEw90ZXN0LmRvbWFpbi5jb20wHhcNMjIwNDIwMjEyMjI4WhcNMzIw
+MjI3MjEyMjI4WjAaMRgwFgYDVQQDEw90ZXN0LmRvbWFpbi5jb20wggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQCqPKRLifQOEP3VYUb+xg4EEExPGnHVggZn
+oJOuEWQNs/82nU91yMRlZCnO/ornALV2VD9vdJa8fqkvAfkU767G7XQKkl4H6ROa
+fH62o0kxF1T6976O6P2x5RWIBMJ53END4DG0XE17GO1hJIknbcN5teRHbQndCl6K
+i8L2dkE5WqlsE+Z6R9hUhB1530mhfqGXU8f420Gvi2uC9juShEP57VpMjSNb2+pF
+Ky45N56c4Q5/GEd//ionNwElfqegLOw+c1TbZsNB6/i+5XQOISayfWC3QidGdVJ5
+tL2qObvIynbSEFY23YLQMkwqQ++JgIIJrPks4fguU6L8fohBKHBDAgMBAAGjbDBq
+MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw
+HQYDVR0OBBYEFP64JsBvMwzzLOym2V2W0xmIz/tHMBoGA1UdEQQTMBGCD3Rlc3Qu
+ZG9tYWluLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEAc9SKUaDS1/0p9/X4zBtG8D2i
+8sYcYZAkyqRmh+Ebkj+sj5QSQeNyUkaH53GXo2F7Vhk70tp/9di0GL2kGaTR+4rv
+0vFcd6jjb9UQ+RVRSvGmrdXjLm8QAykyy/ZJ37+tMvlYQN0dsnzACiS/hJFvaKpq
+etvymTvT9awNFyptlgbFgTdQEJqLUFTfBTvwOoB/9kZqcwLOcDTd1IXNw3OhPWKC
+Qk7q7MXpVSGh9K93rKXp2ERhpIodnHP8eP77j2/kRP52AReJeZ9BLrZEEIozM1zw
+2yan2If8S34rrwm6j3UXnCQrsE+1R/rwEb4vKm5x+ctjGtuT4jPbYpURa3cjTg==
+-----END CERTIFICATE-----
+`
 )
 
 func TestGetCert(t *testing.T) {
 	cases := []struct {
 		Name        string
-		data        string
+		data        func() string
 		part        string
-		expectedPEM []byte
+		expected    []byte
 		expectedErr bool
 	}{
 		{
-			Name:        "Get cert PEM",
-			data:        certFile,
+			Name: "Get cert PFX",
+			data: func() string {
+				pfxBytes, err := base64.StdEncoding.DecodeString(certPFXFile)
+				assert.Nil(t, err, "error decoding certPFXFile")
+
+				return string(pfxBytes)
+			},
 			part:        "tls.crt",
-			expectedPEM: []byte(certPEM),
+			expected:    []byte(certPFX),
+			expectedErr: false,
+		},
+		{
+			Name:        "Get cert PEM",
+			data:        func() string { return certFile },
+			part:        "tls.crt",
+			expected:    []byte(certPEM),
 			expectedErr: false,
 		},
 		{
 			Name:        "Get key PEM",
-			data:        certFile,
+			data:        func() string { return certFile },
 			part:        "tls.key",
-			expectedPEM: []byte(keyPEM),
+			expected:    []byte(keyPEM),
 			expectedErr: false,
 		},
 		{
 			Name:        "Unsupported part type",
-			data:        certFile,
+			data:        func() string { return certFile },
 			part:        "key",
-			expectedPEM: []byte(nil),
+			expected:    []byte(nil),
 			expectedErr: true,
 		},
 	}
 
 	for _, tc := range cases {
-		actualPEM, err := GetCertPart([]byte(tc.data), tc.part)
+		actual, err := GetCertPart([]byte(tc.data()), tc.part)
 		assert.Equal(t, tc.expectedErr, err != nil)
-		assert.Equal(t, tc.expectedPEM, actualPEM)
+		assert.Equal(t, tc.expected, actual)
 	}
 }
 
@@ -398,13 +435,52 @@ func TestGenerateSHAFromSecret(t *testing.T) {
 func TestGetPrivateKey(t *testing.T) {
 	tests := []struct {
 		name        string
-		actualPEM   string
+		actual      func() string
 		expectedKey string
 		expectedErr bool
 	}{
 		{
+			name: "RSA key in pfx cert",
+			actual: func() string {
+				pfxBytes, err := base64.StdEncoding.DecodeString(certPFXFile)
+				assert.Nil(t, err, "expected err to be nil, got: %+v", err)
+
+				return string(pfxBytes)
+			},
+			expectedKey: `-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEAqjykS4n0DhD91WFG/sYOBBBMTxpx1YIGZ6CTrhFkDbP/Np1P
+dcjEZWQpzv6K5wC1dlQ/b3SWvH6pLwH5FO+uxu10CpJeB+kTmnx+tqNJMRdU+ve+
+juj9seUViATCedxDQ+AxtFxNexjtYSSJJ23DebXkR20J3QpeiovC9nZBOVqpbBPm
+ekfYVIQded9JoX6hl1PH+NtBr4trgvY7koRD+e1aTI0jW9vqRSsuOTeenOEOfxhH
+f/4qJzcBJX6noCzsPnNU22bDQev4vuV0DiEmsn1gt0InRnVSebS9qjm7yMp20hBW
+Nt2C0DJMKkPviYCCCaz5LOH4LlOi/H6IQShwQwIDAQABAoIBAQCWsVmKGJL2hKn9
+Yb/ztSQhCsBR4YnUwuWig61Wj8RusOAA213EWLUpP3IW7pHMjH8VQNxqb90i/EgM
++YUguE6Rfw6ScSBVhke5H+0XBRG8J/gstHN1k99Gww+9OOFh981/Xw0AqBhaGCXB
+MRNL2MkJiy6I34e0qAIqSC+L9gAkoJ/M4aj68gAP3TEZZ18iUP0p9O2F87qS+wEh
+Nb5Vhp2R4+5f7wqgIHh+/xh5/rXtSaaNBegHp2bwbjlm+Sn7/7V89gU9l41klYbn
+UdVpoMgU+vIQI9VGQ4Kh+1oBgQJbfK97QTJIxTG1TN9H9m/9z13r1du6Yfwao07T
+ZDoiwCGZAoGBAMrmpnchf6+pGLWTKffYMa0Es5h9tWuU6bb4OIOfJP2XdrYEvazi
+TziTRL61M7VCkpMfTEQ9I/ewRaNTgo9InZv7ckWLR2kuzIg1WjYImxSZagOmc+Gi
++q7JTZuizbvvVBVQhqna92O86D+yYGlBOdlZ053zBKpE7LNTAewekLiXAoGBANbJ
+qR+GfEESsPgvHIqaQVIzD8dciPn7Pac7Y/65+HuPo7ej3BJ2V09HTCPLxWQqX0TZ
+3cYnkgpusdBjlk4cgA1JIHpkMVxOlfBa1eY2rDP4wHE9mJ6MHl4+G115eaK16+hA
+UWYZNMKF/15GCwBum8P1B5CTZamJVEE2Rcquda81AoGBAJer/zgChI5tGxlwXuj0
+ZX3ui8or/lfjQyoRNz2800v10zmRJbB8o7eo7rSYg4S1tRfhR4OjKKXY0NWccXZm
+U9rsBanSyZjo8N/I8hx+Jl8pp0P/Q5Sh3j6WIDt9YclgyDv+rAuAsXmPFxW2Y7eK
+mJHPQg9KQGx/hWkvXbqBxrEVAoGAV/DvZvH4U+hkPumDJRitYAt6DWVMzBVbE+qU
+MYpRO73/CUR06bY8X0BQ42MeKbnTkewmCmjPOahC85CizM6Me2QSgSoer62ZZHS8
+mWqPLSRPHs5ae6fhEzMYnzgKXl1f/pK/AS+W04JroVzKSl3/NsdPVpmTCUwqDB09
+jBPMKXUCgYEAhKFp69Egmpce7d43krfW+Dks/RtD6gkjf17BTselg1mMmi0Fkewt
+C9t2uYyKm0cI/ef3FWRMzC8mav4lIQgjMZsF3qrXuc7grWbwYXkTHZzDdz6SRPxC
+ZQQElAOpqovEoLKEtYq7+JCJk/0q2wvEd85OdCutD7nOppUpAMdHioI=
+-----END RSA PRIVATE KEY-----
+`,
+			expectedErr: false,
+		},
+		{
 			name: "RSA Key",
-			actualPEM: `
+			actual: func() string {
+				return `
 -----BEGIN CERTIFICATE-----
 MIIC5DCCAcwCCQClrnRsmeWS4TANBgkqhkiG9w0BAQsFADA0MRYwFAYDVQQDDA1k
 ZW1vLnRlc3QuY29tMRowGAYDVQQKDBFpbmdyZXNzLXRscy1jZXJ0MTAeFw0yMDEw
@@ -451,7 +527,8 @@ V9uWIRJv657s9Vlv/5f2UnsMBMirj99quGL1iSSdEComYoRyyiaflvfkqPRAHCIN
 0QTu0hJ2SPfqOChrPqnLK6P3KzUGUI3R8EfZAkYWkndMEqoijaIaY8ctdlUVqM8X
 8o1UNU2Vz0RQitpWCZbAO5nu
 -----END PRIVATE KEY-----
-`,
+`
+			},
 			expectedKey: `-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEA0AWQCdeukwkzIKKJNp3DaRe9azBZ8J/NFb2Nczq3Y8xcMDB/
 eT7lfMMNYluLQPDzkRN9QHKiz8ei9ynxRiEC/Al2OsdZPdPqNxnBVDsFcD729nof
@@ -483,7 +560,8 @@ SL6HFzUCgYBpod9mhdljh4VsysZqeFfbliESb+ue7PVZb/+X9lJ7DATIq4/farhi
 		},
 		{
 			name: "EC Key",
-			actualPEM: `
+			actual: func() string {
+				return `
 -----BEGIN CERTIFICATE-----
 MIIBeTCCAR4CCQCTj/tsh3SrEzAKBggqhkjOPQQDAjBEMQswCQYDVQQGEwJVUzEL
 MAkGA1UECAwCV0ExEDAOBgNVBAcMB1JlZG1vbmQxFjAUBgNVBAMMDWRlbW8udGVz
@@ -499,7 +577,8 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgHv1nWow0ijr1+B4S
 Vs6otqpmkzv2VRSjSPuH2zBRqQShRANCAAQ75g7UgxCQYmWxfn2jf6qlqaEfE45U
 pRsXybr1dtijtGkjE+v8I7A/GtSxfJe3LsREynlA3LGMxZL7TD3cWsAj
 -----END PRIVATE KEY-----
-`,
+`
+			},
 			expectedKey: `-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIB79Z1qMNIo69fgeElbOqLaqZpM79lUUo0j7h9swUakEoAoGCCqGSM49
 AwEHoUQDQgAEO+YO1IMQkGJlsX59o3+qpamhHxOOVKUbF8m69XbYo7RpIxPr/COw
@@ -509,7 +588,8 @@ PxrUsXyXty7ERMp5QNyxjMWS+0w93FrAIw==
 		},
 		{
 			name: "RSA Key in PKCS1 format",
-			actualPEM: `
+			actual: func() string {
+				return `
 -----BEGIN CERTIFICATE-----
 MIICzzCCAbegAwIBAgIJAJCzVhE/yl3LMA0GCSqGSIb3DQEBBQUAMBgxFjAUBgNV
 BAMTDWRlbW8uaG9zdC5jb20wHhcNMjEwMjEwMjIxNzU2WhcNMzEwMjA4MjIxNzU2
@@ -555,7 +635,8 @@ qaUu0QKBgFKIoEB6Ubf6R4t+Eu2tdDc6A4GPlyR+W3axGvz3HA6zF5DSj7Q2SCW4
 KniDIYx5Xg4CFKzEdd2kmCSUX7lJkbW4fm8EXiHZhj9UMa4GP/CeB3d3Lo5CHEjZ
 g+Ia2YI15BzapW0agqSSTlfGMoQHaPRh1+XYtkOd/xb4xc8d+gc0
 -----END RSA PRIVATE KEY-----
-`,
+`
+			},
 			expectedKey: `-----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAoU7u8m55fSqA8hQN46Q6+2H8MzfFzbZ3p2/Dm7ySQg6KdFAU
 n8ed6pgOuPMmqFBih1xxBKPkYoXCSQ2RonJLRoCln5Fm3gB696mJjeq4antyCpk6
@@ -590,7 +671,7 @@ g+Ia2YI15BzapW0agqSSTlfGMoQHaPRh1+XYtkOd/xb4xc8d+gc0
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			privateKey, err := getPrivateKey([]byte(test.actualPEM))
+			privateKey, err := getPrivateKey([]byte(test.actual()))
 			assert.Equal(t, test.expectedErr, err != nil)
 			assert.Equal(t, test.expectedKey, string(privateKey))
 		})


### PR DESCRIPTION
Signed-off-by: Nilekh Chaudhari <1626598+nilekhc@users.noreply.github.com>

<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1057

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
