### PR TITLE
Automated cherry pick of #1502: chore: bump kubectl to v1.29.4 in driver-crds for CVE-2023-45288

### DIFF
--- a/docker/crd.Dockerfile
+++ b/docker/crd.Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM alpine as builder
-ARG KUBE_VERSION=v1.29.3
+ARG KUBE_VERSION=v1.29.4
 ARG TARGETARCH
 
 RUN apk add --no-cache curl && \


### PR DESCRIPTION
Cherry pick of #1502 on release-1.4.

#1502: chore: bump kubectl to v1.29.4 in driver-crds for

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.