### PR TITLE
fix: remove hardcoded driver name

### DIFF
--- a/cmd/secrets-store-csi-driver/main.go
+++ b/cmd/secrets-store-csi-driver/main.go
@@ -168,7 +168,7 @@ func mainErr() error {
 		return err
 	}
 
-	reconciler, err := controllers.New(mgr, *nodeID)
+	reconciler, err := controllers.New(*driverName, mgr, *nodeID)
 	if err != nil {
 		klog.ErrorS(err, "failed to create secret provider class pod status reconciler")
 		return err
@@ -217,7 +217,7 @@ func mainErr() error {
 
 	// Secret rotation
 	if *enableSecretRotation {
-		rec, err := rotation.NewReconciler(mgr.GetCache(), scheme, *rotationPollInterval, providerClients, tokenClient)
+		rec, err := rotation.NewReconciler(*driverName, mgr.GetCache(), scheme, *rotationPollInterval, providerClients, tokenClient)
 		if err != nil {
 			klog.ErrorS(err, "failed to initialize rotation reconciler")
 			return err

--- a/controllers/secretproviderclasspodstatus_controller.go
+++ b/controllers/secretproviderclasspodstatus_controller.go
@@ -64,10 +64,11 @@ type SecretProviderClassPodStatusReconciler struct {
 	reader        client.Reader
 	writer        client.Writer
 	eventRecorder record.EventRecorder
+	driverName    string
 }
 
 // New creates a new SecretProviderClassPodStatusReconciler
-func New(mgr manager.Manager, nodeID string) (*SecretProviderClassPodStatusReconciler, error) {
+func New(driverName string, mgr manager.Manager, nodeID string) (*SecretProviderClassPodStatusReconciler, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	kubeClient := kubernetes.NewForConfigOrDie(mgr.GetConfig())
 	eventBroadcaster.StartRecordingToSink(&clientcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
@@ -81,6 +82,7 @@ func New(mgr manager.Manager, nodeID string) (*SecretProviderClassPodStatusRecon
 		reader:        mgr.GetCache(),
 		writer:        mgr.GetClient(),
 		eventRecorder: recorder,
+		driverName:    driverName,
 	}, nil
 }
 
@@ -265,7 +267,7 @@ func (r *SecretProviderClassPodStatusReconciler) Reconcile(ctx context.Context, 
 	}
 
 	// determine which pod volume this is associated with
-	podVol := k8sutil.SPCVolume(pod, spc.Name)
+	podVol := k8sutil.SPCVolume(pod, r.driverName, spc.Name)
 	if podVol == nil {
 		return ctrl.Result{}, fmt.Errorf("failed to find secret provider class pod status volume for pod %s/%s", req.Namespace, spcPodStatus.Status.PodName)
 	}

--- a/controllers/secretproviderclasspodstatus_controller_test.go
+++ b/controllers/secretproviderclasspodstatus_controller_test.go
@@ -117,6 +117,7 @@ func newReconciler(client client.Client, scheme *runtime.Scheme, nodeID string) 
 		eventRecorder: fakeRecorder,
 		mutex:         &sync.Mutex{},
 		nodeID:        nodeID,
+		driverName:    "secrets-store.csi.k8s.io",
 	}
 }
 

--- a/pkg/rotation/reconciler_test.go
+++ b/pkg/rotation/reconciler_test.go
@@ -83,6 +83,7 @@ func newTestReconciler(client client.Reader, kubeClient kubernetes.Interface, cr
 		cache:                client,
 		secretStore:          secretStore,
 		tokenClient:          k8s.NewTokenClient(kubeClient, "test-driver", 1*time.Second),
+		driverName:           "secrets-store.csi.k8s.io",
 	}, nil
 }
 

--- a/pkg/util/k8sutil/volume.go
+++ b/pkg/util/k8sutil/volume.go
@@ -24,13 +24,13 @@ import (
 
 // SPCVolume finds the Secret Provider Class volume from a Pod, or returns nil
 // if a volume could not be found.
-func SPCVolume(pod *corev1.Pod, spcName string) *corev1.Volume {
+func SPCVolume(pod *corev1.Pod, driverName, spcName string) *corev1.Volume {
 	for idx := range pod.Spec.Volumes {
 		vol := &pod.Spec.Volumes[idx]
 		if vol.CSI == nil {
 			continue
 		}
-		if vol.CSI.Driver != "secrets-store.csi.k8s.io" {
+		if vol.CSI.Driver != driverName {
 			continue
 		}
 		if vol.CSI.VolumeAttributes["secretProviderClass"] != spcName {

--- a/pkg/util/k8sutil/volume_test.go
+++ b/pkg/util/k8sutil/volume_test.go
@@ -159,7 +159,7 @@ func TestSPCVolume(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := SPCVolume(tc.pod, tc.spcName)
+			got := SPCVolume(tc.pod, "secrets-store.csi.k8s.io", tc.spcName)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("SPCVolume() mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
Looking through the code, the driver name seems to be configurable. However, there is one place where it is hardcoded. This PR tries to ease the restriction and allow the use of custom driver names.

<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Looking through the code, the driver name seems to be configurable. However, there is one place where it is hardcoded. This PR tries to ease the restriction and allow the use of custom driver names.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
