### PR TITLE
fix: support more than one linux.crds.annotations entry

### DIFF
--- a/manifest_staging/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
@@ -94,7 +94,7 @@ spec:
       name: {{ template "sscd.fullname" . }}-upgrade-crds
       {{- if .Values.linux.crds.annotations }}
       annotations:
-        {{ toYaml .Values.linux.crds.annotations }}
+        {{- toYaml .Values.linux.crds.annotations | nindent 8 }}
       {{- end }}
       {{- if .Values.linux.crds.podLabels }}
       labels:

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/keep-crds-upgrade-hook.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/keep-crds-upgrade-hook.yaml
@@ -94,7 +94,7 @@ spec:
       name: {{ template "sscd.fullname" . }}-keep-crds
       {{- if .Values.linux.crds.annotations }}
       annotations:
-        {{ toYaml .Values.linux.crds.annotations}}
+        {{- toYaml .Values.linux.crds.annotations | nindent 8 }}
       {{- end }}
       {{- if .Values.linux.crds.podLabels }}
       labels:


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Add support for more than one `linux.crds.annotations` dictionary entry in the `secrets-store-driver-csi` chart. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes # N/A

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
```bash
$ helm lint ./
==> Linting ./

1 chart(s) linted, 0 chart(s) failed
```

Tested by templating locally with the following configuration in values.yaml.
```
  crds:
    annotations:
      keyOne: valueOne
      keyTwo: valueTwo
```

_Before_
```bash
$ helm template .
Error: YAML parse error on secrets-store-csi-driver/templates/crds-upgrade-hook.yaml: error converting YAML to JSON: yaml: line 25: mapping values are not allowed in this context
```

_After_
```bash
$ helm template .
.
.
# Source: secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: secrets-store-csi-driver-upgrade-crds
  namespace: default
  labels:
    app.kubernetes.io/instance: "release-name"
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/name: "secrets-store-csi-driver"
    app.kubernetes.io/version: "1.4.2"
    app: secrets-store-csi-driver
    helm.sh/chart: "secrets-store-csi-driver-1.4.2"
  annotations:
    helm.sh/hook: pre-install,pre-upgrade
    helm.sh/hook-weight: "10"
    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
spec:
  backoffLimit: 3
  template:
    metadata:
      name: release-name-secrets-store-csi-driver-upgrade-crds
      annotations:
        keyOne: valueOne
        keyTwo: valueTwo
    spec:
      serviceAccountName: release-name-secrets-store-csi-driver-upgrade-crds
      restartPolicy: Never
      containers:
      - name: crds-upgrade
        image: "registry.k8s.io/csi-secrets-store/driver-crds:v1.4.2"
        args:
        - apply
        - -f
        - crds/
        imagePullPolicy: IfNotPresent
      nodeSelector:
        kubernetes.io/os: linux
      tolerations:
        - operator: Exists
---
# Source: secrets-store-csi-driver/templates/keep-crds-upgrade-hook.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: secrets-store-csi-driver-keep-crds
  namespace: default
  labels:
    app.kubernetes.io/instance: "release-name"
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/name: "secrets-store-csi-driver"
    app.kubernetes.io/version: "1.4.2"
    app: secrets-store-csi-driver
    helm.sh/chart: "secrets-store-csi-driver-1.4.2"
  annotations:
    helm.sh/hook: pre-upgrade
    helm.sh/hook-weight: "20"
    helm.sh/hook-delete-policy: "hook-succeeded,before-hook-creation"
spec:
  backoffLimit: 3
  template:
    metadata:
      name: release-name-secrets-store-csi-driver-keep-crds
      annotations:
        keyOne: valueOne
        keyTwo: valueTwo
    spec:
      serviceAccountName: release-name-secrets-store-csi-driver-keep-crds
      restartPolicy: Never
      containers:
      - name: crds-keep
        image: "registry.k8s.io/csi-secrets-store/driver-crds:v1.4.2"
        args:
        - patch
        - crd
        - secretproviderclasses.secrets-store.csi.x-k8s.io
        - secretproviderclasspodstatuses.secrets-store.csi.x-k8s.io
        - -p
        - '{"metadata":{"annotations": {"helm.sh/resource-policy": "keep"}}}'
        imagePullPolicy: IfNotPresent
      nodeSelector:
        kubernetes.io/os: linux
      tolerations:
        - operator: Exists
```

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
