### PR TITLE
Allow modification of the hostNetwork parameter to avoid the need of a dedicated pod ip

### DIFF
--- a/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -30,6 +30,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: secrets-store-csi-driver
+      hostNetwork: {{ default false .Values.hostNetwork }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{ toYaml .Values.imagePullSecrets | indent 8 }}


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allow modification of the hostNetwork parameter to avoid the need of a dedicated pod ip.
We would like our daemonsets to run in the hostNetwork so to avoid needing allocate IP for them.
Adding hostNetwork to this template allow us to do this.