### PR TITLE
feat: add `--version` flag to print the driver version

### DIFF
--- a/cmd/secrets-store-csi-driver/main.go
+++ b/cmd/secrets-store-csi-driver/main.go
@@ -65,6 +65,7 @@ var (
 	enableProfile           = flag.Bool("enable-pprof", false, "enable pprof profiling")
 	profilePort             = flag.Int("pprof-port", 6065, "port for pprof profiling")
 	maxCallRecvMsgSize      = flag.Int("max-call-recv-msg-size", 1024*1024*4, "maximum size in bytes of gRPC response from plugins")
+	versionInfo             = flag.Bool("version", false, "Print the version and exit")
 
 	// Enable optional healthcheck for provider clients that exist in memory
 	providerHealthCheck         = flag.Bool("provider-health-check", false, "Enable health check for configured providers")
@@ -100,6 +101,10 @@ func mainErr() error {
 	if err := mlog.ValidateAndSetKlogLevelAndFormatGlobally(ctx, getKlogLevel(), format); err != nil {
 		mlog.Error("failed to validate log level", err)
 		return err
+	}
+
+	if *versionInfo {
+		return version.PrintVersion()
 	}
 
 	if *enableProfile {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,6 +16,7 @@ limitations under the License.
 package version
 
 import (
+	"encoding/json"
 	"fmt"
 	"runtime"
 )
@@ -32,4 +33,26 @@ var (
 // GetUserAgent returns a user agent of the format: csi-secrets-store/<controller name>/<version> (<goos>/<goarch>) <vcs>/<timestamp>
 func GetUserAgent(controllerName string) string {
 	return fmt.Sprintf("csi-secrets-store/%s/%s (%s/%s) %s/%s", controllerName, BuildVersion, runtime.GOOS, runtime.GOARCH, Vcs, BuildTime)
+}
+
+// PrintVersion prints the current driver version
+func PrintVersion() error {
+	var err error
+	pv := struct {
+		BuildVersion string
+		GitCommit    string
+		BuildDate    string
+	}{
+		BuildDate:    BuildTime,
+		BuildVersion: BuildVersion,
+		GitCommit:    Vcs,
+	}
+
+	var res []byte
+	if res, err = json.Marshal(pv); err != nil {
+		return err
+	}
+
+	fmt.Printf(string(res) + "\n")
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
- Adds a new `--version` flag to the driver to write the build date, git commit and version to stdout. This flag can be useful when trying to find the image tags/build details given just the digest of an image. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
