### PR TITLE
ci: remove low quota regions for aks windows job

### DIFF
--- a/test/scripts/run-e2e-windows.sh
+++ b/test/scripts/run-e2e-windows.sh
@@ -27,7 +27,7 @@ parse_cred() {
 }
 
 get_random_region() {
-    local REGIONS=("eastus" "eastus2" "southcentralus" "westeurope" "uksouth" "northeurope" "francecentral")
+    local REGIONS=("eastus" "eastus2" "southcentralus" "westeurope" "uksouth")
     echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
 }
 


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Cluster creation in `northeurope` and `francecentral` has been flaky. I reviewed the failed jobs, and all the cluster creation failures seem to be only in these 2 regions.
