### PR TITLE
chore: cleanup WritePayloads to be easier to use

### DIFF
--- a/pkg/secrets-store/provider_client_test.go
+++ b/pkg/secrets-store/provider_client_test.go
@@ -458,8 +458,8 @@ func TestPluginClientBuilderErrorNotFound(t *testing.T) {
 	cb := NewPluginClientBuilder([]string{path})
 	ctx := context.Background()
 
-	if _, err := cb.Get(ctx, "notfoundprovider"); !errors.Is(err, ErrProviderNotFound) {
-		t.Errorf("Get(%s) = %v, want %v", "notfoundprovider", err, ErrProviderNotFound)
+	if _, err := cb.Get(ctx, "notfoundprovider"); !errors.Is(err, errProviderNotFound) {
+		t.Errorf("Get(%s) = %v, want %v", "notfoundprovider", err, errProviderNotFound)
 	}
 
 	// check that the provider is found once server is started
@@ -480,8 +480,8 @@ func TestPluginClientBuilderErrorInvalid(t *testing.T) {
 	cb := NewPluginClientBuilder([]string{path})
 	ctx := context.Background()
 
-	if _, err := cb.Get(ctx, "bad/provider/name"); !errors.Is(err, ErrInvalidProvider) {
-		t.Errorf("Get(%s) = %v, want %v", "bad/provider/name", err, ErrInvalidProvider)
+	if _, err := cb.Get(ctx, "bad/provider/name"); !errors.Is(err, errInvalidProvider) {
+		t.Errorf("Get(%s) = %v, want %v", "bad/provider/name", err, errInvalidProvider)
 	}
 }
 

--- a/pkg/util/fileutil/writer.go
+++ b/pkg/util/fileutil/writer.go
@@ -43,6 +43,10 @@ func Validate(payloads []*v1alpha1.File) error {
 // atomic writer and converts the v1alpha1.File proto to the FileProjection type
 // used by the atomic writer.
 func WritePayloads(path string, payloads []*v1alpha1.File) error {
+	if err := Validate(payloads); err != nil {
+		return err
+	}
+
 	// cleanup any payload paths that may have been written by a previous
 	// version of the driver/provider.
 	if err := cleanupProviderFiles(path, payloads); err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Makes WritePayloads() call Validate() internally so that it can be used safely on its own. Also cleans up some of the indentation on the provider client.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests
