### PR TITLE
docs: remove unnecessary "the" in concepts

### DIFF
--- a/docs/book/src/concepts.md
+++ b/docs/book/src/concepts.md
@@ -44,7 +44,7 @@ the provider plugin must create a unix domain socket in a `hostPath` for the dri
 Further, service account tokens for pods that require secrets may be forwarded from the kubelet process to the driver
 and then to provider plugins. This allows the provider to impersonate the pod when contacting the external secret API.
 
-**Note:** On Windows hosts secrets will be written to the the node's filesystem which may be persistent storage. This
+**Note:** On Windows hosts secrets will be written to the node's filesystem which may be persistent storage. This
 contrasts with Linux where a `tmpfs` is used to try to ensure that secret material is never persisted.
 
 **Note:** Kubernetes 1.22 introduced a way to configure nodes to


### PR DESCRIPTION
Removing unnecessary "the"


**What type of PR is this?**

/kind documentation


**What this PR does / why we need it**:
Fixing typo.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #


**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [X] includes documentation
- [] adds unit tests
