### PR TITLE
docs: correct metric names in topics/metrics.md to match exported Prometheus names

### DIFF
--- a/docs/book/src/topics/metrics.md
+++ b/docs/book/src/topics/metrics.md
@@ -6,16 +6,18 @@ Prometheus is the only exporter that's currently supported with the driver.
 
 ## List of metrics provided by the driver
 
+> **Note:** The OpenTelemetry Prometheus exporter appends a `_total` suffix to counter instruments (see [open-telemetry/opentelemetry-go#3360](https://github.com/open-telemetry/opentelemetry-go/pull/3360)). The names below are the names as they appear on the `/metrics` endpoint.
+
 | Metric                          | Description                                                               | Tags                                                                              |
 | ------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| total_node_publish              | Total number of successful volume mount requests                          | `os_type=<runtime os>`<br>`provider=<provider name>`                              |
-| total_node_unpublish            | Total number of successful volume unmount requests                        | `os_type=<runtime os>`                                                            |
-| total_node_publish_error        | Total number of errors with volume mount requests                         | `os_type=<runtime os>`<br>`provider=<provider name>`<br>`error_type=<error code>` |
-| total_node_unpublish_error      | Total number of errors with volume unmount requests                       | `os_type=<runtime os>`                                                            |
-| total_sync_k8s_secret           | Total number of k8s secrets synced                                        | `os_type=<runtime os>`<br>`provider=<provider name>`                              |
-| sync_k8s_secret_duration_sec    | Distribution of how long it took to sync k8s secret                       | `os_type=<runtime os>`                                                            |
-| total_rotation_reconcile        | Total number of rotation reconciles                                       | `os_type=<runtime os>`<br>`rotated=<true or false>`                               |
-| total_rotation_reconcile_error  | Total number of rotation reconciles with error                            | `os_type=<runtime os>`<br>`rotated=<true or false>`<br>`error_type=<error code>`  |
+| node_publish_total              | Total number of successful volume mount requests                          | `os_type=<runtime os>`<br>`provider=<provider name>`                              |
+| node_unpublish_total            | Total number of successful volume unmount requests                        | `os_type=<runtime os>`                                                            |
+| node_publish_error_total        | Total number of errors with volume mount requests                         | `os_type=<runtime os>`<br>`provider=<provider name>`<br>`error_type=<error code>` |
+| node_unpublish_error_total      | Total number of errors with volume unmount requests                       | `os_type=<runtime os>`                                                            |
+| sync_k8s_secret_total           | Total number of k8s secrets synced                                        | `os_type=<runtime os>`<br>`provider=<provider name>`                              |
+| k8s_secret_duration_sec         | Distribution of how long it took to sync k8s secret                       | `os_type=<runtime os>`                                                            |
+| rotation_reconcile_total        | Total number of rotation reconciles                                       | `os_type=<runtime os>`<br>`provider=<provider name>`<br>`rotated=<true or false>` |
+| rotation_reconcile_error_total  | Total number of rotation reconciles with error                            | `os_type=<runtime os>`<br>`provider=<provider name>`<br>`rotated=<true or false>`<br>`error_type=<error code>`  |
 | rotation_reconcile_duration_sec | Distribution of how long it took to rotate secrets-store content for pods | `os_type=<runtime os>`                                                            |
 
 Metrics are served from port 8095, but this port is not exposed outside the pod by default. Use kubectl port-forward to access the metrics over localhost:
@@ -25,39 +27,41 @@ kubectl port-forward ds/csi-secrets-store -n kube-system 8095:8095 &
 curl localhost:8095/metrics
 ```
 
+> **Note:** Metrics are only emitted from driver pods that have actually performed the corresponding work (e.g. a volume mount, unmount, or rotation reconcile). When port-forwarding a single pod for validation, it is possible to hit a pod that has not yet served any requests and therefore exposes no driver-specific metrics. Trigger the relevant action against that pod, or query all pods, to see the metrics.
+
 ### Sample Metrics output
 
 ```shell
-# HELP sync_k8s_secret_duration_sec Distribution of how long it took to sync k8s secret
-# TYPE sync_k8s_secret_duration_sec histogram
-sync_k8s_secret_duration_sec_bucket{os_type="linux",le="0.1"} 0
-sync_k8s_secret_duration_sec_bucket{os_type="linux",le="0.2"} 0
-sync_k8s_secret_duration_sec_bucket{os_type="linux",le="0.3"} 0
-sync_k8s_secret_duration_sec_bucket{os_type="linux",le="0.4"} 1
-sync_k8s_secret_duration_sec_bucket{os_type="linux",le="0.5"} 1
-sync_k8s_secret_duration_sec_bucket{os_type="linux",le="1"} 1
-sync_k8s_secret_duration_sec_bucket{os_type="linux",le="1.5"} 1
-sync_k8s_secret_duration_sec_bucket{os_type="linux",le="2"} 1
-sync_k8s_secret_duration_sec_bucket{os_type="linux",le="2.5"} 1
-sync_k8s_secret_duration_sec_bucket{os_type="linux",le="3"} 1
-sync_k8s_secret_duration_sec_bucket{os_type="linux",le="5"} 1
-sync_k8s_secret_duration_sec_bucket{os_type="linux",le="10"} 1
-sync_k8s_secret_duration_sec_bucket{os_type="linux",le="15"} 1
-sync_k8s_secret_duration_sec_bucket{os_type="linux",le="30"} 1
-sync_k8s_secret_duration_sec_bucket{os_type="linux",le="+Inf"} 1
-sync_k8s_secret_duration_sec_sum{os_type="linux"} 0.3115892
-sync_k8s_secret_duration_sec_count{os_type="linux"} 1
-# HELP total_node_publish Total number of node publish calls
-# TYPE total_node_publish counter
-total_node_publish{os_type="linux",provider="azure"} 1
-# HELP total_node_publish_error Total number of node publish calls with error
-# TYPE total_node_publish_error counter
-total_node_publish_error{error_type="ProviderBinaryNotFound",os_type="linux",provider="azure"} 2
-total_node_publish_error{error_type="SecretProviderClassNotFound",os_type="linux",provider=""} 4
-# HELP total_node_unpublish Total number of node unpublish calls
-# TYPE total_node_unpublish counter
-total_node_unpublish{os_type="linux"} 1
-# HELP total_sync_k8s_secret Total number of k8s secrets synced
-# TYPE total_sync_k8s_secret counter
-total_sync_k8s_secret{os_type="linux",provider="azure"} 1
+# HELP k8s_secret_duration_sec Distribution of how long it took to sync k8s secret
+# TYPE k8s_secret_duration_sec histogram
+k8s_secret_duration_sec_bucket{os_type="linux",le="0.1"} 0
+k8s_secret_duration_sec_bucket{os_type="linux",le="0.2"} 0
+k8s_secret_duration_sec_bucket{os_type="linux",le="0.3"} 0
+k8s_secret_duration_sec_bucket{os_type="linux",le="0.4"} 1
+k8s_secret_duration_sec_bucket{os_type="linux",le="0.5"} 1
+k8s_secret_duration_sec_bucket{os_type="linux",le="1"} 1
+k8s_secret_duration_sec_bucket{os_type="linux",le="1.5"} 1
+k8s_secret_duration_sec_bucket{os_type="linux",le="2"} 1
+k8s_secret_duration_sec_bucket{os_type="linux",le="2.5"} 1
+k8s_secret_duration_sec_bucket{os_type="linux",le="3"} 1
+k8s_secret_duration_sec_bucket{os_type="linux",le="5"} 1
+k8s_secret_duration_sec_bucket{os_type="linux",le="10"} 1
+k8s_secret_duration_sec_bucket{os_type="linux",le="15"} 1
+k8s_secret_duration_sec_bucket{os_type="linux",le="30"} 1
+k8s_secret_duration_sec_bucket{os_type="linux",le="+Inf"} 1
+k8s_secret_duration_sec_sum{os_type="linux"} 0.3115892
+k8s_secret_duration_sec_count{os_type="linux"} 1
+# HELP node_publish_total Total number of node publish calls
+# TYPE node_publish_total counter
+node_publish_total{os_type="linux",provider="azure"} 1
+# HELP node_publish_error_total Total number of node publish calls with error
+# TYPE node_publish_error_total counter
+node_publish_error_total{error_type="ProviderBinaryNotFound",os_type="linux",provider="azure"} 2
+node_publish_error_total{error_type="SecretProviderClassNotFound",os_type="linux",provider=""} 4
+# HELP node_unpublish_total Total number of node unpublish calls
+# TYPE node_unpublish_total counter
+node_unpublish_total{os_type="linux"} 1
+# HELP sync_k8s_secret_total Total number of k8s secrets synced
+# TYPE sync_k8s_secret_total counter
+sync_k8s_secret_total{os_type="linux",provider="azure"} 1
 ```


### PR DESCRIPTION
Fixes #1937

## What's wrong today

[`docs/book/src/topics/metrics.md`](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/docs/book/src/topics/metrics.md) (rendered at https://secrets-store-csi-driver.sigs.k8s.io/topics/metrics) lists metric names that do not match what the driver actually exports on `/metrics`. Following [open-telemetry/opentelemetry-go#3360](https://github.com/open-telemetry/opentelemetry-go/pull/3360), the OpenTelemetry Prometheus exporter appends `_total` to counter instruments, so the counter names on the wire end with `_total` rather than beginning with `total_`.

The e2e test at `test/bats/e2e-provider.bats` already asserts the real names:
```bash
assert_match "node_publish_total" "${output}"
assert_match "node_unpublish_total" "${output}"
assert_match "rotation_reconcile_total" "${output}"
```
…which contradicts the docs.

## What this PR changes

Docs-only. Updates `docs/book/src/topics/metrics.md`:

**Counter names** — match what the Prometheus exporter emits:

| Before | After |
| --- | --- |
| `total_node_publish` | `node_publish_total` |
| `total_node_unpublish` | `node_unpublish_total` |
| `total_node_publish_error` | `node_publish_error_total` |
| `total_node_unpublish_error` | `node_unpublish_error_total` |
| `total_sync_k8s_secret` | `sync_k8s_secret_total` |
| `total_rotation_reconcile` | `rotation_reconcile_total` |
| `total_rotation_reconcile_error` | `rotation_reconcile_error_total` |

**Histogram name** — fixed typo; the instrument is registered as `k8s_secret_duration_sec` in [`pkg/secrets-store/stats_reporter.go`](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/pkg/secrets-store/stats_reporter.go#L87), not `sync_k8s_secret_duration_sec`.

**Tags on `rotation_reconcile_total` / `rotation_reconcile_error_total`** — added the `provider` tag, which the reporter already sets at [`stats_reporter.go:146`](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/pkg/secrets-store/stats_reporter.go#L146) and [`:155`](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/pkg/secrets-store/stats_reporter.go#L155) but which was missing from the docs.

**Sample output block** — regenerated with the current names.

**Two clarifications** added:
1. A note explaining the OTEL `_total` suffix behavior (so future readers understand why the exported names differ from the instrument names registered in code).
2. A note that driver metrics only appear on pods that have actually served a mount / unmount / rotation reconcile — when port-forwarding a single pod for validation it's easy to hit an idle pod and see no driver metrics, which was confusing enough to motivate this issue.

No code changes. Metric names on the wire are unchanged.

## Which issue this PR fixes

Fixes #1937

## Special notes for your reviewer

None.

## Does this PR introduce a user-facing change?

```release-note
NONE
```
