### PR TITLE
Issue 1339 added multiple secret template to gcp tests example.

### DIFF
--- a/test/bats/tests/gcp/gcp_v1_multiple_secretproviderclass.yaml
+++ b/test/bats/tests/gcp/gcp_v1_multiple_secretproviderclass.yaml
@@ -1,0 +1,39 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: gcp-01
+spec:
+  provider: gcp
+  secretObjects:
+    - secretName: secret-01
+      type: 
+      data:
+        - objectName: foo
+          key: username
+        - objectName: foo1
+          key: password
+  parameters:
+    auth: provider-adc
+    secrets: |
+      - resourceName: $RESOURCE_NAME
+        fileName: $FILE_NAME
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: gcp-02
+spec:
+  provider: gcp
+  secretObjects:
+    - secretName: secret-02
+      type: 
+      data:
+        - objectName: foo
+          key: username
+        - objectName: foo1
+          key: password
+  parameters:
+    auth: provider-adc
+    secrets: |
+      - resourceName: $RESOURCE_NAME
+        fileName: $FILE_NAME


### PR DESCRIPTION
/kind documentation

This PR adds the template for GCP secretProviderClass on how to use multiple secrets

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1339 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
No
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [X] includes documentation
- [ ] adds unit tests
