### PR TITLE
chore: remove unused node name in rotation reconciler

### DIFF
--- a/cmd/secrets-store-csi-driver/main.go
+++ b/cmd/secrets-store-csi-driver/main.go
@@ -217,7 +217,7 @@ func mainErr() error {
 
 	// Secret rotation
 	if *enableSecretRotation {
-		rec, err := rotation.NewReconciler(mgr.GetCache(), scheme, *nodeID, *rotationPollInterval, providerClients, tokenClient)
+		rec, err := rotation.NewReconciler(mgr.GetCache(), scheme, *rotationPollInterval, providerClients, tokenClient)
 		if err != nil {
 			klog.ErrorS(err, "failed to initialize rotation reconciler")
 			return err

--- a/pkg/rotation/reconciler.go
+++ b/pkg/rotation/reconciler.go
@@ -88,7 +88,6 @@ type Reconciler struct {
 // NewReconciler returns a new reconciler for rotation
 func NewReconciler(client client.Reader,
 	s *runtime.Scheme,
-	nodeName string,
 	rotationPollInterval time.Duration,
 	providerClients *secretsstore.PluginClientBuilder,
 	tokenClient *k8s.TokenClient) (*Reconciler, error) {

--- a/pkg/rotation/reconciler_test.go
+++ b/pkg/rotation/reconciler_test.go
@@ -62,7 +62,7 @@ func setupScheme() (*runtime.Scheme, error) {
 	return scheme, nil
 }
 
-func newTestReconciler(client client.Reader, s *runtime.Scheme, kubeClient kubernetes.Interface, crdClient *secretsStoreFakeClient.Clientset, rotationPollInterval time.Duration, socketPath string) (*Reconciler, error) {
+func newTestReconciler(client client.Reader, kubeClient kubernetes.Interface, crdClient *secretsStoreFakeClient.Clientset, rotationPollInterval time.Duration, socketPath string) (*Reconciler, error) {
 	secretStore, err := k8s.New(kubeClient, 5*time.Second)
 	if err != nil {
 		return nil, err
@@ -448,7 +448,7 @@ func TestReconcileError(t *testing.T) {
 			}
 			client := controllerfake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
-			testReconciler, err := newTestReconciler(client, scheme, kubeClient, crdClient, test.rotationPollInterval, test.socketPath)
+			testReconciler, err := newTestReconciler(client, kubeClient, crdClient, test.rotationPollInterval, test.socketPath)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			err = testReconciler.secretStore.Run(wait.NeverStop)
@@ -589,7 +589,7 @@ func TestReconcileNoError(t *testing.T) {
 		}
 		ctrlClient := controllerfake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
-		testReconciler, err := newTestReconciler(ctrlClient, scheme, kubeClient, crdClient, 60*time.Second, socketPath)
+		testReconciler, err := newTestReconciler(ctrlClient, kubeClient, crdClient, 60*time.Second, socketPath)
 		g.Expect(err).NotTo(HaveOccurred())
 		err = testReconciler.secretStore.Run(wait.NeverStop)
 		g.Expect(err).NotTo(HaveOccurred())
@@ -634,7 +634,7 @@ func TestReconcileNoError(t *testing.T) {
 			test.nodePublishSecretRefSecretToAdd,
 		}
 		ctrlClient = controllerfake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
-		testReconciler, err = newTestReconciler(ctrlClient, scheme, kubeClient, crdClient, 60*time.Second, socketPath)
+		testReconciler, err = newTestReconciler(ctrlClient, kubeClient, crdClient, 60*time.Second, socketPath)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(err).NotTo(HaveOccurred())
 
@@ -650,7 +650,7 @@ func TestReconcileNoError(t *testing.T) {
 			test.nodePublishSecretRefSecretToAdd,
 		}
 		ctrlClient = controllerfake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
-		testReconciler, err = newTestReconciler(ctrlClient, scheme, kubeClient, crdClient, 60*time.Second, socketPath)
+		testReconciler, err = newTestReconciler(ctrlClient, kubeClient, crdClient, 60*time.Second, socketPath)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(err).NotTo(HaveOccurred())
 
@@ -741,7 +741,7 @@ func TestPatchSecret(t *testing.T) {
 			}
 			ctrlClient := controllerfake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
-			testReconciler, err := newTestReconciler(ctrlClient, scheme, kubeClient, crdClient, 60*time.Second, "")
+			testReconciler, err := newTestReconciler(ctrlClient, kubeClient, crdClient, 60*time.Second, "")
 			g.Expect(err).NotTo(HaveOccurred())
 			err = testReconciler.secretStore.Run(wait.NeverStop)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -766,7 +766,7 @@ func TestPatchSecret(t *testing.T) {
 func TestHandleError(t *testing.T) {
 	g := NewWithT(t)
 
-	testReconciler, err := newTestReconciler(nil, nil, nil, nil, 60*time.Second, "")
+	testReconciler, err := newTestReconciler(nil, nil, nil, 60*time.Second, "")
 	g.Expect(err).NotTo(HaveOccurred())
 
 	testReconciler.handleError(errors.New("failed error"), "key1", false)


### PR DESCRIPTION
/kind cleanup

- remove unused node name in rotation reconciler
- remove unused scheme parameter in rotation reconciler test