### PR TITLE
fix: put annotations in right position of daemonset

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -18,12 +18,12 @@ spec:
 {{ toYaml .Values.linux.updateStrategy | indent 4 }}
   template:
     metadata:
-      annotations:
       labels:
 {{ include "sscd.labels" . | indent 8 }}
 {{- if .Values.linux.podLabels }}
 {{- toYaml .Values.linux.podLabels | nindent 8 }}
 {{- end }}
+      annotations:
         kubectl.kubernetes.io/default-container: secrets-store
 {{- if .Values.linux.podAnnotations }}
 {{ toYaml .Values.linux.podAnnotations | indent 8 }}


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Annotations in `secrets-store-csi-driver` daemonset was put in wrong position in #1043, this patch fixes it. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1093

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
