### PR TITLE
chore: update project ownership and move ritazh to emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,16 @@
 approvers:
 - aramase
-- ritazh
+- enj
 
 reviewers:
 - aramase
-- ritazh
+- enj
 
 emeritus_approvers:
+- ritazh
 - tam7t
 
 emeritus_reviewers:
 - nilekhc
+- ritazh
 - tam7t

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -10,5 +10,5 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-ritazh
 aramase
+enj

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,6 @@ RUN apt update && \
     apt upgrade -y && \
     clean-install ca-certificates mount
 
-LABEL maintainers="ritazh"
 LABEL description="Secrets Store CSI Driver"
 
 ENTRYPOINT ["/secrets-store-csi"]

--- a/docs/book/OWNERS
+++ b/docs/book/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-reviewers:
-- aramase
-- ritazh

--- a/manifest_staging/charts/secrets-store-csi-driver/Chart.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/Chart.yaml
@@ -7,6 +7,3 @@ description: A Helm chart to install the SecretsStore CSI Driver inside a Kubern
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 sources:
   - https://github.com/kubernetes-sigs/secrets-store-csi-driver
-maintainers:
-  - name: Rita Zhang
-    email: ritazh@microsoft.com

--- a/test/e2eprovider/Dockerfile
+++ b/test/e2eprovider/Dockerfile
@@ -20,7 +20,6 @@ RUN make build-e2e-provider
 FROM gcr.io/distroless/static
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/test/e2eprovider/e2e-provider /e2e-provider
 
-LABEL maintainers="nilekhc"
 LABEL description="Mock provider for Secrets Store CSI Driver"
 
 ENTRYPOINT ["/e2e-provider"]


### PR DESCRIPTION
- Move @ritazh to `emeritus_approvers`. Thank you for all the work on the project! ❤️ 
- Add @enj to project owners.

/kind cleanup
/triage accepted
/assign @enj 