### PR TITLE
ci: fix govulncheck tools step with doc.go

### DIFF
--- a/hack/tools/doc.go
+++ b/hack/tools/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package tools tracks tool dependencies for this project.
+package tools


### PR DESCRIPTION
Fix govulncheck CI failure for `hack/tools` by running govulncheck directly with `-tags tools` since the action doesn't support build tags and `tools.go` uses a `//go:build tools` constraint.

/kind failing-test
/triage accepted