### PR TITLE
ci: update goreleaser config for v2

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -24,6 +24,6 @@ jobs:
         uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
         with:
           version: "~> v2"
-          args: release --clean --timeout 60m --verbose
+          args: release --clean --fail-fast --timeout 60m --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,5 @@
 # refer to https://goreleaser.com for more options
-build:
-  skip: true
+version: 2
 release:
   prerelease: auto
   header: |
@@ -8,7 +7,7 @@ release:
   extra_files:
     - glob: deploy/*.yaml
 changelog:
-  skip: false
+  disable: false
   groups:
     - title: Bug Fixes 🐞
       regexp: ^.*fix[(\\w)]*:+.*$


### PR DESCRIPTION
Validation before the change:
```bash
➜ goreleaser check        
  • only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
  ⨯ command failed                                   error=only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
```

Validation after the change:

```bash
➜ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```