### PR TITLE
WIP: helm: add support to override securityContext

### DIFF
--- a/.local/debug-driver.yaml
+++ b/.local/debug-driver.yaml
@@ -41,6 +41,14 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
         - name: liveness-probe
           image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0
           imagePullPolicy: IfNotPresent
@@ -59,6 +67,14 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
       volumes:
         - name: mountpoint-dir
           hostPath:
@@ -118,6 +134,14 @@ spec:
             requests:
               cpu: 250m
               memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
       volumes:
         - name: driver-volume
           persistentVolumeClaim:

--- a/deploy/secrets-store-csi-driver-windows.yaml
+++ b/deploy/secrets-store-csi-driver-windows.yaml
@@ -35,6 +35,14 @@ spec:
             requests:
               cpu: 100m
               memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
         - name: secrets-store
           image: registry.k8s.io/csi-secrets-store/driver:v1.4.7
           args:
@@ -84,6 +92,14 @@ spec:
               mountPath: "C:\\var\\lib\\kubelet\\pods"
             - name: providers-dir
               mountPath: C:\k\secrets-store-csi-providers
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
         - name: liveness-probe
           image: registry.k8s.io/sig-storage/livenessprobe:v2.13.1
           imagePullPolicy: IfNotPresent
@@ -102,6 +118,14 @@ spec:
             requests:
               cpu: 100m
               memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
       volumes:
         - name: mountpoint-dir
           hostPath:

--- a/deploy/secrets-store-csi-driver.yaml
+++ b/deploy/secrets-store-csi-driver.yaml
@@ -35,6 +35,14 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
         - name: secrets-store
           image: registry.k8s.io/csi-secrets-store/driver:v1.4.7
           args:
@@ -90,6 +98,14 @@ spec:
             requests:
               cpu: 50m
               memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
         - name: liveness-probe
           image: registry.k8s.io/sig-storage/livenessprobe:v2.13.1
           imagePullPolicy: IfNotPresent
@@ -108,6 +124,14 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
       volumes:
         - name: mountpoint-dir
           hostPath:

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver-windows.yaml
@@ -53,6 +53,10 @@ spec:
               mountPath: C:\csi
             - name: registration-dir
               mountPath: C:\registration
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
 {{- with .Values.windows.registrar.resources }}
           resources:
 {{ toYaml . | indent 12 }}
@@ -134,6 +138,10 @@ spec:
             {{- if .Values.windows.volumeMounts }}
               {{- toYaml .Values.windows.volumeMounts | nindent 12 }}
             {{- end }}
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
 {{- with .Values.windows.driver.resources }}
           resources:
 {{ toYaml . | indent 12 }}
@@ -153,12 +161,20 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: C:\csi
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
 {{- with .Values.windows.livenessProbe.resources }}
           resources:
 {{ toYaml . | indent 12 }}
 {{- end }}
       {{- if .Values.windows.priorityClassName }}
       priorityClassName: {{ .Values.windows.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
       volumes:
         - name: mountpoint-dir

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/secrets-store-csi-driver.yaml
@@ -53,6 +53,10 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
 {{- with .Values.linux.registrar.resources }}
           resources:
 {{ toYaml . | indent 12 }}
@@ -137,6 +141,10 @@ spec:
             {{- if .Values.linux.volumeMounts }}
               {{- toYaml .Values.linux.volumeMounts | nindent 12 }}
             {{- end }}
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
 {{- with .Values.linux.driver.resources }}
           resources:
 {{ toYaml . | indent 12 }}
@@ -156,12 +164,20 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
 {{- with .Values.linux.livenessProbe.resources }}
           resources:
 {{ toYaml . | indent 12 }}
 {{- end }}
       {{- if .Values.linux.priorityClassName }}
       priorityClassName: {{ .Values.linux.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
       volumes:
         - name: mountpoint-dir

--- a/manifest_staging/charts/secrets-store-csi-driver/values.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/values.yaml
@@ -13,7 +13,8 @@ linux:
       tag: v1.4.7
       pullPolicy: IfNotPresent
     ## Optionally override resource limits for crd hooks(jobs)
-    resources: {}
+    resources:
+      {}
       # requests:
       #   cpu: "100m"
       #   memory: "128Mi"
@@ -242,3 +243,17 @@ tokenRequests: []
 # -- Labels to apply to all resources
 commonLabels: {}
 # team_name: dev
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# podSecurityContext -- [Security context for Pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+podSecurityContext:
+  # fsGroup: 1000


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Adds `securityContext` and `podSecurityContext` to `values.yaml`.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
I'm not expert on Helm templates, so this is initial attempt to pass `securityContext` to Helm manifest to see if the CI will be happy. Feel free to take over this PR.


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
