### PR TITLE
test: use e2e-provider for manifest tests

### DIFF
--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -20,10 +20,6 @@ if [ -z "$AUTO_ROTATE_SECRET_NAME" ]; then
     export AUTO_ROTATE_SECRET_NAME=secret-$(openssl rand -hex 6)
 fi
 
-if [ -z "$IS_YAML_TEST" ]; then
-    export IS_YAML_TEST=false
-fi
-
 export KEYVAULT_NAME=${KEYVAULT_NAME:-csi-secrets-store-e2e}
 export SECRET_NAME=${KEYVAULT_SECRET_NAME:-secret1}
 export SECRET_VERSION=${KEYVAULT_SECRET_VERSION:-""}

--- a/test/scripts/e2e_provider.sh
+++ b/test/scripts/e2e_provider.sh
@@ -15,4 +15,15 @@
 # limitations under the License.
 
 echo "running e2e provider test"
-make e2e-bootstrap e2e-mock-provider-container e2e-helm-deploy e2e-provider-deploy e2e-provider
+make e2e-bootstrap e2e-mock-provider-container
+
+# if YAML_TEST env var is true, then use e2e-deploy-manifest instead of e2e-helm-deploy
+if [ "$IS_YAML_TEST" = "true" ]; then
+  echo "Deploying driver using manifest"
+  make e2e-deploy-manifest
+else
+  echo "Deploying driver using helm chart"
+  make e2e-helm-deploy
+fi
+
+make e2e-provider-deploy e2e-provider


### PR DESCRIPTION
- Use e2e-provider for manifest tests

This enables us to move to eks prow cluster without any dependencies on secrets used by the azure provider.