### PR TITLE
test: add e2e for Fortanix CSI provider

### DIFF
--- a/test/bats/fortanix.bats
+++ b/test/bats/fortanix.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+
+load helpers
+
+BATS_TESTS_DIR=tests/fortanix
+WAIT_TIME=120
+SLEEP_TIME=1
+PROVIDER_YAML=https://raw.githubusercontent.com/fortanix/fortanix-csi-provider/main/deployment/fortanix-csi-provider.yaml
+NAMESPACE=kube-system
+export FORTANIX_SECRET_VALUE=${FORTANIX_SECRET_VALUE:-"test-value"}
+
+setup() {
+  if [[ -z "${FORTANIX_API_KEY}" ]]; then
+    echo "Error: Fortanix API Key is not provided" >&2
+    return 1
+  fi
+  if [[ -z "${FORTANIX_DSM_ENDPOINT}" ]]; then
+    echo "Error: Fortanix DSM Endpoint is not provided" >&2
+    return 1
+  fi
+  if [[ -z "${FORTANIX_SECRET_NAME}" ]]; then
+    echo "Error: Fortanix Secret Name is not provided" >&2
+    return 1
+  fi
+}
+
+@test "install fortanix csi provider" {
+  run kubectl apply -f $PROVIDER_YAML
+  assert_success
+
+  kubectl --namespace $NAMESPACE wait --for=condition=Ready --timeout=120s pod -l app=fortanix-csi-provider
+
+  PROVIDER_POD=$(kubectl --namespace $NAMESPACE get pod -l app=fortanix-csi-provider -o jsonpath="{.items[0].metadata.name}")
+  run kubectl --namespace $NAMESPACE get pod/$PROVIDER_POD
+  assert_success
+}
+
+@test "create fortanix api key secret" {
+  # Delete existing secret if it exists
+  kubectl delete secret fortanix-api-key -n $NAMESPACE --ignore-not-found=true
+  run kubectl create secret generic fortanix-api-key --from-literal=api-key=${FORTANIX_API_KEY} -n $NAMESPACE
+  assert_success
+}
+
+@test "secretproviderclasses crd is established" {
+  kubectl wait --for condition=established --timeout=${WAIT_TIME}s crd/secretproviderclasses.secrets-store.csi.x-k8s.io
+
+  run kubectl get crd/secretproviderclasses.secrets-store.csi.x-k8s.io
+  assert_success
+}
+
+@test "deploy fortanix secretproviderclass crd" {
+  envsubst < $BATS_TESTS_DIR/secretproviderclass.yaml | kubectl apply -f -
+
+  cmd="kubectl get secretproviderclasses.secrets-store.csi.x-k8s.io/fortanix-test -o yaml | grep fortanix-csi-provider"
+  wait_for_process $WAIT_TIME $SLEEP_TIME "$cmd"
+}
+
+@test "CSI inline volume test with pod portability" {
+  envsubst < $BATS_TESTS_DIR/pod-inline-volume-secretproviderclass.yaml | kubectl apply -f -
+
+  # wait for pod to be running
+  kubectl wait --for=condition=Ready --timeout=${WAIT_TIME}s pod/secrets-store-inline
+
+  run kubectl get pod/secrets-store-inline
+  assert_success
+}
+
+@test "CSI inline volume test with pod portability - read fortanix secret from pod" {
+  result=$(kubectl exec secrets-store-inline -- cat /mnt/secrets-store/$FORTANIX_SECRET_NAME)
+  [[ "${result}" == "$FORTANIX_SECRET_VALUE" ]]
+}
+
+@test "CSI inline volume test with pod portability - unmount" {
+  # On Linux a failure to unmount the tmpfs will block the pod from being deleted.
+  run kubectl delete pod secrets-store-inline
+  assert_success
+
+  run kubectl wait --for=delete --timeout=${WAIT_TIME}s pod/secrets-store-inline
+
+  # Sleep to allow time for logs to propagate.
+  sleep 10
+
+  # save debug information to archive in case of failure
+  archive_info
+
+  run bash -c "kubectl logs -l app=secrets-store-csi-driver --tail -1 -c secrets-store -n kube-system | grep '^E.*failed to clean and unmount target path.*$'"
+  assert_failure
+}
+
+teardown_file() {
+  archive_provider "app=fortanix-csi-provider" || true
+  archive_info || true
+}

--- a/test/bats/tests/fortanix/pod-inline-volume-secretproviderclass.yaml
+++ b/test/bats/tests/fortanix/pod-inline-volume-secretproviderclass.yaml
@@ -1,0 +1,23 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: secrets-store-inline
+spec:
+  containers:
+  - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
+    name: busybox
+    imagePullPolicy: IfNotPresent
+    command:
+    - "/bin/sleep"
+    - "10000"
+    volumeMounts:
+    - name: secrets-store-inline
+      mountPath: "/mnt/secrets-store"
+      readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: fortanix-test

--- a/test/bats/tests/fortanix/secretproviderclass.yaml
+++ b/test/bats/tests/fortanix/secretproviderclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: fortanix-test
+spec:
+  provider: fortanix-csi-provider
+  parameters:
+    dsmEndpoint: "$FORTANIX_DSM_ENDPOINT"
+    objects: |
+      - secretName: "$FORTANIX_SECRET_NAME"


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
/kind feature
/kind test

**What this PR does / why we need it**:
This PR adds an e2e Bats test suite for the new **Fortanix Secret Store CSI Provider** integration.

The test covers:
- Installation of the Fortanix CSI provider using the upstream deployment manifest
- Validation of SecretProviderClass creation referencing Fortanix DSM
- Verification that secrets from Fortanix DSM are mounted successfully into a test pod
- Basic cleanup and teardown steps to ensure the provider, SecretProviderClass, and API key secret are deleted cleanly after test completion

These tests are modeled after existing provider test suites (e.g., AWS, Azure, Vault) and ensure compatibility of the Fortanix provider with the `secrets-store-csi-driver` e2e test harness.

**Which issue(s) this PR fixes**:
Fixes #<issue-number-if-any>

**Is this a chart or deployment yaml update?**
No, this PR only adds test files under `test/bats/` to include Fortanix provider validation.

**Special notes for your reviewer**:
- The Fortanix provider manifest is referenced from its official GitHub repository.
- Tests require the following environment variables to be set prior to execution:
  - `FORTANIX_API_KEY`
  - `FORTANIX_DSM_ENDPOINT`
  - `FORTANIX_TEST_SECRET_NAME`
- Verified against Kubernetes v1.30 and `secrets-store-csi-driver` v1.4.1.

**TODOs**:
- [x] Added new Fortanix provider e2e test
- [x] Verified successful run on kind/minikube
- [ ] Update provider documentation with test instructions
- [x] (optional) Integrate into CI test matrix once provider image is public
