### PR TITLE
fix: bumping kubectl version from v1.34.8 to v1.36.2

### DIFF
--- a/docker/crd.Dockerfile
+++ b/docker/crd.Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM alpine as builder
-ARG KUBE_VERSION=v1.34.8
+ARG KUBE_VERSION=v1.36.2
 ARG TARGETARCH
 
 RUN apk add --no-cache curl && \


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind/bug

**What this PR does / why we need it**:
Bumping version of kubectl to the newest one to get rid of the cve-2025-68121 (critical) which shows up on trivy scans

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #2048

**Special notes for your reviewer**:
You can test this locally by installing trivy (or use a docker image), building the crd.Dockerfile and then run the trivy scan on both version. You should see that at least the critical issue disappears.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
