### PR TITLE
Automated cherry pick of #1660: chore: bumps base images

### DIFF
--- a/docker/BASEIMAGE
+++ b/docker/BASEIMAGE
@@ -1,4 +1,4 @@
-linux/amd64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.3
-linux/arm64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.3
+linux/amd64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.4
+linux/arm64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.4
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.3
+ARG BASEIMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.4
 
 FROM golang:1.21@sha256:7026fb72cfa9cc112e4d1bf4b35a15cac61a413d0252d06615808e7c987b33a7 as builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver


### PR DESCRIPTION
Cherry pick of #1660 on release-1.4.

#1660: chore: bumps base images

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.