### PR TITLE
Charts: Fix imagePullSecrets

### DIFF
--- a/charts/secrets-store-csi-driver/templates/_helpers.tpl
+++ b/charts/secrets-store-csi-driver/templates/_helpers.tpl
@@ -53,3 +53,20 @@ Return the appropriate apiVersion for CSIDriver.
 {{- print "storage.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+imagePullSecrets generates pull secrets from either string or map values.
+A map value must be indexable by the key 'name'.
+*/}}
+{{- define "imagePullSecrets" -}}
+{{- with .Values.imagePullSecrets -}}
+imagePullSecrets:
+{{- range . -}}
+{{- if typeIs "string" . }}
+  - name: {{ . }}
+{{- else if index . "name" }}
+  - name: {{ .name }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
+++ b/charts/secrets-store-csi-driver/templates/crds-upgrade-hook.yaml
@@ -102,10 +102,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "sscd.fullname" . }}-upgrade-crds
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 6 }}
-      {{- end }}
+      {{- include "imagePullSecrets" . | nindent 6 }}
       restartPolicy: Never
       containers:
       - name: crds-upgrade

--- a/charts/secrets-store-csi-driver/templates/keep-crds-upgrade-hook.yaml
+++ b/charts/secrets-store-csi-driver/templates/keep-crds-upgrade-hook.yaml
@@ -102,10 +102,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "sscd.fullname" . }}-keep-crds
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 6 }}
-      {{- end }}
+      {{- include "imagePullSecrets" . | nindent 6 }}
       restartPolicy: Never
       containers:
       - name: crds-keep

--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -30,10 +30,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: secrets-store-csi-driver
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{ toYaml .Values.imagePullSecrets | indent 8 }}
-      {{- end }}
+      {{- include "imagePullSecrets" . | nindent 6 }}
       affinity:
 {{ toYaml .Values.windows.affinity | indent 8 }}
       containers:

--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -30,10 +30,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: secrets-store-csi-driver
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{ toYaml .Values.imagePullSecrets | indent 8 }}
-      {{- end }}
+      {{- include "imagePullSecrets" . | nindent 6 }}
       affinity:
 {{ toYaml .Values.linux.affinity | indent 8 }}
       containers:


### PR DESCRIPTION
This PR fixes `imagePullSecrets` rendering did not work as expected,
the diff between the bug revision and the fixed revision is shown
below:

```text
diff -y bad.yml good.yml (with some identical sections removed for simplicity)

---									---
kind: DaemonSet								kind: DaemonSet
apiVersion: apps/v1							apiVersion: apps/v1
spec:									spec:
  template:								  template:
    spec:								    spec:
      serviceAccountName: secrets-store-csi-driver			      serviceAccountName: secrets-store-csi-driver
      imagePullSecrets:							      imagePullSecrets:
                - ps1						|               - name: ps1
      affinity:								      affinity:
        nodeAffinity:							        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:		          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:						            nodeSelectorTerms:
            - matchExpressions:						            - matchExpressions:
              - key: type						              - key: type
                operator: NotIn						                operator: NotIn
                values:							                values:
                - virtual-kubelet					                - virtual-kubelet
---									---
apiVersion: batch/v1							apiVersion: batch/v1
kind: Job								kind: Job
spec:									spec:
  template:								  template:
    spec:								    spec:
      serviceAccountName: release-name-secrets-store-csi-		      serviceAccountName: release-name-secrets-store-csi-
      imagePullSecrets:							      imagePullSecrets:
      - ps1							|               - name: ps1
      restartPolicy: Never						      restartPolicy: Never
      containers:							      containers:
      - name: crds-upgrade						      - name: crds-upgrade
        image: "hiltoncn-registry-vpc.cn-shanghai.cr.aliy		        image: "hiltoncn-registry-vpc.cn-shanghai.cr.aliy
        args:								        args:
        - apply								        - apply
        - -f								        - -f
        - crds/								        - crds/
        imagePullPolicy: IfNotPresent					        imagePullPolicy: IfNotPresent
      nodeSelector:							      nodeSelector:
        kubernetes.io/os: linux						        kubernetes.io/os: linux
      tolerations:							      tolerations:
        - operator: Exists						        - operator: Exists
---									---
apiVersion: batch/v1							apiVersion: batch/v1
kind: Job								kind: Job
spec:									spec:
  template:								  template:
    spec:								    spec:
      serviceAccountName: release-name-secrets-store-csi-		      serviceAccountName: release-name-secrets-store-csi-
      imagePullSecrets:							      imagePullSecrets:
      - ps1							|               - name: ps1
      restartPolicy: Never						      restartPolicy: Never
      nodeSelector:							      nodeSelector:
        kubernetes.io/os: linux						        kubernetes.io/os: linux
      tolerations:							      tolerations:
        - operator: Exists						        - operator: Exists
```

The fixup is a port from hashicorp/vault helm charts when I'm setting
up csi driver with vault provider. The hashicorp/vault charts work
well, but csi driver charts works bad. So it's quite obvious that the
fixup is out there.

https://github.com/hashicorp/vault-helm/commit/64b4d88c727a1d7ad163e5449a79ca21dce7ceaa

Signed-off-by: Park Zhou <ideapark@petalmail.com>
