### PR TITLE
ci: enable tests with kubernetes v1.26

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,5 +1,5 @@
 name: e2e_mock_provider_tests
-on: 
+on:
   workflow_dispatch:
     inputs:
       registry:
@@ -24,23 +24,23 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        KUBERNETES_VERSION: ["v1.22.13", "v1.23.10", "v1.24.4", "v1.25.0"]
+        KUBERNETES_VERSION: ["v1.23.13", "v1.24.7", "v1.25.3", "v1.26.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
         with:
           submodules: true
-          fetch-depth: 0  
+          fetch-depth: 0
       - name: Setup BATS
         # pinning to the sha af9a00deb21b5d795cabfeaa8d9060410377686d from https://github.com/mig4/setup-bats/releases/tag/v1.2.0
         uses: mig4/setup-bats@af9a00deb21b5d795cabfeaa8d9060410377686d
         with:
-          bats-version: 1.4.1      
+          bats-version: 1.4.1
       - name: Setup Kind
         # pinning to the sha aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 from https://github.com/engineerd/setup-kind/releases/tag/v0.5.0
         uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0
         with:
-          version: "v0.15.0"
+          version: "v0.17.0"
           image: "kindest/node:${{ matrix.KUBERNETES_VERSION }}"
       - name: Test
         run: |
@@ -48,8 +48,8 @@ jobs:
           unset CI
 
           make e2e-helm-deploy e2e-mock-provider-container e2e-provider-deploy e2e-provider
-        env: 
+        env:
           REGISTRY: ${{ github.event.inputs.registry }}
-          IMAGE_NAME: ${{ github.event.inputs.driverImageName }} 
-          CRD_IMAGE_NAME: ${{ github.event.inputs.crdImageName }} 
+          IMAGE_NAME: ${{ github.event.inputs.driverImageName }}
+          CRD_IMAGE_NAME: ${{ github.event.inputs.crdImageName }}
           IMAGE_VERSION: ${{ github.event.inputs.imageVersion }}


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
- enable tests with kubernetes v1.26 
- remove kubernetes version 1.22 (EOL)
- update kubernetes versions for supported releases

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
