### PR TITLE
helm: aggregated clusterrole to view secretproviderclasspodstatuses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -413,6 +413,7 @@ e2e-deploy-manifest:
 	kubectl apply -f manifest_staging/deploy/secrets-store.csi.x-k8s.io_secretproviderclasspodstatuses.yaml
 	kubectl apply -f manifest_staging/deploy/role-secretproviderclasses-admin.yaml
 	kubectl apply -f manifest_staging/deploy/role-secretproviderclasses-viewer.yaml
+	kubectl apply -f manifest_staging/deploy/role-secretproviderclasspodstatuses-viewer.yaml
 
 	yq e '(.spec.template.spec.containers[1].image = "$(IMAGE_TAG)") | (.spec.template.spec.containers[1].args as $$x | $$x += "--enable-secret-rotation=true" | $$x[-1] style="double") | (.spec.template.spec.containers[1].args as $$x | $$x += "--rotation-poll-interval=30s" | $$x[-1] style="double")' 'manifest_staging/deploy/secrets-store-csi-driver.yaml' | kubectl apply -f -
 

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/role-secretproviderclasspodstatuses-viewer.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/role-secretproviderclasspodstatuses-viewer.yaml
@@ -1,0 +1,21 @@
+{{ if .Values.rbac.install }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+{{ include "sscd.labels" . | indent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: secretproviderclasspodstatuses-viewer-role
+rules:
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasspodstatuses
+  verbs:
+  - get
+  - list
+  - watch
+{{ end }}

--- a/manifest_staging/deploy/role-secretproviderclasspodstatuses-viewer.yaml
+++ b/manifest_staging/deploy/role-secretproviderclasspodstatuses-viewer.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: secretproviderclasspodstatuses-viewer-role
+rules:
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasspodstatuses
+  verbs:
+  - get
+  - list
+  - watch

--- a/test/bats/e2e-provider.bats
+++ b/test/bats/e2e-provider.bats
@@ -80,6 +80,9 @@ export VALIDATE_TOKENS_AUDIENCE=$(get_token_requests_audience)
   run kubectl get clusterrole/secretproviderclasses-viewer-role
   assert_success
 
+  run kubectl get clusterrole/secretproviderclasspodstatuses-viewer-role
+  assert_success
+
   run kubectl get clusterrole/secretproviderrotation-role
   assert_success
 


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

This adds a new aggregated cluster role granting access to view `SecretProviderClassPodStatus`.

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->
/kind feature

**What this PR does / why we need it**:

As a regular user using `SecretProviderClass`, there is currently no RBAC that allows me to view the status of SPC usage in pods. We have worked around this by asking our cluster-admin to create the aggregated clusterrole included in this PR. I think it makes sense to include this cluster role by default in an installation of Secrets Store CSI Driver.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/secrets-store-csi-driver/issues/1281

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

~I have included aggregation to the `cluster-reader` cluster role. This cluster role is not listed among the[ default user-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) in the Kubernetes docs, but I think it is quite common and makes sense. It is [included by default](https://docs.openshift.com/container-platform/4.13/authentication/using-rbac.html#default-roles_using-rbac) in OpenShift, and we use it quite a lot. I have also added this aggregation to the existing `secretproviderclasses-viewer-role` to make it consistent.~ Update: I will file a separate issue/PR for this.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests