### PR TITLE
chore: remove unused providerVolumePath code paths

### DIFF
--- a/cmd/secrets-store-csi-driver/main.go
+++ b/cmd/secrets-store-csi-driver/main.go
@@ -217,7 +217,7 @@ func mainErr() error {
 
 	// Secret rotation
 	if *enableSecretRotation {
-		rec, err := rotation.NewReconciler(mgr.GetCache(), scheme, *providerVolumePath, *nodeID, *rotationPollInterval, providerClients, tokenClient)
+		rec, err := rotation.NewReconciler(mgr.GetCache(), scheme, *nodeID, *rotationPollInterval, providerClients, tokenClient)
 		if err != nil {
 			klog.ErrorS(err, "failed to initialize rotation reconciler")
 			return err
@@ -225,7 +225,7 @@ func mainErr() error {
 		go rec.Run(ctx.Done())
 	}
 
-	driver := secretsstore.NewSecretsStoreDriver(*driverName, *nodeID, *endpoint, *providerVolumePath, providerClients, mgr.GetClient(), mgr.GetAPIReader(), tokenClient)
+	driver := secretsstore.NewSecretsStoreDriver(*driverName, *nodeID, *endpoint, providerClients, mgr.GetClient(), mgr.GetAPIReader(), tokenClient)
 	driver.Run(ctx)
 
 	return nil

--- a/pkg/rotation/reconciler.go
+++ b/pkg/rotation/reconciler.go
@@ -66,7 +66,6 @@ const (
 // Reconciler reconciles and rotates contents in the pod
 // and Kubernetes secrets periodically
 type Reconciler struct {
-	providerVolumePath   string
 	rotationPollInterval time.Duration
 	providerClients      *secretsstore.PluginClientBuilder
 	queue                workqueue.RateLimitingInterface
@@ -89,7 +88,7 @@ type Reconciler struct {
 // NewReconciler returns a new reconciler for rotation
 func NewReconciler(client client.Reader,
 	s *runtime.Scheme,
-	providerVolumePath, nodeName string,
+	nodeName string,
 	rotationPollInterval time.Duration,
 	providerClients *secretsstore.PluginClientBuilder,
 	tokenClient *k8s.TokenClient) (*Reconciler, error) {
@@ -109,7 +108,6 @@ func NewReconciler(client client.Reader,
 	}
 
 	return &Reconciler{
-		providerVolumePath:   providerVolumePath,
 		rotationPollInterval: rotationPollInterval,
 		providerClients:      providerClients,
 		reporter:             newStatsReporter(),

--- a/pkg/rotation/reconciler_test.go
+++ b/pkg/rotation/reconciler_test.go
@@ -69,7 +69,6 @@ func newTestReconciler(client client.Reader, s *runtime.Scheme, kubeClient kuber
 	}
 
 	return &Reconciler{
-		providerVolumePath:   socketPath,
 		rotationPollInterval: rotationPollInterval,
 		providerClients:      secretsstore.NewPluginClientBuilder([]string{socketPath}),
 		queue:                workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),

--- a/pkg/secrets-store/nodeserver.go
+++ b/pkg/secrets-store/nodeserver.go
@@ -39,11 +39,10 @@ import (
 )
 
 type nodeServer struct {
-	providerVolumePath string
-	mounter            mount.Interface
-	reporter           StatsReporter
-	nodeID             string
-	client             client.Client
+	mounter  mount.Interface
+	reporter StatsReporter
+	nodeID   string
+	client   client.Client
 	// reader is an instance of mgr.GetAPIReader that is configured to use the API server.
 	// This should be used sparingly and only when the client does not fit the use case.
 	reader          client.Reader
@@ -344,11 +343,6 @@ func (ns *nodeServer) mountSecretsStoreObjectContent(ctx context.Context, provid
 	}
 	if len(permission) == 0 {
 		return nil, "", errors.New("missing file permissions")
-	}
-	// get provider volume path
-	providerVolumePath := ns.providerVolumePath
-	if providerVolumePath == "" {
-		return nil, "", fmt.Errorf("providers volume path not found. Set PROVIDERS_VOLUME_PATH")
 	}
 
 	client, err := ns.providerClients.Get(ctx, providerName)

--- a/pkg/secrets-store/nodeserver_test.go
+++ b/pkg/secrets-store/nodeserver_test.go
@@ -41,9 +41,8 @@ import (
 
 func testNodeServer(t *testing.T, mountPoints []mount.MountPoint, client client.Client, reporter StatsReporter) (*nodeServer, error) {
 	t.Helper()
-	d := t.TempDir()
-	providerClients := NewPluginClientBuilder([]string{d})
-	return newNodeServer(d, "testnode", mount.NewFakeMounter(mountPoints), providerClients, client, client, reporter, k8s.NewTokenClient(fakeclient.NewSimpleClientset(), "test-driver", 1*time.Second))
+	providerClients := NewPluginClientBuilder([]string{t.TempDir()})
+	return newNodeServer("testnode", mount.NewFakeMounter(mountPoints), providerClients, client, client, reporter, k8s.NewTokenClient(fakeclient.NewSimpleClientset(), "test-driver", 1*time.Second))
 }
 
 func TestNodePublishVolume(t *testing.T) {

--- a/pkg/secrets-store/secrets-store.go
+++ b/pkg/secrets-store/secrets-store.go
@@ -38,14 +38,14 @@ type SecretsStore struct {
 	ids *identityServer
 }
 
-func NewSecretsStoreDriver(driverName, nodeID, endpoint, providerVolumePath string,
+func NewSecretsStoreDriver(driverName, nodeID, endpoint string,
 	providerClients *PluginClientBuilder,
 	client client.Client,
 	reader client.Reader,
 	tokenClient *k8s.TokenClient) *SecretsStore {
 	klog.InfoS("Initializing Secrets Store CSI Driver", "driver", driverName, "version", version.BuildVersion, "buildTime", version.BuildTime)
 
-	ns, err := newNodeServer(providerVolumePath, nodeID, mount.New(""), providerClients, client, reader, NewStatsReporter(), tokenClient)
+	ns, err := newNodeServer(nodeID, mount.New(""), providerClients, client, reader, NewStatsReporter(), tokenClient)
 	if err != nil {
 		klog.ErrorS(err, "failed to initialize node server")
 		os.Exit(1)
@@ -59,7 +59,7 @@ func NewSecretsStoreDriver(driverName, nodeID, endpoint, providerVolumePath stri
 	}
 }
 
-func newNodeServer(providerVolumePath, nodeID string,
+func newNodeServer(nodeID string,
 	mounter mount.Interface,
 	providerClients *PluginClientBuilder,
 	client client.Client,
@@ -67,14 +67,13 @@ func newNodeServer(providerVolumePath, nodeID string,
 	statsReporter StatsReporter,
 	tokenClient *k8s.TokenClient) (*nodeServer, error) {
 	return &nodeServer{
-		providerVolumePath: providerVolumePath,
-		mounter:            mounter,
-		reporter:           statsReporter,
-		nodeID:             nodeID,
-		client:             client,
-		reader:             reader,
-		providerClients:    providerClients,
-		tokenClient:        tokenClient,
+		mounter:         mounter,
+		reporter:        statsReporter,
+		nodeID:          nodeID,
+		client:          client,
+		reader:          reader,
+		providerClients: providerClients,
+		tokenClient:     tokenClient,
 	}, nil
 }
 

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -31,13 +31,12 @@ import (
 )
 
 const (
-	socket             = "/tmp/csi.sock"
-	endpoint           = "unix://" + socket
-	providerVolumePath = "/etc/kubernetes/secrets-store-csi-providers"
+	socket   = "/tmp/csi.sock"
+	endpoint = "unix://" + socket
 )
 
 func TestSanity(t *testing.T) {
-	driver := secretsstore.NewSecretsStoreDriver("secrets-store.csi.k8s.io", "somenodeid", endpoint, providerVolumePath, nil, nil, nil, nil)
+	driver := secretsstore.NewSecretsStoreDriver("secrets-store.csi.k8s.io", "somenodeid", endpoint, nil, nil, nil, nil)
 	go func() {
 		driver.Run(context.Background())
 	}()


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The provider paths were updated to be configured in the clients in https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/851. This cleans up unused parameters that we were passing around to different components.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests
