### PR TITLE
chore: update to go 1.24.7 and bump base image

### DIFF
--- a/docker/BASEIMAGE
+++ b/docker/BASEIMAGE
@@ -1,5 +1,5 @@
-linux/amd64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.5
-linux/arm64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.5
+linux/amd64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.6
+linux/arm64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.6
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022
 windows/amd64/ltsc2025=mcr.microsoft.com/windows/nanoserver:ltsc2025

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.5
+ARG BASEIMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.6
 
 FROM golang:1.24.7@sha256:87916acb3242b6259a26deaa7953bdc6a3a6762a28d340e4f1448e7b5c27c009 AS builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG BASEIMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.5
 
-FROM golang:1.23.10@sha256:dd5cc4b4f85d13329cb5b17cbf35c509e1c82a43bf6e5961516fda444013121a AS builder
+FROM golang:1.24.7@sha256:87916acb3242b6259a26deaa7953bdc6a3a6762a28d340e4f1448e7b5c27c009 AS builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver
 ADD . .
 ARG TARGETARCH

--- a/docker/crd.Dockerfile
+++ b/docker/crd.Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM alpine as builder
-ARG KUBE_VERSION=v1.29.11
+ARG KUBE_VERSION=v1.34.1
 ARG TARGETARCH
 
 RUN apk add --no-cache curl && \

--- a/docker/windows.Dockerfile
+++ b/docker/windows.Dockerfile
@@ -17,7 +17,7 @@ ARG BASEIMAGE_CORE=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1
 
 FROM --platform=linux/amd64 ${BASEIMAGE_CORE} AS core
 
-FROM --platform=$BUILDPLATFORM golang:1.23.10@sha256:dd5cc4b4f85d13329cb5b17cbf35c509e1c82a43bf6e5961516fda444013121a AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.7@sha256:87916acb3242b6259a26deaa7953bdc6a3a6762a28d340e4f1448e7b5c27c009 AS builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver
 ADD . .
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/secrets-store-csi-driver
 
-go 1.23.10
+go 1.24.7
 
 require (
 	github.com/container-storage-interface/spec v1.6.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/secrets-store-csi-driver/hack/tools
 
-go 1.24.2
+go 1.24.7
 
 require (
 	github.com/golangci/golangci-lint v1.64.8

--- a/test/e2eprovider/Dockerfile
+++ b/test/e2eprovider/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23.10@sha256:dd5cc4b4f85d13329cb5b17cbf35c509e1c82a43bf6e5961516fda444013121a as builder
+FROM golang:1.24.7@sha256:87916acb3242b6259a26deaa7953bdc6a3a6762a28d340e4f1448e7b5c27c009 as builder
 WORKDIR /go/src/sigs.k8s.io/secrets-store-csi-driver
 ADD . .
 RUN make build-e2e-provider

--- a/test/e2eprovider/go.mod
+++ b/test/e2eprovider/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/secrets-store-csi-driver/test/e2eprovider
 
-go 1.23.10
+go 1.24.7
 
 replace sigs.k8s.io/secrets-store-csi-driver => ../..
 


### PR DESCRIPTION
Cherry pick of #1915 on release-1.5.

#1915: chore: update to go 1.24.7

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.