### PR TITLE
chore: bump version to v1.4.0 in release-1.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,12 @@ E2E_PROVIDER_IMAGE_NAME ?= e2e-provider
 
 # Release version is the current supported release for the driver
 # Update this version when the helm chart is being updated for release
-RELEASE_VERSION := v1.3.4
-IMAGE_VERSION ?= v1.3.4
+RELEASE_VERSION := v1.4.0
+IMAGE_VERSION ?= v1.4.0
 
 # Use a custom version for E2E tests if we are testing in CI
 ifdef CI
-override IMAGE_VERSION := v1.3.0-e2e-$(BUILD_COMMIT)
+override IMAGE_VERSION := v1.4.0-e2e-$(BUILD_COMMIT)
 endif
 
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@
 REGISTRY?=docker.io/deislabs
 IMAGE_NAME=driver
 CRD_IMAGE_NAME=driver-crds
-IMAGE_VERSION?=v1.3.4
+IMAGE_VERSION?=v1.4.0
 BUILD_TIMESTAMP := $(shell date +%Y-%m-%d-%H:%M)
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION
- bump version to `v1.4.0` in release-1.4