### PR TITLE
Automated cherry pick of #1491: chore: update debian-base to bookworm-v1.0.2

### DIFF
--- a/docker/BASEIMAGE
+++ b/docker/BASEIMAGE
@@ -1,4 +1,4 @@
-linux/amd64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.1
-linux/arm64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.1
+linux/amd64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.2
+linux/arm64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.2
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.1
+ARG BASEIMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.2
 
 FROM golang:1.21@sha256:7026fb72cfa9cc112e4d1bf4b35a15cac61a413d0252d06615808e7c987b33a7 as builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver


### PR DESCRIPTION
Cherry pick of #1491 on release-1.4.

#1491: chore: update debian-base to bookworm-v1.0.2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.