### PR TITLE
fix: escape dot in target path regex

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - main
+  pull_request:
+    branches:
+    - main
   schedule:
     - cron: "0 7 * * 1" # Mondays at 7:00 AM
 

--- a/pkg/util/fileutil/filesystem.go
+++ b/pkg/util/fileutil/filesystem.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	targetPathRe = regexp.MustCompile(`[\\|\/]+pods[\\|\/]+(.+?)[\\|\/]+volumes[\\|\/]+kubernetes.io~csi[\\|\/]+(.+?)[\\|\/]+mount$`)
+	targetPathRe = regexp.MustCompile(`[\\|\/]+pods[\\|\/]+(.+?)[\\|\/]+volumes[\\|\/]+kubernetes\.io~csi[\\|\/]+(.+?)[\\|\/]+mount$`)
 )
 
 // GetMountedFiles returns all the mounted files mapping their path relative to

--- a/pkg/util/fileutil/filesystem_test.go
+++ b/pkg/util/fileutil/filesystem_test.go
@@ -267,6 +267,10 @@ func TestGetVolumeNameFromTargetPath(t *testing.T) {
 			want:       "",
 		},
 		{
+			targetPath: "/var/lib/kubelet/pods/7e7686a1-56c4-4c67-a6fd-4656ac484f0a/volumes/kubernetesxio~csi/secrets-store-inline/mount",
+			want:       "",
+		},
+		{
 			targetPath: "/var/lib/kubelet/pods/7e7686a1-56c4-4c67-a6fd-4656ac484f0a/volumes/kubernetes.io~csi/secrets-store-inline/mount",
 			want:       "secrets-store-inline",
 		},


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
ref: https://github.com/kubernetes-sigs/secrets-store-csi-driver/security/code-scanning/1

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
