### PR TITLE
fix: skip no-op secret updates in createOrUpdateK8sSecret

### DIFF
--- a/controllers/secretproviderclasspodstatus_controller.go
+++ b/controllers/secretproviderclasspodstatus_controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/secrets-store-csi-driver/pkg/util/secretutil"
 
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
@@ -420,12 +421,36 @@ func (r *SecretProviderClassPodStatusReconciler) createOrUpdateK8sSecret(ctx con
 	}
 
 	klog.V(5).InfoS("Kubernetes secret is already created", "secret", klog.ObjectRef{Namespace: namespace, Name: name})
+
+	existing := &corev1.Secret{}
+	if err := r.reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, existing); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	} else if secretUpToDate(existing, secret) {
+		klog.V(5).InfoS("Kubernetes secret already up to date, skipping update", "secret", klog.ObjectRef{Namespace: namespace, Name: name})
+		return nil
+	}
+
 	err = r.writer.Update(ctx, secret)
 	if err != nil {
 		return err
 	}
 	klog.V(5).InfoS("successfully updated Kubernetes secret", "secret", klog.ObjectRef{Namespace: namespace, Name: name})
 	return nil
+}
+
+// secretUpToDate returns true if the existing secret already has the desired
+// type, data, labels and annotations, so writing it again would be a no-op.
+// apiequality.Semantic.DeepEqual is used instead of reflect.DeepEqual so that
+// a nil map (as returned by the API server for an unset field) and an empty
+// map (as built by the caller when no labels/annotations are configured) are
+// treated as equal.
+func secretUpToDate(existing, desired *corev1.Secret) bool {
+	return existing.Type == desired.Type &&
+		apiequality.Semantic.DeepEqual(existing.Data, desired.Data) &&
+		apiequality.Semantic.DeepEqual(existing.Labels, desired.Labels) &&
+		apiequality.Semantic.DeepEqual(existing.Annotations, desired.Annotations)
 }
 
 // patchSecretWithOwnerRef patches the secret owner reference with the spc pod status

--- a/controllers/secretproviderclasspodstatus_controller_test.go
+++ b/controllers/secretproviderclasspodstatus_controller_test.go
@@ -188,6 +188,76 @@ func TestCreateOrUpdateK8sSecret(t *testing.T) {
 	g.Expect(secret.Name).To(Equal("my-secret2"))
 }
 
+func TestCreateOrUpdateK8sSecretNoopWhenUnchanged(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme, err := setupScheme()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	labels := map[string]string{"environment": "test"}
+	annotations := map[string]string{"kubed.appscode.com/sync": "app=test"}
+	datamap := map[string][]byte{"key": []byte("value")}
+
+	existing := newSecret("my-secret", "default", labels, annotations)
+	existing.Type = corev1.SecretTypeOpaque
+	existing.Data = datamap
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	reconciler := newReconciler(client, scheme, "node1")
+
+	before := &corev1.Secret{}
+	g.Expect(client.Get(context.TODO(), types.NamespacedName{Name: "my-secret", Namespace: "default"}, before)).To(Succeed())
+
+	// reconciling with the exact same data/type/labels/annotations should not issue an update.
+	err = reconciler.createOrUpdateK8sSecret(context.TODO(), "my-secret", "default", datamap, labels, annotations, corev1.SecretTypeOpaque)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	after := &corev1.Secret{}
+	g.Expect(client.Get(context.TODO(), types.NamespacedName{Name: "my-secret", Namespace: "default"}, after)).To(Succeed())
+	g.Expect(after.ResourceVersion).To(Equal(before.ResourceVersion))
+
+	// reconciling with different data should still update the secret.
+	err = reconciler.createOrUpdateK8sSecret(context.TODO(), "my-secret", "default", map[string][]byte{"key": []byte("new-value")}, labels, annotations, corev1.SecretTypeOpaque)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	updated := &corev1.Secret{}
+	g.Expect(client.Get(context.TODO(), types.NamespacedName{Name: "my-secret", Namespace: "default"}, updated)).To(Succeed())
+	g.Expect(updated.ResourceVersion).NotTo(Equal(before.ResourceVersion))
+	g.Expect(updated.Data).To(Equal(map[string][]byte{"key": []byte("new-value")}))
+}
+
+// TestCreateOrUpdateK8sSecretNoopWhenAnnotationsUnset mirrors how Reconcile builds
+// annotationsMap when the SecretProviderClass doesn't set explicit annotations: a
+// fresh, empty (non-nil) map on every reconcile. The stored secret comes back from
+// the API/fake client with Annotations == nil, so the no-op comparison must treat
+// nil and empty maps as equal or it will update on every reconcile regardless.
+func TestCreateOrUpdateK8sSecretNoopWhenAnnotationsUnset(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme, err := setupScheme()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	labels := map[string]string{SecretManagedLabel: "true"}
+	datamap := map[string][]byte{"key": []byte("value")}
+
+	existing := newSecret("my-secret", "default", labels, map[string]string{})
+	existing.Type = corev1.SecretTypeOpaque
+	existing.Data = datamap
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	reconciler := newReconciler(client, scheme, "node1")
+
+	before := &corev1.Secret{}
+	g.Expect(client.Get(context.TODO(), types.NamespacedName{Name: "my-secret", Namespace: "default"}, before)).To(Succeed())
+
+	err = reconciler.createOrUpdateK8sSecret(context.TODO(), "my-secret", "default", datamap, labels, map[string]string{}, corev1.SecretTypeOpaque)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	after := &corev1.Secret{}
+	g.Expect(client.Get(context.TODO(), types.NamespacedName{Name: "my-secret", Namespace: "default"}, after)).To(Succeed())
+	g.Expect(after.ResourceVersion).To(Equal(before.ResourceVersion))
+}
+
 func TestGenerateEvent(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Since v1.6.0, `createOrUpdateK8sSecret` follows a failed `Create` (`AlreadyExists`) with an unconditional `Update`, even when the secret's data/type/labels/annotations already match what's stored. This means every reconcile of every synced `SecretProviderClassPodStatus` writes to the API server, regardless of whether anything actually changed, causing sustained write load, unnecessary etcd/KMS re-encryption, and (via the cluster-wide managed-Secret informer) network fan-out to every driver pod.

This PR fetches the existing secret before falling back to `Update` and skips the write when the desired type/data/labels/annotations already match, restoring the effective no-op behavior of v1.5.6 while keeping the v1.6.0 improvement of updating on real drift.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

- The existing-secret read uses `r.reader` (the controller-runtime manager cache), which is already populated by the managed-Secret informer this code path relies on, so the comparison is a cache read rather than an extra API call. If the cache hasn't yet synced a very recent out-of-band change to the secret, a reconcile could skip an update it should perform; this self-heals on the next reconcile/resync and is not a correctness issue.
- The comparison uses `k8s.io/apimachinery/pkg/api/equality`'s `Semantic.DeepEqual` rather than `reflect.DeepEqual`, because `Reconcile` builds `annotationsMap` as a fresh empty (non-nil) map whenever the `SecretProviderClass` has no explicit annotations, while a fetched secret's `Annotations` comes back `nil` for that case. `reflect.DeepEqual` treats nil vs. empty maps as unequal, which would have defeated the fix for the common case of secrets with no explicit annotations; `Semantic.DeepEqual` correctly treats them as equal.
- If the secret is missing from the cache (e.g. a very recent create not yet observed), the code falls back to the prior unconditional-`Update` behavior rather than erroring.
- This does not touch `patchSecretWithOwnerRef`, which is a separate, independently-scheduled code path (owner-ref patcher) unaffected by this change.

**Validation**:

- `go build ./...` succeeds.
- `go vet ./controllers/...` succeeds.
- `go test ./controllers/... -v` passes, including two new targeted regression tests:
  - `TestCreateOrUpdateK8sSecretNoopWhenUnchanged`: reconciling with identical data/type/labels/annotations does not bump the secret's `ResourceVersion` (i.e. no `Update` call is issued); reconciling with different data does bump it and persists the new data.
  - `TestCreateOrUpdateK8sSecretNoopWhenAnnotationsUnset`: mirrors `Reconcile`'s exact construction of an empty (non-nil) `annotationsMap` against a stored secret with `Annotations == nil`, and asserts no update occurs.
- Both new tests were confirmed to fail against the pre-fix code (unconditional `Update`) with a `ResourceVersion` mismatch, and to fail again if the map comparison is reverted to `reflect.DeepEqual` instead of `apiequality.Semantic.DeepEqual` — i.e. each test is a genuine regression test for the specific defect it targets, not a vacuous pass.
- No live cluster / e2e reproduction of the reported API-server write-rate increase was run in this environment; the driver's own `docs/book/src/testing.md` documents unit tests via `make test` as the local validation path and states e2e runs automatically on Prow for PRs, without requiring a local live-cluster run for a change of this kind. The fix is validated as a targeted, provable code defect (unconditional write on unchanged state) via failing-then-passing unit tests, consistent with the root cause described in the linked issue.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

Fixes #2057

```release-note
fix: skip no-op secret updates in createOrUpdateK8sSecret
```