### PR TITLE
Use values.yaml for default values in securityContext

### DIFF
--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -103,7 +103,7 @@ spec:
                 fieldPath: spec.nodeName
           imagePullPolicy: {{ .Values.linux.image.pullPolicy }}
           securityContext:
-            privileged: true
+            privileged: {{ .Values.securityContext.privileged}}
           {{- if semverCompare ">= v0.0.8-0" .Values.linux.image.tag }}
           ports:
             - containerPort: {{ .Values.livenessProbe.port }}

--- a/charts/secrets-store-csi-driver/values.yaml
+++ b/charts/secrets-store-csi-driver/values.yaml
@@ -242,3 +242,7 @@ tokenRequests: []
 # -- Labels to apply to all resources
 commonLabels: {}
 # team_name: dev
+
+## Driver securityContext default values
+securityContext:
+  privileged: true

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -103,7 +103,7 @@ spec:
                 fieldPath: spec.nodeName
           imagePullPolicy: {{ .Values.linux.image.pullPolicy }}
           securityContext:
-            privileged: true
+            privileged: {{ .Values.securityContext.privileged}}
           {{- if semverCompare ">= v0.0.8-0" .Values.linux.image.tag }}
           ports:
             - containerPort: {{ .Values.livenessProbe.port }}

--- a/manifest_staging/charts/secrets-store-csi-driver/values.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/values.yaml
@@ -242,3 +242,7 @@ tokenRequests: []
 # -- Labels to apply to all resources
 commonLabels: {}
 # team_name: dev
+
+## manifest_staging Driver securityContext default values
+securityContext:
+  privileged: true


### PR DESCRIPTION

<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
In secret-store-csi-driver.yaml there is a securityContext which uses `privileged: true` and does not use values.yaml to apply the defaults. This PR migrates to the values as default values in values.yaml for an easy configuration
**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #
None, there is an open comment in a bug in gcp provider https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/issues/242#issuecomment-1928894797
<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
