### PR TITLE
chore: add labels to metrics (updated)

### DIFF
--- a/controllers/stats_reporter.go
+++ b/controllers/stats_reporter.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"runtime"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/global"
+)
+
+const (
+	scope = "sigs.k8s.io/secrets-store-csi-driver"
+)
+
+var (
+	providerKey  = "provider"
+	osTypeKey    = "os_type"
+	runtimeOS    = runtime.GOOS
+	namespaceKey = "namespace"
+	spcKey       = "secret_provider_class"
+)
+
+type reporter struct {
+	syncK8sSecretTotal    metric.Int64Counter
+	syncK8sSecretDuration metric.Float64Histogram
+}
+
+type StatsReporter interface {
+	ReportSyncSecretCtMetric(ctx context.Context, provider, namespace, spc string)
+	ReportSyncSecretDuration(ctx context.Context, duration float64)
+}
+
+func newStatsReporter() (StatsReporter, error) {
+	var err error
+
+	r := &reporter{}
+	meter := global.Meter(scope)
+
+	if r.syncK8sSecretTotal, err = meter.Int64Counter("sync_k8s_secret", metric.WithDescription("Total number of k8s secrets synced")); err != nil {
+		return nil, err
+	}
+	if r.syncK8sSecretDuration, err = meter.Float64Histogram("sync_k8s_secret_duration_sec", metric.WithDescription("Distribution of how long it took to sync k8s secret")); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (r reporter) ReportSyncSecretCtMetric(ctx context.Context, provider, namespace, spc string) {
+	opt := metric.WithAttributes(
+		attribute.Key(providerKey).String(provider),
+		attribute.Key(osTypeKey).String(runtimeOS),
+		attribute.Key(namespaceKey).String(namespace),
+		attribute.Key(spcKey).String(spc),
+	)
+	r.syncK8sSecretTotal.Add(ctx, 1, opt)
+}
+
+func (r reporter) ReportSyncSecretDuration(ctx context.Context, duration float64) {
+	opt := metric.WithAttributes(
+		attribute.Key(osTypeKey).String(runtimeOS),
+	)
+	r.syncK8sSecretDuration.Record(ctx, duration, opt)
+}

--- a/controllers/stats_reporter.go
+++ b/controllers/stats_reporter.go
@@ -65,7 +65,6 @@ func newStatsReporter() (StatsReporter, error) {
 func (r reporter) ReportSyncSecretCtMetric(ctx context.Context, provider, namespace, spc string) {
 	opt := metric.WithAttributes(
 		attribute.Key(providerKey).String(provider),
-		attribute.Key(osTypeKey).String(runtimeOS),
 		attribute.Key(namespaceKey).String(namespace),
 		attribute.Key(spcKey).String(spc),
 	)
@@ -73,8 +72,5 @@ func (r reporter) ReportSyncSecretCtMetric(ctx context.Context, provider, namesp
 }
 
 func (r reporter) ReportSyncSecretDuration(ctx context.Context, duration float64) {
-	opt := metric.WithAttributes(
-		attribute.Key(osTypeKey).String(runtimeOS),
-	)
-	r.syncK8sSecretDuration.Record(ctx, duration, opt)
+	r.syncK8sSecretDuration.Record(ctx, duration)
 }

--- a/docs/book/src/topics/metrics.md
+++ b/docs/book/src/topics/metrics.md
@@ -6,17 +6,17 @@ Prometheus is the only exporter that's currently supported with the driver.
 
 ## List of metrics provided by the driver
 
-| Metric                          | Description                                                               | Tags                                                                              |
-| ------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| total_node_publish              | Total number of successful volume mount requests                          | `os_type=<runtime os>`<br>`provider=<provider name>`                              |
-| total_node_unpublish            | Total number of successful volume unmount requests                        | `os_type=<runtime os>`                                                            |
-| total_node_publish_error        | Total number of errors with volume mount requests                         | `os_type=<runtime os>`<br>`provider=<provider name>`<br>`error_type=<error code>` |
-| total_node_unpublish_error      | Total number of errors with volume unmount requests                       | `os_type=<runtime os>`                                                            |
-| total_sync_k8s_secret           | Total number of k8s secrets synced                                        | `os_type=<runtime os>`<br>`provider=<provider name>`                              |
-| sync_k8s_secret_duration_sec    | Distribution of how long it took to sync k8s secret                       | `os_type=<runtime os>`                                                            |
-| total_rotation_reconcile        | Total number of rotation reconciles                                       | `os_type=<runtime os>`<br>`rotated=<true or false>`                               |
-| total_rotation_reconcile_error  | Total number of rotation reconciles with error                            | `os_type=<runtime os>`<br>`rotated=<true or false>`<br>`error_type=<error code>`  |
-| rotation_reconcile_duration_sec | Distribution of how long it took to rotate secrets-store content for pods | `os_type=<runtime os>`                                                            |
+| Metric                          | Description                                                               | Tags                                                                                                                                                                                             |
+|---------------------------------|---------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| node_publish_total              | Total number of successful volume mount requests                          | `os_type=<runtime os>`<br>`provider=<provider name>`<br>`pod_name=<pod_name>`<br>`pod_namespace=<pod_namespace>`<br>`secret_provider_class=<secret_provider_class>`                              |
+| node_unpublish_total            | Total number of successful volume unmount requests                        | `os_type=<runtime os>`                                                                                                                                                                           |
+| node_publish_error_total        | Total number of errors with volume mount requests                         | `os_type=<runtime os>`<br>`provider=<provider name>`<br>`error_type=<error code>`<br>`pod_name=<pod_name>`<br>`pod_namespace=<pod_namespace>`<br>`secret_provider_class=<secret_provider_class>` |
+| node_unpublish_error_total      | Total number of errors with volume unmount requests                       | `os_type=<runtime os>`                                                                                                                                                                           |
+| sync_k8s_secret_total           | Total number of k8s secrets synced                                        | `os_type=<runtime os>`<br>`provider=<provider name>`<br>`namespace=<namespace>`<br>`secret_provider_class=<secret_provider_class>`                                                               |
+| sync_k8s_secret_duration_sec    | Distribution of how long it took to sync k8s secret                       | `os_type=<runtime os>`                                                                                                                                                                           |
+| rotation_reconcile_total        | Total number of rotation reconciles                                       | `os_type=<runtime os>`<br>`rotated=<true or false>`<br>`pod_name=<pod_name>`<br>`pod_namespace=<pod_namespace>`<br>`secret_provider_class=<secret_provider_class>`                               |
+| rotation_reconcile_error_total  | Total number of rotation reconciles with error                            | `os_type=<runtime os>`<br>`rotated=<true or false>`<br>`error_type=<error code>`<br>`pod_name=<pod_name>`<br>`pod_namespace=<pod_namespace>`<br>`secret_provider_class=<secret_provider_class>`  |
+| rotation_reconcile_duration_sec | Distribution of how long it took to rotate secrets-store content for pods | `os_type=<runtime os>`<br>`pod_name=<pod_name>`<br>`pod_namespace=<pod_namespace>`<br>`secret_provider_class=<secret_provider_class>`                                                            |
 
 Metrics are served from port 8095, but this port is not exposed outside the pod by default. Use kubectl port-forward to access the metrics over localhost:
 
@@ -47,17 +47,43 @@ sync_k8s_secret_duration_sec_bucket{os_type="linux",le="30"} 1
 sync_k8s_secret_duration_sec_bucket{os_type="linux",le="+Inf"} 1
 sync_k8s_secret_duration_sec_sum{os_type="linux"} 0.3115892
 sync_k8s_secret_duration_sec_count{os_type="linux"} 1
-# HELP total_node_publish Total number of node publish calls
-# TYPE total_node_publish counter
-total_node_publish{os_type="linux",provider="azure"} 1
-# HELP total_node_publish_error Total number of node publish calls with error
-# TYPE total_node_publish_error counter
-total_node_publish_error{error_type="ProviderBinaryNotFound",os_type="linux",provider="azure"} 2
-total_node_publish_error{error_type="SecretProviderClassNotFound",os_type="linux",provider=""} 4
-# HELP total_node_unpublish Total number of node unpublish calls
-# TYPE total_node_unpublish counter
-total_node_unpublish{os_type="linux"} 1
-# HELP total_sync_k8s_secret Total number of k8s secrets synced
-# TYPE total_sync_k8s_secret counter
-total_sync_k8s_secret{os_type="linux",provider="azure"} 1
+
+# HELP sync_k8s_secret_total Total number of k8s secrets synced
+# TYPE sync_k8s_secret_total counter
+sync_k8s_secret_total{namespace="csi-test-secret-ns",os_type="linux",provider="azure",secret_provider_class="csi-test-spc"} 1
+
+# HELP rotation_reconcile_duration_sec Distribution of how long it took to rotate secrets-store content for pods
+# TYPE rotation_reconcile_duration_sec histogram
+rotation_reconcile_duration_sec_bucket{os_type="linux",le="0.1"} 0
+rotation_reconcile_duration_sec_bucket{os_type="linux",le="0.2"} 0
+rotation_reconcile_duration_sec_bucket{os_type="linux",le="0.3"} 0
+rotation_reconcile_duration_sec_bucket{os_type="linux",le="0.4"} 1
+rotation_reconcile_duration_sec_bucket{os_type="linux",le="0.5"} 1
+rotation_reconcile_duration_sec_bucket{os_type="linux",le="1"} 1
+rotation_reconcile_duration_sec_bucket{os_type="linux",le="1.5"} 1
+rotation_reconcile_duration_sec_bucket{os_type="linux",le="2"} 1
+rotation_reconcile_duration_sec_bucket{os_type="linux",le="2.5"} 1
+rotation_reconcile_duration_sec_bucket{os_type="linux",le="3"} 1
+rotation_reconcile_duration_sec_bucket{os_type="linux",le="5"} 1
+rotation_reconcile_duration_sec_bucket{os_type="linux",le="10"} 1
+rotation_reconcile_duration_sec_bucket{os_type="linux",le="15"} 1
+rotation_reconcile_duration_sec_bucket{os_type="linux",le="30"} 1
+rotation_reconcile_duration_sec_bucket{os_type="linux",le="+Inf"} 1
+rotation_reconcile_duration_sec_sum{os_type="linux",} 0.3115892
+rotation_reconcile_duration_sec_count{os_type="linux"} 1
+# HELP rotation_reconcile_total Total number of rotation reconciles
+# TYPE rotation_reconcile_total counter
+rotation_reconcile_total{os_type="linux",pod_name="csi-test-app-wcsxk",pod_namespace="csi-test-secret-ns",provider="azure",rotated="false",secret_provider_class="csi-test-spc"} 1
+# HELP rotation_reconcile_error_total Total number of rotation reconciles with error
+# TYPE rotation_reconcile_error_total counter
+rotation_reconcile_error_total{error_type="GRPCProviderError",os_type="linux",pod_name="csi-test-app-wcsxk",pod_namespace="csi-test-secret-ns",provider="azure",rotated="false",secret_provider_class="csi-test-spc"} 12
+# HELP node_publish_total Total number of node publish calls
+# TYPE node_publish_total counter
+node_publish_total{os_type="linux",pod_name="csi-test-app-wcsxk",pod_namespace="csi-test-secret-ns",provider="azure",secret_provider_class="csi-test-spc"} 1
+# HELP node_publish_error_total Total number of node publish calls with error
+# TYPE node_publish_error_total counter
+node_publish_error_total{error_type="ProviderBinaryNotFound",os_type="linux",pod_name="csi-test-app-wcsxk",pod_namespace="csi-test-secret-ns",provider="azure",secret_provider_class="csi-test-spc"} 7
+# HELP node_unpublish_total Total number of node unpublish calls
+# TYPE node_unpublish_total counter
+node_unpublish_total{os_type="linux"} 1
 ```

--- a/pkg/rotation/reconciler.go
+++ b/pkg/rotation/reconciler.go
@@ -253,14 +253,14 @@ func (r *Reconciler) reconcile(ctx context.Context, spcps *secretsstorev1.Secret
 	var providerName string
 	podName := spcps.Status.PodName
 	podNamespace := spcps.Namespace
-	secretProviderClass := spcps.Status.SecretProviderClassName
+	secretProviderClassName := spcps.Status.SecretProviderClassName
 
 	defer func() {
 		if err != nil {
-			r.reporter.reportRotationErrorCtMetric(ctx, providerName, podName, podNamespace, secretProviderClass, errorReason, requiresUpdate)
+			r.reporter.reportRotationErrorCtMetric(ctx, providerName, podName, podNamespace, secretProviderClassName, errorReason, requiresUpdate)
 			return
 		}
-		r.reporter.reportRotationCtMetric(ctx, providerName, podName, podNamespace, secretProviderClass, requiresUpdate)
+		r.reporter.reportRotationCtMetric(ctx, providerName, podName, podNamespace, secretProviderClassName, requiresUpdate)
 		r.reporter.reportRotationDuration(ctx, time.Since(begin).Seconds())
 	}()
 
@@ -293,13 +293,13 @@ func (r *Reconciler) reconcile(ctx context.Context, spcps *secretsstorev1.Secret
 		ctx,
 		client.ObjectKey{
 			Namespace: podNamespace,
-			Name:      secretProviderClass,
+			Name:      secretProviderClassName,
 		},
 		spc,
 	)
 	if err != nil {
 		errorReason = internalerrors.SecretProviderClassNotFound
-		return fmt.Errorf("failed to get secret provider class %s/%s, err: %w", podNamespace, secretProviderClass, err)
+		return fmt.Errorf("failed to get secret provider class %s/%s, err: %w", podNamespace, secretProviderClassName, err)
 	}
 
 	// determine which pod volume this is associated with

--- a/pkg/rotation/stats_reporter.go
+++ b/pkg/rotation/stats_reporter.go
@@ -30,11 +30,14 @@ const (
 )
 
 var (
-	providerKey = "provider"
-	errorKey    = "error_type"
-	osTypeKey   = "os_type"
-	rotatedKey  = "rotated"
-	runtimeOS   = runtime.GOOS
+	providerKey     = "provider"
+	errorKey        = "error_type"
+	osTypeKey       = "os_type"
+	rotatedKey      = "rotated"
+	runtimeOS       = runtime.GOOS
+	podNameKey      = "pod_name"
+	podNamespaceKey = "pod_namespace"
+	spcKey          = "secret_provider_class"
 )
 
 type reporter struct {
@@ -44,8 +47,8 @@ type reporter struct {
 }
 
 type StatsReporter interface {
-	reportRotationCtMetric(ctx context.Context, provider string, wasRotated bool)
-	reportRotationErrorCtMetric(ctx context.Context, provider, errType string, wasRotated bool)
+	reportRotationCtMetric(ctx context.Context, provider, podName, podNamespace, spc string, wasRotated bool)
+	reportRotationErrorCtMetric(ctx context.Context, provider, podName, podNamespace, spc, errType string, wasRotated bool)
 	reportRotationDuration(ctx context.Context, duration float64)
 }
 
@@ -67,21 +70,27 @@ func newStatsReporter() (StatsReporter, error) {
 	return r, nil
 }
 
-func (r *reporter) reportRotationCtMetric(ctx context.Context, provider string, wasRotated bool) {
+func (r *reporter) reportRotationCtMetric(ctx context.Context, provider, podName, podNamespace, spc string, wasRotated bool) {
 	opt := metric.WithAttributes(
 		attribute.Key(providerKey).String(provider),
 		attribute.Key(osTypeKey).String(runtimeOS),
 		attribute.Key(rotatedKey).Bool(wasRotated),
+		attribute.Key(podNameKey).String(podName),
+		attribute.Key(podNamespaceKey).String(podNamespace),
+		attribute.Key(spcKey).String(spc),
 	)
 	r.rotationReconcileTotal.Add(ctx, 1, opt)
 }
 
-func (r *reporter) reportRotationErrorCtMetric(ctx context.Context, provider, errType string, wasRotated bool) {
+func (r *reporter) reportRotationErrorCtMetric(ctx context.Context, provider, podName, podNamespace, spc, errType string, wasRotated bool) {
 	opt := metric.WithAttributes(
 		attribute.Key(providerKey).String(provider),
 		attribute.Key(errorKey).String(errType),
 		attribute.Key(osTypeKey).String(runtimeOS),
 		attribute.Key(rotatedKey).Bool(wasRotated),
+		attribute.Key(podNameKey).String(podName),
+		attribute.Key(podNamespaceKey).String(podNamespace),
+		attribute.Key(spcKey).String(spc),
 	)
 	r.rotationReconcileErrorTotal.Add(ctx, 1, opt)
 }

--- a/pkg/secrets-store/mocks/stats_reporter_mock.go
+++ b/pkg/secrets-store/mocks/stats_reporter_mock.go
@@ -18,41 +18,55 @@ package mocks // import sigs.k8s.io/secrets-store-csi-driver/pkg/secrets-store/m
 
 import "context"
 
+type MetricDetails struct {
+	Provider     string
+	PodName      string
+	PodNamespace string
+	Spc          string
+	ErrorType    string
+}
+
 type FakeReporter struct {
 	reportNodePublishCtMetricInvoked        int
 	reportNodeUnPublishCtMetricInvoked      int
 	reportNodePublishErrorCtMetricInvoked   int
 	reportNodeUnPublishErrorCtMetricInvoked int
-	reportSyncK8SecretCtMetricInvoked       int
-	reportSyncK8SecretDurationInvoked       int
+	metricDetails                           []MetricDetails
 }
 
 func NewFakeReporter() *FakeReporter {
-	return &FakeReporter{}
+	return &FakeReporter{
+		metricDetails: []MetricDetails{},
+	}
 }
 
-func (f *FakeReporter) ReportNodePublishCtMetric(ctx context.Context, provider string) {
+func (f *FakeReporter) ReportNodePublishCtMetric(ctx context.Context, provider, podName, podNamespace, spc string) {
 	f.reportNodePublishCtMetricInvoked++
+	f.metricDetails = append(f.metricDetails, MetricDetails{
+		Provider:     provider,
+		PodName:      podName,
+		PodNamespace: podNamespace,
+		Spc:          spc,
+	})
 }
 
 func (f *FakeReporter) ReportNodeUnPublishCtMetric(ctx context.Context) {
 	f.reportNodeUnPublishCtMetricInvoked++
 }
 
-func (f *FakeReporter) ReportNodePublishErrorCtMetric(ctx context.Context, provider, errType string) {
+func (f *FakeReporter) ReportNodePublishErrorCtMetric(ctx context.Context, provider, podName, podNamespace, spc, errType string) {
 	f.reportNodePublishErrorCtMetricInvoked++
+	f.metricDetails = append(f.metricDetails, MetricDetails{
+		Provider:     provider,
+		PodName:      podName,
+		PodNamespace: podNamespace,
+		Spc:          spc,
+		ErrorType:    errType,
+	})
 }
 
 func (f *FakeReporter) ReportNodeUnPublishErrorCtMetric(ctx context.Context) {
 	f.reportNodeUnPublishErrorCtMetricInvoked++
-}
-
-func (f *FakeReporter) ReportSyncK8SecretCtMetric(ctx context.Context, provider string, count int) {
-	f.reportSyncK8SecretCtMetricInvoked++
-}
-
-func (f *FakeReporter) ReportSyncK8SecretDuration(ctx context.Context, duration float64) {
-	f.reportSyncK8SecretDurationInvoked++
 }
 
 func (f *FakeReporter) ReportNodePublishCtMetricInvoked() int {
@@ -67,9 +81,7 @@ func (f *FakeReporter) ReportNodePublishErrorCtMetricInvoked() int {
 func (f *FakeReporter) ReportNodeUnPublishErrorCtMetricInvoked() int {
 	return f.reportNodeUnPublishErrorCtMetricInvoked
 }
-func (f *FakeReporter) ReportSyncK8SecretCtMetricInvoked() int {
-	return f.reportSyncK8SecretCtMetricInvoked
-}
-func (f *FakeReporter) ReportSyncK8SecretDurationInvoked() int {
-	return f.reportSyncK8SecretDurationInvoked
+
+func (f *FakeReporter) GetMetricDetails() []MetricDetails {
+	return f.metricDetails
 }

--- a/pkg/secrets-store/nodeserver.go
+++ b/pkg/secrets-store/nodeserver.go
@@ -73,7 +73,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	startTime := time.Now()
 	var parameters map[string]string
 	var providerName string
-	var podName, podNamespace, podUID, serviceAccountName string
+	var podName, podNamespace, podUID, serviceAccountName, secretProviderClass string
 	var targetPath string
 	var mounted bool
 	errorReason := internalerrors.FailedToMount
@@ -89,10 +89,10 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 					klog.ErrorS(unmountErr, "failed to unmounting target path")
 				}
 			}
-			ns.reporter.ReportNodePublishErrorCtMetric(ctx, providerName, errorReason)
+			ns.reporter.ReportNodePublishErrorCtMetric(ctx, providerName, podName, podNamespace, secretProviderClass, errorReason)
 			return
 		}
-		ns.reporter.ReportNodePublishCtMetric(ctx, providerName)
+		ns.reporter.ReportNodePublishCtMetric(ctx, providerName, podName, podNamespace, secretProviderClass)
 	}()
 
 	// Check arguments
@@ -115,7 +115,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	mountFlags := req.GetVolumeCapability().GetMount().GetMountFlags()
 	secrets := req.GetSecrets()
 
-	secretProviderClass := attrib[secretProviderClassField]
+	secretProviderClass = attrib[secretProviderClassField]
 	providerName = attrib["providerName"]
 	podName = attrib[CSIPodName]
 	podNamespace = attrib[CSIPodNamespace]

--- a/test/bats/e2e-provider.bats
+++ b/test/bats/e2e-provider.bats
@@ -426,6 +426,7 @@ export VALIDATE_TOKENS_AUDIENCE=$(get_token_requests_audience)
     assert_match "node_publish_total" "${output}"
     assert_match "node_unpublish_total" "${output}"
     assert_match "rotation_reconcile_total" "${output}"
+    assert_match "sync_k8s_secret_total" "${output}"
   done
   # keeping metrics ns in upgrade tests has no relevance
   # the namespace is only to run a curl pod to validate metrics


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind feature
/kind documentation

**What this PR does / why we need it**:
 - Adds additional labels pod_name, pod_namespace and secret_provider_class to the existing metrics.
 - Fixes documentation about current metrics

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1344 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
This PR contains the minor refinements suggested in the review of #1433. 
Original work credit goes to @Suraiya-Hameed.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
