### PR TITLE
Automated cherry pick of #1557: ci: use `--verbose` instead of `--debug` in goreleaser

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -24,6 +24,6 @@ jobs:
         uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
         with:
           version: latest
-          args: release --clean --timeout 60m --debug
+          args: release --clean --timeout 60m --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Cherry pick of #1557 on release-1.4.

#1557: ci: use `--verbose` instead of `--debug` in goreleaser

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.