### PR TITLE
feat: remove node startup taint on driver start

### DIFF
--- a/cmd/secrets-store-csi-driver/main.go
+++ b/cmd/secrets-store-csi-driver/main.go
@@ -198,6 +198,11 @@ func mainErr() error {
 		reconciler.RunPatcher(ctx)
 	}()
 
+	// Remove the node startup taint (if present) so workload pods can schedule
+	// onto this node now that the driver is starting. Runs in the background and
+	// no-ops on clusters that do not apply the taint.
+	secretsstore.RemoveNotReadyTaintInBackground()
+
 	driver := secretsstore.NewSecretsStoreDriver(*driverName, *nodeID, *endpoint, providerClients, mgr.GetClient(), mgr.GetAPIReader(), *enableSecretRotation, *rotationPollInterval)
 	driver.Run(ctx)
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -14,6 +14,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/controllers/secretproviderclasspodstatus_controller.go
+++ b/controllers/secretproviderclasspodstatus_controller.go
@@ -215,6 +215,9 @@ func (r *SecretProviderClassPodStatusReconciler) ListOptionsLabelSelector() clie
 // +kubebuilder:rbac:groups=secrets-store.csi.x-k8s.io,resources=secretproviderclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// The nodes get/patch rule is not used by this reconciler; it is required by the
+// node startup taint removal in pkg/secrets-store/node_taint.go.
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;patch
 // +kubebuilder:rbac:groups="storage.k8s.io",resources=csidrivers,verbs=get;list;watch,resourceNames=secrets-store.csi.k8s.io
 
 func (r *SecretProviderClassPodStatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/docs/book/src/getting-started/installation.md
+++ b/docs/book/src/getting-started/installation.md
@@ -33,6 +33,14 @@ Notably the following feature must be explicitly enabled:
 
 For a list of customizable values that can be injected when invoking helm install, please see the [Helm chart configurations](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/charts/secrets-store-csi-driver#configuration).
 
+### Configure node startup taint
+
+There are potential race conditions on node startup (especially when a node is first joining the cluster) where pods that rely on the Secrets Store CSI Driver can be scheduled onto a node and attempt to mount a `SecretProviderClass` volume before the driver has started up and become fully ready on that node. To close this race, the driver automatically removes a taint from its node on startup. Cluster administrators can taint their nodes when they join the cluster (and/or on startup) to prevent workload pods from being scheduled before the driver is ready.
+
+This behavior is always on and requires no configuration on the driver side. To use it, taint your nodes with `secrets-store.csi.k8s.io/agent-not-ready` (any effect works, but `NoExecute` is recommended, e.g. `secrets-store.csi.k8s.io/agent-not-ready:NoExecute`). The driver's node `DaemonSet` already tolerates all taints, so its own pod still schedules and, once running, removes the taint so other pods can be scheduled. For example, EKS Managed Node Groups [support automatically tainting nodes](https://docs.aws.amazon.com/eks/latest/userguide/node-taints-managed-node-groups.html).
+
+On clusters that never apply this taint the feature is a no-op. Removing the taint requires the driver's `ServiceAccount` to have `get` and `patch` on the `nodes` resource; the bundled RBAC grants this.
+
 ### [Alternatively] Deployment using yamls
 
 ```bash

--- a/manifest_staging/charts/secrets-store-csi-driver/templates/role.yaml
+++ b/manifest_staging/charts/secrets-store-csi-driver/templates/role.yaml
@@ -17,6 +17,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/manifest_staging/deploy/rbac-secretproviderclass.yaml
+++ b/manifest_staging/deploy/rbac-secretproviderclass.yaml
@@ -19,6 +19,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/pkg/secrets-store/node_taint.go
+++ b/pkg/secrets-store/node_taint.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secretsstore
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+)
+
+// AgentNotReadyNodeTaintKey is the taint key the driver removes from its local
+// node once it has started. Operators (for example EKS Managed Node Groups) can
+// apply this taint to a node so that workload pods are not scheduled there until
+// the secrets-store CSI driver pod is running, avoiding the startup race where a
+// pod mounts a SecretProviderClass volume before the driver is ready.
+const AgentNotReadyNodeTaintKey = "secrets-store.csi.k8s.io/agent-not-ready"
+
+// nodeNameEnvVar is the environment variable the DaemonSet populates from
+// spec.nodeName (also consumed as --nodeid). It identifies the local node whose
+// taint should be removed.
+const nodeNameEnvVar = "KUBE_NODE_NAME"
+
+// kubernetesClientGetter lazily builds a Kubernetes clientset. It is a function
+// so tests can inject a fake clientset and exercise the failure path.
+type kubernetesClientGetter func() (kubernetes.Interface, error)
+
+// inClusterClientGetter builds a clientset from the in-cluster config. It is the
+// production implementation passed to removeTaintInBackground.
+var inClusterClientGetter kubernetesClientGetter = func() (kubernetes.Interface, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(config)
+}
+
+// taintRemovalBackoff is the exponential backoff for node taint removal retries.
+// Max delay across the steps is 0.5s * 2^9 = ~4 minutes.
+var taintRemovalBackoff = wait.Backoff{
+	Duration: 500 * time.Millisecond,
+	Factor:   2,
+	Steps:    10,
+}
+
+// jsonPatch is a single RFC 6902 JSON patch operation.
+type jsonPatch struct {
+	OP    string      `json:"op,omitempty"`
+	Path  string      `json:"path,omitempty"`
+	Value interface{} `json:"value"`
+}
+
+// RemoveNotReadyTaintInBackground removes the node startup taint
+// (AgentNotReadyNodeTaintKey) from the local node in a background goroutine,
+// retrying with exponential backoff. It is the production entry point and is safe
+// to call unconditionally: it no-ops on clusters that never apply the taint.
+func RemoveNotReadyTaintInBackground() {
+	go removeTaintInBackground(inClusterClientGetter, removeNotReadyTaint)
+}
+
+// removeTaintInBackground retries removalFunc with exponential backoff until it
+// succeeds or the backoff is exhausted. It is intended to be run as a goroutine
+// so driver startup is not blocked on the Kubernetes API being reachable.
+func removeTaintInBackground(clientGetter kubernetesClientGetter, removalFunc func(kubernetesClientGetter) error) {
+	backoffErr := wait.ExponentialBackoff(taintRemovalBackoff, func() (bool, error) {
+		if err := removalFunc(clientGetter); err != nil {
+			klog.ErrorS(err, "Unexpected failure when attempting to remove node taint(s)")
+			return false, nil
+		}
+		return true, nil
+	})
+	if backoffErr != nil {
+		klog.ErrorS(backoffErr, "Retries exhausted, giving up attempting to remove node taint(s)")
+	}
+}
+
+// removeNotReadyTaint removes the AgentNotReadyNodeTaintKey taint from the local
+// node. It is a no-op (returns nil) when the node name is unknown or the client
+// cannot be built, so a cluster that never applies the taint is unaffected. It
+// returns an error only on transient API failures so the caller can retry.
+func removeNotReadyTaint(clientGetter kubernetesClientGetter) error {
+	nodeName := os.Getenv(nodeNameEnvVar)
+	if nodeName == "" {
+		klog.V(4).InfoS("node name env var missing, skipping taint removal", "envVar", nodeNameEnvVar)
+		return nil
+	}
+
+	clientset, err := clientGetter()
+	if err != nil {
+		klog.V(4).InfoS("failed to setup k8s client, skipping taint removal", "error", err)
+		return nil
+	}
+
+	node, err := clientset.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	taintsToKeep := make([]corev1.Taint, 0, len(node.Spec.Taints))
+	for _, taint := range node.Spec.Taints {
+		if taint.Key != AgentNotReadyNodeTaintKey {
+			taintsToKeep = append(taintsToKeep, taint)
+		} else {
+			klog.V(4).InfoS("queued taint for removal", "key", taint.Key, "effect", taint.Effect)
+		}
+	}
+
+	if len(taintsToKeep) == len(node.Spec.Taints) {
+		klog.V(4).InfoS("no taints to remove on node, skipping taint removal", "node", nodeName)
+		return nil
+	}
+
+	// Use a test-and-replace patch so we never clobber a concurrent update to
+	// the node's taints: if spec.taints changed since the Get, the test op fails
+	// and the patch is rejected, and the backoff retry re-reads the node.
+	patchRemoveTaints := []jsonPatch{
+		{
+			OP:    "test",
+			Path:  "/spec/taints",
+			Value: node.Spec.Taints,
+		},
+		{
+			OP:    "replace",
+			Path:  "/spec/taints",
+			Value: taintsToKeep,
+		},
+	}
+
+	patch, err := json.Marshal(patchRemoveTaints)
+	if err != nil {
+		return err
+	}
+
+	if _, err := clientset.CoreV1().Nodes().Patch(context.Background(), nodeName, k8stypes.JSONPatchType, patch, metav1.PatchOptions{}); err != nil {
+		return err
+	}
+
+	klog.InfoS("removed taint(s) from local node", "node", nodeName, "taintKey", AgentNotReadyNodeTaintKey)
+	return nil
+}

--- a/pkg/secrets-store/node_taint_test.go
+++ b/pkg/secrets-store/node_taint_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secretsstore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+const testNodeName = "test-node-123"
+
+// node returns a *corev1.Node named testNodeName with the supplied taints.
+func node(taints ...corev1.Taint) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: testNodeName},
+		Spec:       corev1.NodeSpec{Taints: taints},
+	}
+}
+
+func TestRemoveNotReadyTaint(t *testing.T) {
+	otherTaint := corev1.Taint{Key: "example.com/other", Effect: corev1.TaintEffectNoSchedule}
+	notReadyTaint := corev1.Taint{Key: AgentNotReadyNodeTaintKey, Effect: corev1.TaintEffectNoExecute}
+
+	testCases := []struct {
+		name string
+		// setNodeNameEnv controls whether KUBE_NODE_NAME is set for the test.
+		setNodeNameEnv bool
+		// objects seeds the fake clientset.
+		objects []runtime.Object
+		// reactors are prepended so they take precedence over default tracker behavior.
+		reactors []k8stesting.Reactor
+		// clientGetterErr, when set, makes the client getter return an error.
+		clientGetterErr error
+		expErr          bool
+		// expectPatch asserts whether a patch was issued against the node.
+		expectPatch bool
+		// expectTaintsAfter is checked against the live node when expectPatch is true.
+		expectTaintsAfter []corev1.Taint
+	}{
+		{
+			name:           "missing KUBE_NODE_NAME is a no-op",
+			setNodeNameEnv: false,
+			expErr:         false,
+			expectPatch:    false,
+		},
+		{
+			name:            "client getter failure is a no-op",
+			setNodeNameEnv:  true,
+			clientGetterErr: fmt.Errorf("failed to build client"),
+			expErr:          false,
+			expectPatch:     false,
+		},
+		{
+			name:           "get node failure returns error",
+			setNodeNameEnv: true,
+			objects:        nil, // node absent -> Get returns NotFound
+			expErr:         true,
+			expectPatch:    false,
+		},
+		{
+			name:           "node with no taints does not patch",
+			setNodeNameEnv: true,
+			objects:        []runtime.Object{node()},
+			expErr:         false,
+			expectPatch:    false,
+		},
+		{
+			name:           "node without the not-ready taint does not patch",
+			setNodeNameEnv: true,
+			objects:        []runtime.Object{node(otherTaint)},
+			expErr:         false,
+			expectPatch:    false,
+		},
+		{
+			name:           "patch failure returns error",
+			setNodeNameEnv: true,
+			objects:        []runtime.Object{node(notReadyTaint)},
+			reactors: []k8stesting.Reactor{
+				&k8stesting.SimpleReactor{
+					Verb:     "patch",
+					Resource: "nodes",
+					Reaction: func(action k8stesting.Action) (bool, runtime.Object, error) {
+						return true, nil, fmt.Errorf("failed to patch node")
+					},
+				},
+			},
+			expErr:      true,
+			expectPatch: false,
+		},
+		{
+			name:              "removes only the not-ready taint, keeps others",
+			setNodeNameEnv:    true,
+			objects:           []runtime.Object{node(notReadyTaint, otherTaint)},
+			expErr:            false,
+			expectPatch:       true,
+			expectTaintsAfter: []corev1.Taint{otherTaint},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setNodeNameEnv {
+				t.Setenv(nodeNameEnvVar, testNodeName)
+			} else {
+				// Ensure the var is empty even if inherited from the environment.
+				t.Setenv(nodeNameEnvVar, "")
+			}
+
+			cs := k8sfake.NewSimpleClientset(tc.objects...)
+			if len(tc.reactors) > 0 {
+				cs.ReactionChain = append(tc.reactors, cs.ReactionChain...)
+			}
+
+			getter := func() (kubernetes.Interface, error) {
+				if tc.clientGetterErr != nil {
+					return nil, tc.clientGetterErr
+				}
+				return cs, nil
+			}
+
+			err := removeNotReadyTaint(getter)
+			if tc.expErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			if tc.expectPatch {
+				updated, getErr := cs.CoreV1().Nodes().Get(t.Context(), testNodeName, metav1.GetOptions{})
+				assert.NoError(t, getErr)
+				assert.Equal(t, tc.expectTaintsAfter, updated.Spec.Taints)
+			}
+		})
+	}
+}
+
+// TestRemoveNotReadyTaintSoleTaintSerializesAsEmptyArray verifies that when the
+// not-ready taint is the ONLY taint, the replace op serializes the resulting
+// empty taint list as a JSON empty array ([]) and not null. A null would clear
+// the field in a way the apiserver treats differently from an explicit empty
+// list, and a future regression to a nil slice would emit null. The patch bytes
+// are captured to assert the wire format directly.
+func TestRemoveNotReadyTaintSoleTaintSerializesAsEmptyArray(t *testing.T) {
+	t.Setenv(nodeNameEnvVar, testNodeName)
+	notReadyTaint := corev1.Taint{Key: AgentNotReadyNodeTaintKey, Effect: corev1.TaintEffectNoExecute}
+
+	cs := k8sfake.NewSimpleClientset(node(notReadyTaint))
+
+	var capturedPatch []byte
+	cs.PrependReactor("patch", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		capturedPatch = action.(k8stesting.PatchAction).GetPatch()
+		// Fall through to the default tracker so the patch is actually applied.
+		return false, nil, nil
+	})
+
+	err := removeNotReadyTaint(func() (kubernetes.Interface, error) { return cs, nil })
+	assert.NoError(t, err)
+
+	// The replace op must serialize the (now empty) taint list as [] not null.
+	// The test op's value is the pre-read non-empty taint list, so `"value":[]`
+	// uniquely identifies the replace op.
+	assert.Contains(t, string(capturedPatch), `"value":[]`)
+	assert.NotContains(t, string(capturedPatch), `"value":null`)
+
+	updated, getErr := cs.CoreV1().Nodes().Get(t.Context(), testNodeName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Empty(t, updated.Spec.Taints)
+}
+
+// TestRemoveNotReadyTaintConcurrentModificationRejected proves the RFC6902 test
+// op actually guards against a concurrent taint change between the Get and the
+// Patch. The client Get returns a stale view (only the not-ready taint) while the
+// live node carries an additional taint, so the test op's asserted value differs
+// from live state and the patch must be rejected. removeNotReadyTaint surfaces
+// that as an error, which removeTaintInBackground retries.
+func TestRemoveNotReadyTaintConcurrentModificationRejected(t *testing.T) {
+	t.Setenv(nodeNameEnvVar, testNodeName)
+	notReadyTaint := corev1.Taint{Key: AgentNotReadyNodeTaintKey, Effect: corev1.TaintEffectNoExecute}
+	otherTaint := corev1.Taint{Key: "example.com/other", Effect: corev1.TaintEffectNoSchedule}
+
+	// Live tracker state carries both taints.
+	cs := k8sfake.NewSimpleClientset(node(notReadyTaint, otherTaint))
+
+	// Stale client Get returns only the not-ready taint, so the code computes a
+	// test-op value of [notReadyTaint], which will not match the live
+	// /spec/taints ([notReadyTaint, otherTaint]) at patch time. The patch's
+	// internal read goes through the tracker directly, not this reaction chain.
+	cs.PrependReactor("get", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, node(notReadyTaint), nil
+	})
+
+	err := removeNotReadyTaint(func() (kubernetes.Interface, error) { return cs, nil })
+	assert.Error(t, err)
+
+	// The live node must be untouched: the not-ready taint is still present
+	// because the conflicting patch was rejected.
+	updated, getErr := cs.Tracker().Get(corev1.SchemeGroupVersion.WithResource("nodes"), "", testNodeName)
+	assert.NoError(t, getErr)
+	liveNode := updated.(*corev1.Node)
+	assert.Equal(t, []corev1.Taint{notReadyTaint, otherTaint}, liveNode.Spec.Taints)
+}
+
+// TestRemoveTaintInBackground verifies the goroutine retries until the removal
+// function succeeds.
+func TestRemoveTaintInBackground(t *testing.T) {
+	calls := 0
+	removal := func(_ kubernetesClientGetter) error {
+		calls++
+		if calls == 3 {
+			return nil
+		}
+		return fmt.Errorf("taint removal failed")
+	}
+
+	removeTaintInBackground(nil, removal)
+	assert.Equal(t, 3, calls)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds node startup taint removal, the same pattern the AWS FSx, EFS, and EBS CSI drivers ship.

There is a race on node startup: pods that mount `SecretProviderClass` volumes can be scheduled onto a new node before the driver pod is running there, and their mounts fail until it is. Operators can now close this race by tainting nodes at registration with `secrets-store.csi.k8s.io/agent-not-ready` (EKS Managed Node Groups, for example, can apply taints automatically). The driver's node pod tolerates all taints, so it still schedules, and once it starts it removes the taint so workload pods can follow.

How it works:

- `main` launches a background goroutine at startup (`RemoveNotReadyTaintInBackground`).
- The goroutine reads the node name from the existing `KUBE_NODE_NAME` env var (already injected via `fieldRef: spec.nodeName` in all four DaemonSets), gets the Node, and removes any taint whose key matches, retrying with exponential backoff. Driver startup is never blocked on this.
- The JSON patch pairs an RFC 6902 `test` op on `/spec/taints` with the `replace`, so a concurrent change to the node's taints rejects the patch and the retry re-reads fresh state. This is the one intentional difference from the FSx implementation, which patches without the guard.
- On clusters that never apply the taint, or when `KUBE_NODE_NAME` is unset, this is a no-op.

RBAC: the ClusterRole needs `get` and `patch` on `nodes`. Added via kubebuilder marker; staging chart and kustomize output regenerated. Released chart and deploy copies are left alone for promotion at release time. No new configurable values, so no chart configuration table changes.

Docs: new "Configure node startup taint" section in the installation guide.

Testing:

- Unit tests cover the no-op paths, selective removal (unrelated taints are kept), sole-taint serialization (`[]`, not `null`), patch rejection on concurrent modification, and backoff retry.
- Validated on EKS 1.34 (AL2023, dual-stack): 7/7 e2e checks against pre-tainted nodes, and 8/8 against a managed nodegroup created with the taint (`NO_EXECUTE`) in its config. Nodes register already tainted, a pinned workload stays Pending while the taint is live, and it binds in the same second the driver removes the taint. Removal also worked over the cluster's IPv6 in-cluster API path.

**Which issue(s) this PR fixes**:

None in this repo. Motivated by aws/secrets-store-csi-driver-provider-aws#454, which asks for exactly this. That request was filed against the AWS provider, but the node service that gates readiness lives here in the driver, and the fix benefits every provider.

**Special notes for your reviewer**:

- The `nodes` RBAC marker sits with the other ClusterRole markers on the SecretProviderClassPodStatus reconciler, with a comment noting the actual consumer is `pkg/secrets-store/node_taint.go`.
- The code compiles into the Windows build and `KUBE_NODE_NAME` is present in the Windows DaemonSets, but I have only validated on Linux nodes.
- Behavior is always on and a no-op without the taint. If you would rather have an opt-out chart value, happy to add one.

**TODOs**:

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
