### PR TITLE
ci: use `--verbose` instead of `--debug` in goreleaser

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -24,6 +24,6 @@ jobs:
         uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
         with:
           version: latest
-          args: release --clean --timeout 60m --debug
+          args: release --clean --timeout 60m --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`--debug` is removed, using `--verbose` instead.

This should resolve the `create_release` workflow failure: https://github.com/kubernetes-sigs/secrets-store-csi-driver/actions/runs/9570424010/job/26385138887