### PR TITLE
chore: update debian-base to bookworm-v1.0.1

### DIFF
--- a/docker/BASEIMAGE
+++ b/docker/BASEIMAGE
@@ -1,4 +1,4 @@
-linux/amd64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.0
-linux/arm64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.0
+linux/amd64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.1
+linux/arm64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.1
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.0
+ARG BASEIMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.1
 
 FROM golang:1.21@sha256:7026fb72cfa9cc112e4d1bf4b35a15cac61a413d0252d06615808e7c987b33a7 as builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver


### PR DESCRIPTION
/kind feature

- update debian-base to bookworm-v1.0.0