### PR TITLE
ci: use ubuntu-latest for gh workflows

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   create-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0


### PR DESCRIPTION
Ubuntu 20.04 LTS runner was be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101.