### PR TITLE
feat: add ppc64le and s390x Linux architecture support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ export GOPATH GOBIN GO111MODULE DOCKER_CLI_EXPERIMENTAL
 
 # Generate all combination of all OS, ARCH, and OSVERSIONS for iteration
 ALL_OS = linux windows
-ALL_ARCH_linux ?= amd64 arm64
+ALL_ARCH_linux ?= amd64 arm64 ppc64le s390x
 ALL_OS_ARCH_linux = $(foreach arch, ${ALL_ARCH_linux}, linux-$(arch))
 ALL_ARCH_windows = amd64
 ALL_OSVERSIONS_windows := 1809 ltsc2022 ltsc2025

--- a/docker/BASEIMAGE
+++ b/docker/BASEIMAGE
@@ -1,5 +1,7 @@
 linux/amd64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.7@sha256:a35a24b84a4d505fd1cb897c7085988264508c1189a265c8b1b5e2b8f3515829
 linux/arm64=registry.k8s.io/build-image/debian-base:bookworm-v1.0.7@sha256:f9cc7a063bda5212cd373ce8e06e11f824a688cfd3eccd432e6b56a6f8397490
+linux/ppc64le=registry.k8s.io/build-image/debian-base:bookworm-v1.0.7@sha256:c69b6c3dc24b0428a6d52a87411f2f8fad363a84896cb188fec6c87ee4fe0797
+linux/s390x=registry.k8s.io/build-image/debian-base:bookworm-v1.0.7@sha256:11fd818c9b6abceb11f4c9d9bbb99db953888eac7aedbee8331c75eeb37a9878
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022
 windows/amd64/ltsc2025=mcr.microsoft.com/windows/nanoserver:ltsc2025


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds `linux/ppc64le` and `linux/s390x` architecture support.

Both architectures are classified as [Tier 2 (Officially Built)](https://github.com/kubernetes/sig-release/blob/master/release-engineering/platforms/README.md) by Kubernetes. This PR reopens the request from #1637, which was closed citing that upstream Kubernetes was ending support for these architectures. The referenced kubernetes/kubernetes#131555 has since been closed; IBM Z committed to maintaining CI infrastructure and Kubernetes continues to officially support both architectures.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
The motivation for this PR is that OpenShift CI infrastructure wants to start using the secrets-store-csi-driver on clusters with ppc64le and s390x nodes and currently cannot schedule the DaemonSet on them.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
