### PR TITLE
chore: use base and test image from `registry.k8s.io`

### DIFF
--- a/.local/debug-driver.yaml
+++ b/.local/debug-driver.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: secrets-store-csi-driver
       containers:
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -42,7 +42,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0
           imagePullPolicy: IfNotPresent
           args:
           - --csi-address=/csi/csi.sock

--- a/docker/BASEIMAGE
+++ b/docker/BASEIMAGE
@@ -1,4 +1,4 @@
-linux/amd64=k8s.gcr.io/build-image/debian-base:bullseye-v1.4.2
-linux/arm64=k8s.gcr.io/build-image/debian-base:bullseye-v1.4.2
+linux/amd64=registry.k8s.io/build-image/debian-base:bullseye-v1.4.2
+linux/arm64=registry.k8s.io/build-image/debian-base:bullseye-v1.4.2
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE=k8s.gcr.io/build-image/debian-base:bullseye-v1.4.2
+ARG BASEIMAGE=registry.k8s.io/build-image/debian-base:bullseye-v1.4.2
 
 FROM golang:1.19 as builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver

--- a/docs/book/src/topics/set-as-env-var.md
+++ b/docs/book/src/topics/set-as-env-var.md
@@ -15,13 +15,13 @@ spec:
   secretObjects:                                 # [OPTIONAL] SecretObject defines the desired state of synced K8s secret objects
   - secretName: foosecret
     type: Opaque
-    labels:                                   
+    labels:
       environment: "test"
-    data: 
-    - objectName: secretalias                    # name of the mounted content to sync. this could be the object name or object alias 
+    data:
+    - objectName: secretalias                    # name of the mounted content to sync. this could be the object name or object alias
       key: username
   parameters:
-    usePodIdentity: "false"                      
+    usePodIdentity: "false"
     keyvaultName: "$KEYVAULT_NAME"               # the name of the KeyVault
     objects: |
       array:
@@ -35,7 +35,7 @@ spec:
           objectType: key
           objectVersion: $KEY_VERSION
     tenantId: "tid"                             # the tenant ID of the KeyVault
-``` 
+```
 
 - `Pod` yaml
 
@@ -47,7 +47,7 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    image: registry.k8s.io/e2e-test-images/busybox:1.29
     command:
     - "/bin/sleep"
     - "10000"
@@ -77,7 +77,7 @@ Once the [secret is created](./sync-as-kubernetes-secret.md), you may wish to se
 ```yaml
 spec:
   containers:
-  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+  - image: registry.k8s.io/e2e-test-images/busybox:1.29
     name: busybox
     command:
     - "/bin/sleep"

--- a/docs/book/src/topics/sync-as-kubernetes-secret.md
+++ b/docs/book/src/topics/sync-as-kubernetes-secret.md
@@ -15,13 +15,13 @@ spec:
   secretObjects:                                 # [OPTIONAL] SecretObject defines the desired state of synced K8s secret objects
   - secretName: foosecret
     type: Opaque
-    labels:                                   
+    labels:
       environment: "test"
-    data: 
-    - objectName: secretalias                    # name of the mounted content to sync. this could be the object name or object alias 
+    data:
+    - objectName: secretalias                    # name of the mounted content to sync. this could be the object name or object alias
       key: username
   parameters:
-    usePodIdentity: "true"                      
+    usePodIdentity: "true"
     keyvaultName: "$KEYVAULT_NAME"               # the name of the KeyVault
     objects: |
       array:
@@ -47,7 +47,7 @@ metadata:
 spec:
   containers:
     - name: busybox
-      image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      image: registry.k8s.io/e2e-test-images/busybox:1.29
       command:
       - "/bin/sleep"
       - "10000"
@@ -88,4 +88,4 @@ spec:
     type: Opaque                              # type of the Kubernetes Secret object e.g. Opaque, kubernetes.io/tls
 ```
 
-> NOTE: Here is the list of supported Kubernetes Secret types: `Opaque`, `kubernetes.io/basic-auth`, `bootstrap.kubernetes.io/token`, `kubernetes.io/dockerconfigjson`, `kubernetes.io/dockercfg`, `kubernetes.io/ssh-auth`, `kubernetes.io/service-account-token`, `kubernetes.io/tls`.  
+> NOTE: Here is the list of supported Kubernetes Secret types: `Opaque`, `kubernetes.io/basic-auth`, `bootstrap.kubernetes.io/token`, `kubernetes.io/dockerconfigjson`, `kubernetes.io/dockercfg`, `kubernetes.io/ssh-auth`, `kubernetes.io/service-account-token`, `kubernetes.io/tls`.

--- a/test/bats/tests/akeyless/pod-inline-volume-secretproviderclass.yaml
+++ b/test/bats/tests/akeyless/pod-inline-volume-secretproviderclass.yaml
@@ -4,7 +4,7 @@ metadata:
   name: secrets-store-inline
 spec:
   containers:
-  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+  - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     name: busybox
     imagePullPolicy: IfNotPresent
     command:

--- a/test/bats/tests/aws/BasicTestMount.yaml
+++ b/test/bats/tests/aws/BasicTestMount.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   serviceAccountName: basic-test-mount-sa
   containers:
-  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+  - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     name: busybox
     imagePullPolicy: IfNotPresent
     command:

--- a/test/bats/tests/azure/deployment-synck8s-azure.yaml
+++ b/test/bats/tests/azure/deployment-synck8s-azure.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
         name: busybox
         imagePullPolicy: IfNotPresent
         command:

--- a/test/bats/tests/azure/deployment-two-synck8s-azure.yaml
+++ b/test/bats/tests/azure/deployment-two-synck8s-azure.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
         name: busybox
         imagePullPolicy: IfNotPresent
         command:

--- a/test/bats/tests/azure/pod-azure-inline-volume-multiple-spc.yaml
+++ b/test/bats/tests/azure/pod-azure-inline-volume-multiple-spc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+  - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     name: busybox
     imagePullPolicy: IfNotPresent
     command:

--- a/test/bats/tests/azure/pod-secrets-store-inline-volume-crd.yaml
+++ b/test/bats/tests/azure/pod-secrets-store-inline-volume-crd.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+  - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     name: busybox
     imagePullPolicy: IfNotPresent
     command:

--- a/test/bats/tests/azure/rotation/pod-synck8s-azure.yaml
+++ b/test/bats/tests/azure/rotation/pod-synck8s-azure.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+  - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     name: busybox
     imagePullPolicy: IfNotPresent
     command:

--- a/test/bats/tests/e2e_provider/deployment-synck8s-e2e-provider.yaml
+++ b/test/bats/tests/e2e_provider/deployment-synck8s-e2e-provider.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
         name: busybox
         imagePullPolicy: IfNotPresent
         command:

--- a/test/bats/tests/e2e_provider/deployment-two-synck8s-e2e-provider.yaml
+++ b/test/bats/tests/e2e_provider/deployment-two-synck8s-e2e-provider.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
         name: busybox
         imagePullPolicy: IfNotPresent
         command:

--- a/test/bats/tests/e2e_provider/pod-e2e-provider-inline-volume-multiple-spc.yaml
+++ b/test/bats/tests/e2e_provider/pod-e2e-provider-inline-volume-multiple-spc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+  - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     name: busybox
     imagePullPolicy: IfNotPresent
     command:

--- a/test/bats/tests/e2e_provider/pod-secrets-store-inline-volume-crd.yaml
+++ b/test/bats/tests/e2e_provider/pod-secrets-store-inline-volume-crd.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+  - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     name: busybox
     imagePullPolicy: IfNotPresent
     command:

--- a/test/bats/tests/e2e_provider/rotation/pod-synck8s-e2e-provider.yaml
+++ b/test/bats/tests/e2e_provider/rotation/pod-synck8s-e2e-provider.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+  - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     name: busybox
     imagePullPolicy: IfNotPresent
     command:

--- a/test/bats/tests/gcp/pod-secrets-store-inline-volume-crd.yaml
+++ b/test/bats/tests/gcp/pod-secrets-store-inline-volume-crd.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+  - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     name: busybox
     imagePullPolicy: IfNotPresent
     command:

--- a/test/bats/tests/vault/deployment-synck8s.yaml
+++ b/test/bats/tests/vault/deployment-synck8s.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
         name: busybox
         imagePullPolicy: IfNotPresent
         command:

--- a/test/bats/tests/vault/deployment-two-synck8s.yaml
+++ b/test/bats/tests/vault/deployment-two-synck8s.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
         name: busybox
         imagePullPolicy: IfNotPresent
         command:

--- a/test/bats/tests/vault/pod-vault-inline-volume-multiple-spc.yaml
+++ b/test/bats/tests/vault/pod-vault-inline-volume-multiple-spc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+  - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     name: busybox
     imagePullPolicy: IfNotPresent
     command:

--- a/test/bats/tests/vault/pod-vault-inline-volume-secretproviderclass.yaml
+++ b/test/bats/tests/vault/pod-vault-inline-volume-secretproviderclass.yaml
@@ -4,7 +4,7 @@ metadata:
   name: secrets-store-inline
 spec:
   containers:
-  - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+  - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     name: busybox
     imagePullPolicy: IfNotPresent
     command:

--- a/test/bats/tests/vault/pod-vault-rotation.yaml
+++ b/test/bats/tests/vault/pod-vault-rotation.yaml
@@ -4,7 +4,7 @@ metadata:
   name: secrets-store-rotation
 spec:
   containers:
-    - image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
       name: busybox
       imagePullPolicy: IfNotPresent
       command:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
- use base and test image from `registry.k8s.io`

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
part of https://github.com/kubernetes/k8s.io/issues/4738

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
