### PR TITLE
ci: fix cloud build image publishing

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -100,7 +100,7 @@ build_and_push() {
 
     # NOTE(claudiub): docker buildx works for Windows images as long as it doesn't have to
     # execute RUN commands inside the Windows image.
-    docker buildx build --no-cache --pull --push --platform "${os_name}/${arch}" -t "${IMAGE_TAG}-${suffix}" \
+    docker buildx build --no-cache --pull --push --provenance=false --sbom=false --platform "${os_name}/${arch}" -t "${IMAGE_TAG}-${suffix}" \
       --build-arg BASEIMAGE="${BASEIMAGE}" --build-arg BASEIMAGE_CORE="${BASEIMAGE_CORE}" \
       --build-arg TARGETARCH="${arch}" --build-arg TARGETOS="${os_name}" --build-arg LDFLAGS="${LDFLAGS}" \
       --build-arg IMAGE_VERSION="${IMAGE_VERSION}" \
@@ -111,7 +111,7 @@ build_and_push() {
     # charts to prod dir. So we can use manifest_staging charts for the image build.
     if find ../manifest_staging/charts/secrets-store-csi-driver/crds -mindepth 1 -maxdepth 1 | read -r; then
       if [[ "$os_name" != "windows" ]]; then
-        docker buildx build --no-cache --pull --push --platform "${os_name}/${arch}" -t "${CRD_IMAGE_TAG}-${suffix}" \
+        docker buildx build --no-cache --pull --push --provenance=false --sbom=false --platform "${os_name}/${arch}" -t "${CRD_IMAGE_TAG}-${suffix}" \
         -f crd.Dockerfile ../manifest_staging/charts/secrets-store-csi-driver/crds
       fi
     fi

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -13,7 +13,7 @@ options:
   # job builds a multi-arch docker image for amd64,arm64 and windows 1809, 1903, 1909, 2004.
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f'
     entrypoint: bash
     dir: ./docker
     env:


### PR DESCRIPTION
this is a cherry-pick of the 2 commits that were merged in `release-1.6` to fix the build at the time of v1.6 release.

/kind cleanup
/triage accepted
/assign @enj 