### PR TITLE
fix: correct log format for missing targetpath modification time

### DIFF
--- a/pkg/secrets-store/nodeserver.go
+++ b/pkg/secrets-store/nodeserver.go
@@ -129,7 +129,10 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if rotationEnabled {
 		lastModificationTime, err := ns.getLastUpdateTime(targetPath)
 		if err != nil {
-			klog.InfoS("could not find last modification time for targetpath", targetPath, "error", err)
+			// targetPath not existing is expected on first mount; only log unexpected errors.
+			if !os.IsNotExist(err) {
+				klog.InfoS("could not find last modification time for targetpath", "targetPath", targetPath, "err", err)
+			}
 		} else if startTime.Before(lastModificationTime.Add(ns.rotationConfig.rotationCacheDuration)) {
 			// if next rotation is not yet due, then skip the mount operation
 			skipped = true


### PR DESCRIPTION
**What this PR does / why we need it:**

The structured log call in nodeserver.go passed positional args in the
wrong order, producing a malformed message with a `(MISSING)` value:

```
I0511 10:47:32.708465 1 nodeserver.go:132] "could not find last modification time for targetpath" /var/lib/.../mount="error" stat /var/lib/.../mount: no such file or directory="(MISSING)"
```

This PR uses proper key/value pairs and skips logging when the
targetPath does not yet exist (`os.IsNotExist`), which is the expected
case on first mount and was causing log spam on every pod
reinitialization.

**Which issue(s) this PR fixes:**

Fixes #2040

/kind bug
/triage accepted