### PR TITLE
Use GCP SA json for auth

### DIFF
--- a/test/bats/tests/gcp/pod-secrets-store-inline-volume-crd.yaml
+++ b/test/bats/tests/gcp/pod-secrets-store-inline-volume-crd.yaml
@@ -22,3 +22,6 @@ spec:
         readOnly: true
         volumeAttributes:
           secretProviderClass: "gcp"
+        nodePublishSecretRef:
+          name: secrets-store-creds
+


### PR DESCRIPTION
/kind migration

Testcase Migration for GCP Provider.

Partial revert of https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/641 to use GCP SA json as secret from GitHub Secrets and use that to authenticate GCP Secrets.

Since GCP Prow is migrating to EKS Prow, this is a temporary workaround to make sure the smooth transition of test cases, upon clarity we will build a permanent solution to use federated WI in EKS Prow.

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
