### PR TITLE
chore: remove windows version 1903, 1909 and 2004 (EOL)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,14 +64,14 @@ ALL_OS = linux windows
 ALL_ARCH.linux = amd64 arm64
 ALL_OS_ARCH.linux = $(foreach arch, ${ALL_ARCH.linux}, linux-$(arch))
 ALL_ARCH.windows = amd64
-ALL_OSVERSIONS.windows := 1809 1903 1909 2004 ltsc2022
+ALL_OSVERSIONS.windows := 1809 ltsc2022
 ALL_OS_ARCH.windows = $(foreach arch, $(ALL_ARCH.windows), $(foreach osversion, ${ALL_OSVERSIONS.windows}, windows-${osversion}-${arch}))
 ALL_OS_ARCH = $(foreach os, $(ALL_OS), ${ALL_OS_ARCH.${os}})
 
 # The current context of image building
 # The architecture of the image
 ARCH ?= amd64
-# OS Version for the Windows images: 1809, 1903, 1909, 2004, ltsc2022
+# OS Version for the Windows images: 1809, ltsc2022
 OSVERSION ?= 1809
 # Output type of docker buildx build
 OUTPUT_TYPE ?= registry

--- a/docker/BASEIMAGE
+++ b/docker/BASEIMAGE
@@ -1,7 +1,4 @@
 linux/amd64=k8s.gcr.io/build-image/debian-base:bullseye-v1.4.2
 linux/arm64=k8s.gcr.io/build-image/debian-base:bullseye-v1.4.2
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
-windows/amd64/1903=mcr.microsoft.com/windows/nanoserver:1903
-windows/amd64/1909=mcr.microsoft.com/windows/nanoserver:1909
-windows/amd64/2004=mcr.microsoft.com/windows/nanoserver:2004
 windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/docker/BASEIMAGE_CORE
+++ b/docker/BASEIMAGE_CORE
@@ -1,5 +1,2 @@
 windows/amd64/1809=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1809
-windows/amd64/1903=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1903
-windows/amd64/1909=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1909
-windows/amd64/2004=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-2004
 windows/amd64/ltsc2022=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-ltsc2022


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind deprecation

**What this PR does / why we need it**:
- Remove `1903`, `1909` and `2004` for windows builds (EOL)
    - https://learn.microsoft.com/en-us/lifecycle/announcements/windows-10-1903-end-of-servicing
    - https://learn.microsoft.com/en-us/lifecycle/announcements/windows-10-1909-end-of-servicing
    - https://learn.microsoft.com/en-us/lifecycle/announcements/windows-10-version-2004-end-of-servicing

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
