### PR TITLE
feat: Add VolumeID to Mount request

### DIFF
--- a/docs/book/src/providers.md
+++ b/docs/book/src/providers.md
@@ -35,6 +35,18 @@ The driver uses gRPC to communicate with the provider. To implement a secrets-st
 
 See [design doc](https://docs.google.com/document/d/10-RHUJGM0oMN88AZNxjOmGz0NsWAvOYrWUEV-FbLWyw/edit?usp=sharing) for more details.
 
+The `MountRequest` message structure includes several additional keys in the `Attributes` field that a provider can use when retrieving a secret. Keys beginning with `csi.storage.k8s.io` are [passed through from the Kubelet](https://kubernetes-csi.github.io/docs/pod-info.html?highlight=pod.name#pod-info-on-mount-with-csi-driver-object) if `podInfoOnMount` is `true` on the CSI driver.
+
+| Attribute Key | Description |
+| --- | ---- |
+| `csi.storage.k8s.io/pod-name` | Pod name |
+| `csi.storage.k8s.io/pod.namespace` | Pod namespace  |
+| `csi.storage.k8s.io/pod.uid` | Pod UID |
+| `csi.storage.k8s.io/serviceAccount.name` | The Pod's ServiceAccount name |
+| `csi.storage.k8s.io/serviceAccount.tokens` | A JSON structure serialized to a string containing service account tokens belonging to a pod [when a CSI driver has `tokenRequests` configured](https://kubernetes-csi.github.io/docs/token-requests.html).  |
+| `secrets-store-csi-driver.sigs.k8s.io/volume.id` | The CSI Volume's ID from the `NodePublishVolumeRequest` call. This may be useful as a cache key if using Service Account tokens to fetch secrets. |
+
+
 ## Features supported by current providers
 
 | Features \ Providers      | Azure | GCP | AWS | Vault | Akeyless | Conjur |

--- a/pkg/secrets-store/nodeserver.go
+++ b/pkg/secrets-store/nodeserver.go
@@ -65,6 +65,8 @@ const (
 	// CSIPodServiceAccountTokens is the service account tokens of the pod that the mount is created for
 	CSIPodServiceAccountTokens = "csi.storage.k8s.io/serviceAccount.tokens" //nolint
 
+	SecretStoreVolumeID = "secrets-store-csi-driver.sigs.k8s.io/volume.id"
+
 	secretProviderClassField = "secretProviderClass"
 )
 
@@ -181,6 +183,8 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	for k, v := range attrib {
 		parameters[k] = v
 	}
+	// Add the volume ID to the parameters
+	parameters[SecretStoreVolumeID] = volumeID
 	// csi.storage.k8s.io/serviceAccount.tokens is empty for Kubernetes version < 1.20.
 	// For 1.20+, if tokenRequests is set in the CSI driver spec, kubelet will generate
 	// a token for the pod and send it to the CSI driver.

--- a/test/e2eprovider/e2e_provider.go
+++ b/test/e2eprovider/e2e_provider.go
@@ -78,6 +78,7 @@ func mainErr() error {
 
 		http.HandleFunc("/rotation", server.RotationHandler)
 		http.HandleFunc("/validate-token-requests", server.ValidateTokenAudienceHandler)
+		http.HandleFunc("/validate-volume-id", server.VolumeIDHandler)
 
 		server := &http.Server{
 			Addr:              ":8080",

--- a/test/e2eprovider/server/server.go
+++ b/test/e2eprovider/server/server.go
@@ -186,8 +186,10 @@ func (s *Server) Mount(ctx context.Context, req *v1alpha1.MountRequest) (*v1alph
 		}
 	}
 
-	if err := validateVolumeIDAttr(attrib); err != nil {
-		return nil, fmt.Errorf("failed to validate volume ID, error: %w", err)
+	if _, ok := os.LookupEnv("VALIDATE_VOLUME_ID"); ok {
+		if err := validateVolumeIDAttr(attrib); err != nil {
+			return nil, fmt.Errorf("failed to validate volume ID, error: %w", err)
+		}
 	}
 
 	m.Lock()
@@ -249,6 +251,12 @@ func ValidateTokenAudienceHandler(w http.ResponseWriter, r *http.Request) {
 	// enable rotation response
 	os.Setenv("VALIDATE_TOKENS_AUDIENCE", r.FormValue("audience"))
 	klog.InfoS("Validation for token requests audience", "audience", os.Getenv("VALIDATE_TOKENS_AUDIENCE"))
+}
+
+// VolumeIDHandler enables volume ID for the mock provider
+func VolumeIDHandler(w http.ResponseWriter, r *http.Request) {
+	os.Setenv("VALIDATE_VOLUME_ID", "true")
+	klog.InfoS("Volume ID validation enabled")
 }
 
 // validateTokens checks there are tokens for distinct audiences in the


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds the VolumeID to the request so providers can make smarter caching decisions once `requiresRepublish` is implemented.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1754

**Special notes for your reviewer**:

I opted to name the key with the DNS namespace for this project as there isn't a corresponding CSI key I could find in the Kubernetes codebase (the volume ID is just an attribute of the request, not an encoded key). Let me know if there is a better key name to use

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
