### PR TITLE
chore: update debian-base to bookworm-v1.0.5

### DIFF
--- a/docker/BASEIMAGE
+++ b/docker/BASEIMAGE
@@ -1,5 +1,5 @@
-linux/amd64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.4
-linux/arm64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.4
+linux/amd64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.5
+linux/arm64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.5
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022
 windows/amd64/ltsc2025=mcr.microsoft.com/windows/nanoserver:ltsc2025

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.4
+ARG BASEIMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.5
 
 FROM golang:1.23.10@sha256:dd5cc4b4f85d13329cb5b17cbf35c509e1c82a43bf6e5961516fda444013121a AS builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver


### PR DESCRIPTION
Cherry pick of #1853 on release-1.5.

#1853: chore: update debian-base to bookworm-v1.0.5

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.