### PR TITLE
Add s390x to build automation

### DIFF
--- a/docker/BASEIMAGE
+++ b/docker/BASEIMAGE
@@ -1,4 +1,5 @@
 linux/amd64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.4
 linux/arm64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.4
+linux/s390x=registry.k8s.io/build-image/debian-base:bookworm-v1.0.4
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
-->

**What this PR does / why we need it**:
This PR adds building the s390x image to the current build automation. Currently, the build automation is only for amd64 and arm.
**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #
#1683 
<!--
**Is this a chart or deployment yaml update?**
No
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
