### PR TITLE
chore: bump version to v1.6.0 in release-1.6 (part 2)

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REGISTRY?=docker.io/deislabs
+REGISTRY?=gcr.io/k8s-staging-csi-secrets-store
 IMAGE_NAME=driver
 CRD_IMAGE_NAME=driver-crds
 IMAGE_VERSION?=v1.6.0

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -13,7 +13,7 @@ options:
   # job builds a multi-arch docker image for amd64,arm64 and windows 1809, 1903, 1909, 2004.
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f'
     entrypoint: bash
     dir: ./docker
     env:


### PR DESCRIPTION
/kind cleanup
/triage accepted

no-op change to trigger image-pushing postsubmit job. 
xref: https://kubernetes.slack.com/archives/C7J9RP96G/p1776964686489009