### PR TITLE
test: more usage of t.TempDir()

### DIFF
--- a/pkg/rotation/reconciler_test.go
+++ b/pkg/rotation/reconciler_test.go
@@ -113,7 +113,7 @@ func TestReconcileError(t *testing.T) {
 			},
 			secretProviderClassToAdd: &secretsstorev1.SecretProviderClass{},
 			podToAdd:                 &corev1.Pod{},
-			socketPath:               getTempTestDir(t),
+			socketPath:               t.TempDir(),
 			secretToAdd:              &corev1.Secret{},
 			expectedErr:              true,
 		},
@@ -150,7 +150,7 @@ func TestReconcileError(t *testing.T) {
 				},
 			},
 			podToAdd:    &corev1.Pod{},
-			socketPath:  getTempTestDir(t),
+			socketPath:  t.TempDir(),
 			secretToAdd: &corev1.Secret{},
 			expectedErr: true,
 		},
@@ -211,7 +211,7 @@ func TestReconcileError(t *testing.T) {
 					},
 				},
 			},
-			socketPath:          getTempTestDir(t),
+			socketPath:          t.TempDir(),
 			secretToAdd:         &corev1.Secret{},
 			expectedErr:         true,
 			expectedErrorEvents: true,
@@ -276,7 +276,7 @@ func TestReconcileError(t *testing.T) {
 					},
 				},
 			},
-			socketPath: getTempTestDir(t),
+			socketPath: t.TempDir(),
 			secretToAdd: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "object1",
@@ -349,7 +349,7 @@ func TestReconcileError(t *testing.T) {
 					},
 				},
 			},
-			socketPath: getTempTestDir(t),
+			socketPath: t.TempDir(),
 			secretToAdd: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "object1",
@@ -419,7 +419,7 @@ func TestReconcileError(t *testing.T) {
 					},
 				},
 			},
-			socketPath: getTempTestDir(t),
+			socketPath: t.TempDir(),
 			secretToAdd: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "secret1",
@@ -572,7 +572,7 @@ func TestReconcileNoError(t *testing.T) {
 			Data: map[string][]byte{"foo": []byte("olddata")},
 		}
 
-		socketPath := getTempTestDir(t)
+		socketPath := t.TempDir()
 		expectedObjectVersions := map[string]string{"secret/object1": "v2"}
 		scheme, err := setupScheme()
 		g.Expect(err).NotTo(HaveOccurred())
@@ -789,17 +789,8 @@ func TestHandleError(t *testing.T) {
 	g.Expect(testReconciler.queue.Len()).To(Equal(1))
 }
 
-func getTempTestDir(t *testing.T) string {
-	tmpDir, err := os.MkdirTemp("", "ut")
-	if err != nil {
-		t.Fatalf("expected err to be nil, got: %+v", err)
-	}
-	return tmpDir
-}
-
 func getTestTargetPath(t *testing.T, uid, vol string) string {
-	dir := getTempTestDir(t)
-	path := filepath.Join(dir, "pods", uid, "volumes", "kubernetes.io~csi", vol, "mount")
+	path := filepath.Join(t.TempDir(), "pods", uid, "volumes", "kubernetes.io~csi", vol, "mount")
 	if err := os.MkdirAll(path, 0755); err != nil {
 		t.Fatalf("expected err to be nil, got: %+v", err)
 	}

--- a/pkg/util/secretutil/secret_test.go
+++ b/pkg/util/secretutil/secret_test.go
@@ -346,14 +346,8 @@ func TestGetSecretData(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tmpDir, err := os.MkdirTemp("", "ut")
-			if err != nil {
-				t.Fatalf("expected err to be nil, got: %+v", err)
-			}
-			defer os.RemoveAll(tmpDir)
-
 			for fileName := range test.currentFiles {
-				filePath, err := createTestFile(tmpDir, fileName)
+				filePath, err := createTestFile(t.TempDir(), fileName)
 				if err != nil {
 					t.Fatalf("expected err to be nil, got: %+v", err)
 				}


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

More consistent use of stdlib test helpers.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
