### PR TITLE
Add stringData support for secrets

### DIFF
--- a/.local/Dockerfile
+++ b/.local/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine
+FROM docker.io/golang:1.19-alpine
 
 ENV CGO_ENABLED=0
 ENV GOROOT=/usr/local/go
@@ -6,8 +6,7 @@ ENV GOPATH=${HOME}/go
 ENV PATH=$PATH:${GOROOT}/bin
 
 RUN apk update && apk add --no-cache \
-    git && \
-    go get github.com/go-delve/delve/cmd/dlv
+    git && go install github.com/go-delve/delve/cmd/dlv@latest
 
 WORKDIR /secrets-store-csi-driver-codebase
 

--- a/apis/v1/secretproviderclass_types.go
+++ b/apis/v1/secretproviderclass_types.go
@@ -44,6 +44,8 @@ type SecretObject struct {
 	// annotations of k8s secret object
 	Annotations map[string]string   `json:"annotations,omitempty"`
 	Data        []*SecretObjectData `json:"data,omitempty"`
+	// secret objects key:value as stringData
+	StringData *string `json:"stringData,omitempty"`
 }
 
 // SecretProviderClassSpec defines the desired state of SecretProviderClass

--- a/controllers/secretproviderclasspodstatus_controller.go
+++ b/controllers/secretproviderclasspodstatus_controller.go
@@ -311,7 +311,7 @@ func (r *SecretProviderClassPodStatusReconciler) Reconcile(ctx context.Context, 
 			secretType := secretutil.GetSecretType(strings.TrimSpace(secretObj.Type))
 
 			var datamap map[string][]byte
-			if datamap, err = secretutil.GetSecretData(secretObj.Data, secretType, files); err != nil {
+			if datamap, err = secretutil.GetSecretData(secretObj, secretType, files); err != nil {
 				r.generateEvent(pod, corev1.EventTypeWarning, secretCreationFailedReason, fmt.Sprintf("failed to get data in spc %s/%s for secret %s, err: %+v", req.Namespace, spcName, secretName, err))
 				klog.ErrorS(err, "failed to get data in spc for secret", "spc", klog.KObj(spc), "pod", klog.KObj(pod), "secret", klog.ObjectRef{Namespace: req.Namespace, Name: secretName}, "spcps", klog.KObj(spcPodStatus))
 				errs = append(errs, fmt.Errorf("failed to get data in spc %s/%s for secret %s, err: %w", req.Namespace, spcName, secretName, err))

--- a/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -54,6 +54,10 @@ spec:
                         type: string
                       description: annotations of k8s secret object
                       type: object
+                    stringData:
+                      description:
+                        SecretObjectStringData is alternative to SecretObjectData
+                      type: string
                     data:
                       items:
                         description: SecretObjectData defines the desired state of

--- a/manifest_staging/charts/secrets-store-csi-driver/crds/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/crds/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -54,6 +54,10 @@ spec:
                         type: string
                       description: annotations of k8s secret object
                       type: object
+                    stringData:
+                      description:
+                        SecretObjectStringData is alternative to SecretObjectData
+                      type: string
                     data:
                       items:
                         description: SecretObjectData defines the desired state of

--- a/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
+++ b/manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasses.yaml
@@ -54,6 +54,10 @@ spec:
                         type: string
                       description: annotations of k8s secret object
                       type: object
+                    stringData:
+                      description:
+                        SecretObjectStringData is alternative to SecretObjectData
+                      type: string
                     data:
                       items:
                         description: SecretObjectData defines the desired state of

--- a/pkg/rotation/reconciler.go
+++ b/pkg/rotation/reconciler.go
@@ -465,7 +465,7 @@ func (r *Reconciler) reconcile(ctx context.Context, spcps *secretsstorev1.Secret
 
 		secretType := secretutil.GetSecretType(strings.TrimSpace(secretObj.Type))
 		var datamap map[string][]byte
-		if datamap, err = secretutil.GetSecretData(secretObj.Data, secretType, files); err != nil {
+		if datamap, err = secretutil.GetSecretData(secretObj, secretType, files); err != nil {
 			r.generateEvent(pod, corev1.EventTypeWarning, k8sSecretRotationFailedReason, fmt.Sprintf("failed to get data in spc %s/%s for secret %s, err: %+v", spc.Namespace, spc.Name, secretName, err))
 			klog.ErrorS(err, "failed to get data in spc for secret", "spc", klog.KObj(spc), "secret", klog.ObjectRef{Namespace: spc.Namespace, Name: secretName}, "controller", "rotation")
 			errs = append(errs, err)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Introduce new feature with support _stringData_ at _SecretProviderClass_, not only _dataObject_.

**Which issue(s) this PR fixes** :
Fixes #937 "Secret Provider Class not support secretObject type stringData"

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
Tested only by unit tests, not tested at real environment.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
