### PR TITLE
ci: use `--clean` instead of `--rm-dist`

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -24,6 +24,6 @@ jobs:
         uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
         with:
           version: latest
-          args: release --rm-dist --timeout 60m --debug
+          args: release --clean --timeout 60m --debug
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`--rm-dist` is removed, using `--clean` instead.

This should resolve the `create_release` workflow failure: https://github.com/kubernetes-sigs/secrets-store-csi-driver/actions/runs/9569015004/job/26380558230