### PR TITLE
chore: bump version to v1.6.0 in release-1.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ E2E_PROVIDER_IMAGE_NAME ?= e2e-provider
 
 # Release version is the current supported release for the driver
 # Update this version when the helm chart is being updated for release
-RELEASE_VERSION := v1.5.6
-IMAGE_VERSION ?= v1.5.6
+RELEASE_VERSION := v1.6.0
+IMAGE_VERSION ?= v1.6.0
 
 # Use a custom version for E2E tests if we are testing in CI
 ifdef CI

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,7 +15,7 @@
 REGISTRY?=docker.io/deislabs
 IMAGE_NAME=driver
 CRD_IMAGE_NAME=driver-crds
-IMAGE_VERSION?=v1.5.6
+IMAGE_VERSION?=v1.6.0
 BUILD_TIMESTAMP := $(shell date +%Y-%m-%d-%H:%M)
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION
/kind cleanup
/triage accepted
/assign enj