### PR TITLE
ci: use v2 for goreleaser

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Goreleaser
         uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean --timeout 60m --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Set version to `v2` for goreleaser (xref: https://goreleaser.com/blog/goreleaser-v2/#github-action)