### PR TITLE
chore: move tam7t to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,11 @@
 approvers:
 - aramase
 - ritazh
-- tam7t
 
 reviewers:
 - aramase
 - nilekhc
 - ritazh
+
+emeritus_approvers:
 - tam7t


### PR DESCRIPTION
Move @tam7t to `emeritus_approvers`. Thank you for all the work on the project! 