### PR TITLE
Automated cherry pick of #1543: test: remove target path check in fake provider server

### DIFF
--- a/provider/fake/fake_server.go
+++ b/provider/fake/fake_server.go
@@ -117,9 +117,6 @@ func (m *MockCSIProviderServer) Mount(ctx context.Context, req *v1alpha1.MountRe
 	if err = json.Unmarshal([]byte(req.GetPermission()), &filePermission); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal file permission, error: %w", err)
 	}
-	if len(req.GetTargetPath()) == 0 {
-		return nil, fmt.Errorf("missing target path")
-	}
 	return &v1alpha1.MountResponse{
 		ObjectVersion: m.objects,
 		Error: &v1alpha1.Error{


### PR DESCRIPTION
Cherry pick of #1543 on release-1.4.

#1543: test: remove target path check in fake provider server

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.