### PR TITLE
Add Bitwarden Secrets Manager provider

### DIFF
--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -48,6 +48,7 @@ These features are not stable. If you use these be sure to consult the
 - [Akeyless Provider](https://github.com/akeylesslabs/akeyless-csi-provider)
 - [AWS Provider](https://github.com/aws/secrets-store-csi-driver-provider-aws)
 - [Azure Provider](https://azure.github.io/secrets-store-csi-driver-provider-azure/)
+- [Bitwarden Provider](https://github.com/kvncrw/bitwarden-csi-provider)
 - [Conjur Provider](https://github.com/cyberark/conjur-k8s-csi-provider)
 - [GCP Provider](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp)
 - [OpenBao Provider](https://github.com/openbao/openbao-csi-provider)

--- a/docs/book/src/providers.md
+++ b/docs/book/src/providers.md
@@ -37,9 +37,9 @@ See [design doc](https://docs.google.com/document/d/10-RHUJGM0oMN88AZNxjOmGz0NsW
 
 ## Features supported by current providers
 
-| Features \ Providers      | Azure | GCP | AWS | Vault | Akeyless | Conjur | OpenBao |
-| ------------------------- | ----- | --- | --- | ----- | -------- | ------ | ------- |
-| Sync as Kubernetes secret | Yes   | Yes | Yes | Yes   | Yes      | Yes    | Yes     |
-| Rotation                  | Yes   | Yes | Yes | Yes   | Yes      | Yes    | Yes     |
-| Windows                   | Yes   | No  | No  | No    | No       | No     | No      |
-| Helm Chart                | Yes   | No  | Yes | Yes   | Yes      | Yes    | Yes     |
+| Features \ Providers      | Azure | GCP | AWS | Vault | Akeyless | Bitwarden | Conjur | OpenBao |
+| ------------------------- | ----- | --- | --- | ----- | -------- | --------- | ------ | ------- |
+| Sync as Kubernetes secret | Yes   | Yes | Yes | Yes   | Yes      | Yes       | Yes    | Yes     |
+| Rotation                  | Yes   | Yes | Yes | Yes   | Yes      | No        | Yes    | Yes     |
+| Windows                   | Yes   | No  | No  | No    | No       | No        | No     | No      |
+| Helm Chart                | Yes   | No  | Yes | Yes   | Yes      | Yes       | Yes    | Yes     |


### PR DESCRIPTION
## Summary

This PR adds the [Bitwarden Secrets Manager CSI Provider](https://github.com/kvncrw/bitwarden-csi-provider) to the list of supported providers.

The provider implements the `v1alpha1` gRPC provider protocol and enables Kubernetes workloads to mount secrets from [Bitwarden Secrets Manager](https://bitwarden.com/products/secrets-manager/) via the Secrets Store CSI Driver.

### Provider details

- **Repository**: https://github.com/kvncrw/bitwarden-csi-provider
- **Language**: Rust
- **Installation**: Helm chart included
- **Supported features**: Sync as Kubernetes secret, Helm chart
- **Not yet supported**: Rotation, Windows

### Changes in this PR

- `docs/book/src/introduction.md` — Added Bitwarden Provider link to the Supported Providers list
- `docs/book/src/providers.md` — Added Bitwarden column to the feature comparison table

### Note

e2e tests for the Bitwarden provider will be added in a follow-up PR.