### PR TITLE
Automated cherry pick of #1472: security: bump kubectl to v1.29.3 in driver-crds for

### DIFF
--- a/docker/crd.Dockerfile
+++ b/docker/crd.Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM alpine as builder
-ARG KUBE_VERSION=v1.28.3
+ARG KUBE_VERSION=v1.29.3
 ARG TARGETARCH
 
 RUN apk add --no-cache curl && \


### PR DESCRIPTION
Cherry pick of #1472 on release-1.4.

#1472: security: bump kubectl to v1.29.3 in driver-crds for

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.