### PR TITLE
fix: update atomic_writer to v1.27.1

### DIFF
--- a/pkg/util/fileutil/filesystem_test.go
+++ b/pkg/util/fileutil/filesystem_test.go
@@ -101,7 +101,7 @@ func TestGetMountedFiles(t *testing.T) {
 						Data: []byte("foo.txt"),
 						Mode: 0700,
 					},
-				})
+				}, nil)
 				if err != nil {
 					t.Fatalf("unable to write FileProjection: %s", err)
 				}

--- a/pkg/util/fileutil/writer.go
+++ b/pkg/util/fileutil/writer.go
@@ -67,7 +67,7 @@ func WritePayloads(path string, payloads []*v1alpha1.File) error {
 		}
 	}
 
-	return w.Write(files)
+	return w.Write(files, nil)
 }
 
 // cleanupProviderFiles checks all the paths from payloads to determine whether

--- a/pkg/util/fileutil/writer_test.go
+++ b/pkg/util/fileutil/writer_test.go
@@ -456,7 +456,7 @@ func TestCleanupProviderFiles(t *testing.T) {
 	for _, f := range wantFiles {
 		filesToWriteAtomically[f.Path] = FileProjection{Data: f.Contents, Mode: f.Mode}
 	}
-	if err := w.Write(filesToWriteAtomically); err != nil {
+	if err := w.Write(filesToWriteAtomically, nil); err != nil {
 		t.Errorf("writing with AtomicWriter: %s", err)
 	}
 


### PR DESCRIPTION
This includes 3 changes:

* https://github.com/kubernetes/kubernetes/commit/96306f144a3c917a97fe27c9ad5dd89e4213f741
* https://github.com/kubernetes/kubernetes/commit/a9593d634c6a053848413e600dadbf974627515f
* https://github.com/kubernetes/kubernetes/commit/82a9fb9d0ecbd9f54656d4c6b7e8247a3a49ca7e

<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

We likely need to be using [`SetVolumeOwnership`](https://pkg.go.dev/k8s.io/kubernetes/pkg/volume#SetVolumeOwnership) to better support non-root containers ([ref](https://github.com/kubernetes/kubernetes/blob/d94c733ee2bfaedd9a1c45d58fbd56c99403c94d/pkg/volume/configmap/configmap.go#L252-L257)) but that can be done in a separate effort from updating the atomic writer.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
