### PR TITLE
chore: bump kubectl to v1.29.4 in driver-crds for CVE-2023-45288

### DIFF
--- a/docker/crd.Dockerfile
+++ b/docker/crd.Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM alpine as builder
-ARG KUBE_VERSION=v1.29.3
+ARG KUBE_VERSION=v1.29.4
 ARG TARGETARCH
 
 RUN apk add --no-cache curl && \


### PR DESCRIPTION
bump kubectl to v1.29.3 in driver-crds for CVE-2023-45288