### PR TITLE
fix: make SecretProviderClassPodStatus reconciliation idempotent

### DIFF
--- a/pkg/secrets-store/utils.go
+++ b/pkg/secrets-store/utils.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -98,10 +100,10 @@ func getSecretProviderItem(ctx context.Context, c client.Client, name, namespace
 }
 
 // createOrUpdateSecretProviderClassPodStatus creates secret provider class pod status if not exists.
-// if the secret provider class pod status already exists, it'll update the status and owner references.
+// if the secret provider class pod status already exists but its node label, status or owner references
+// are out of date, it'll be updated. If it already matches the desired state, no write is made.
 func createOrUpdateSecretProviderClassPodStatus(ctx context.Context, c client.Client, reader client.Reader, podname, namespace, podUID, spcName, targetPath, nodeID string, mounted bool, objects map[string]string) error {
 	var o []secretsstorev1.SecretProviderClassObject
-	var err error
 	spcpsName := podname + "-" + namespace + "-" + spcName
 
 	for k, v := range objects {
@@ -109,56 +111,72 @@ func createOrUpdateSecretProviderClassPodStatus(ctx context.Context, c client.Cl
 	}
 	o = spcpsutil.OrderSecretProviderClassObjectByID(o)
 
-	spcPodStatus := &secretsstorev1.SecretProviderClassPodStatus{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      spcpsName,
-			Namespace: namespace,
-			Labels:    map[string]string{secretsstorev1.InternalNodeLabel: nodeID},
-		},
-		Status: secretsstorev1.SecretProviderClassPodStatusStatus{
-			PodName:                 podname,
-			TargetPath:              targetPath,
-			Mounted:                 mounted,
-			SecretProviderClassName: spcName,
-			Objects:                 o,
-		},
+	desiredStatus := secretsstorev1.SecretProviderClassPodStatusStatus{
+		PodName:                 podname,
+		TargetPath:              targetPath,
+		Mounted:                 mounted,
+		SecretProviderClassName: spcName,
+		Objects:                 o,
 	}
-
 	// Set owner reference to the pod as the mapping between secret provider class pod status and
 	// pod is 1 to 1. When pod is deleted, the spc pod status will automatically be garbage collected
-	spcPodStatus.SetOwnerReferences([]metav1.OwnerReference{
+	desiredOwnerReferences := []metav1.OwnerReference{
 		{
 			APIVersion: "v1",
 			Kind:       "Pod",
 			Name:       podname,
 			UID:        types.UID(podUID),
 		},
+	}
+
+	// AlreadyExists can happen if we lose a create race against another writer, Conflict can happen
+	// if we lose an update race. Both are retried with a fresh read of the object.
+	retriable := func(err error) bool {
+		return apierrors.IsAlreadyExists(err) || apierrors.IsConflict(err)
+	}
+
+	return retry.OnError(retry.DefaultBackoff, retriable, func() error {
+		spcps := &secretsstorev1.SecretProviderClassPodStatus{}
+		err := c.Get(ctx, client.ObjectKey{Name: spcpsName, Namespace: namespace}, spcps)
+		if apierrors.IsNotFound(err) {
+			// the secret provider class pod status could be missing from the cache because it was
+			// labeled with a different node label, so check directly against the API server before
+			// concluding that it does not exist
+			err = reader.Get(ctx, client.ObjectKey{Name: spcpsName, Namespace: namespace}, spcps)
+		}
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+			spcPodStatus := &secretsstorev1.SecretProviderClassPodStatus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      spcpsName,
+					Namespace: namespace,
+					Labels:    map[string]string{secretsstorev1.InternalNodeLabel: nodeID},
+				},
+				Status: desiredStatus,
+			}
+			spcPodStatus.SetOwnerReferences(desiredOwnerReferences)
+			return c.Create(ctx, spcPodStatus)
+		}
+
+		if spcps.Labels[secretsstorev1.InternalNodeLabel] == nodeID &&
+			reflect.DeepEqual(spcps.Status, desiredStatus) &&
+			reflect.DeepEqual(spcps.OwnerReferences, desiredOwnerReferences) {
+			// already up to date, nothing to write
+			return nil
+		}
+		klog.InfoS("secret provider class pod status already exists, updating it", "spcps", klog.ObjectRef{Name: spcps.Name, Namespace: spcps.Namespace})
+
+		if spcps.Labels == nil {
+			spcps.Labels = map[string]string{}
+		}
+		spcps.Labels[secretsstorev1.InternalNodeLabel] = nodeID
+		spcps.Status = desiredStatus
+		spcps.OwnerReferences = desiredOwnerReferences
+
+		return c.Update(ctx, spcps)
 	})
-
-	if err = c.Create(ctx, spcPodStatus); err == nil || !apierrors.IsAlreadyExists(err) {
-		return err
-	}
-	klog.InfoS("secret provider class pod status already exists, updating it", "spcps", klog.ObjectRef{Name: spcPodStatus.Name, Namespace: spcPodStatus.Namespace})
-
-	spcps := &secretsstorev1.SecretProviderClassPodStatus{}
-	// the secret provider class pod status with the name already exists, update it
-	if err = c.Get(ctx, client.ObjectKey{Name: spcpsName, Namespace: namespace}, spcps); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-		// the secret provider class pod status could be missing in the cache because it was labeled with a different node
-		// label, so we need to get it from the API server
-		if err = reader.Get(ctx, client.ObjectKey{Name: spcpsName, Namespace: namespace}, spcps); err != nil {
-			return err
-		}
-	}
-
-	// update the labels of the secret provider class pod status to match the node label
-	spcps.Labels[secretsstorev1.InternalNodeLabel] = nodeID
-	spcps.Status = spcPodStatus.Status
-	spcps.OwnerReferences = spcPodStatus.OwnerReferences
-
-	return c.Update(ctx, spcps)
 }
 
 // getProviderFromSPC returns the provider as defined in SecretProviderClass

--- a/pkg/secrets-store/utils_test.go
+++ b/pkg/secrets-store/utils_test.go
@@ -30,6 +30,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 var (
@@ -159,5 +160,58 @@ func TestCreateOrUpdateSecretProviderClassPodStatus(t *testing.T) {
 				t.Errorf("Status got: %v, want: %v", got.Status, want.Status)
 			}
 		})
+	}
+}
+
+// TestCreateOrUpdateSecretProviderClassPodStatus_NoOpWhenUpToDate ensures that reconciling a
+// SecretProviderClassPodStatus that already matches the desired node label, status and owner
+// references does not issue a create or update request against the API server.
+func TestCreateOrUpdateSecretProviderClassPodStatus_NoOpWhenUpToDate(t *testing.T) {
+	spcpsName := fmt.Sprintf("%s-%s-%s", testPodName, testNamespace, testSPCName)
+	upToDate := &secretsstorev1.SecretProviderClassPodStatus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      spcpsName,
+			Namespace: testNamespace,
+			Labels:    map[string]string{secretsstorev1.InternalNodeLabel: "test-node"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       testPodName,
+					UID:        types.UID(testPodUID),
+				},
+			},
+		},
+		Status: secretsstorev1.SecretProviderClassPodStatusStatus{
+			PodName:                 testPodName,
+			TargetPath:              testTargetPath,
+			SecretProviderClassName: testSPCName,
+			Mounted:                 true,
+			Objects: []secretsstorev1.SecretProviderClassObject{
+				{ID: "a", Version: "v2"},
+				{ID: "b", Version: "v1"},
+			},
+		},
+	}
+
+	scheme, err := setupScheme()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	funcs := interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			t.Errorf("unexpected Create call for an already up-to-date object")
+			return c.Create(ctx, obj, opts...)
+		},
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			t.Errorf("unexpected Update call for an already up-to-date object")
+			return c.Update(ctx, obj, opts...)
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(upToDate).WithInterceptorFuncs(funcs).Build()
+
+	objects := map[string]string{"b": "v1", "a": "v2"}
+	if err := createOrUpdateSecretProviderClassPodStatus(context.TODO(), c, c, testPodName, testNamespace, testPodUID, testSPCName, testTargetPath, "test-node", true, objects); err != nil {
+		t.Errorf("Unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`createOrUpdateSecretProviderClassPodStatus` unconditionally attempted a `Create` on every
reconcile, and once the object already existed, unconditionally ran a `Get` followed by a `Put`
(`Update`) even when the label, `Status`, and `OwnerReferences` already matched the desired state.
In steady state (repeated `NodePublishVolume`/republish activity for an unchanged mount), this
produces a `POST` returning `409 AlreadyExists` followed by an unconditional `PUT` on every
reconcile, adding unnecessary write traffic to the API server without changing any observable
behavior.

This PR makes the helper idempotent: it reads the existing object first (falling back to a direct
API read if the cache doesn't have it, since it may be labeled for a different node and therefore
excluded from this node's cache), compares the node label, `Status`, and `OwnerReferences` against
the desired values, and returns without writing when they already match. It only creates when an
authoritative read confirms the object is absent, and only updates when something actually
differs. A bounded retry (`k8s.io/client-go/util/retry`, `retry.OnError` with `retry.DefaultBackoff`)
handles genuine races - `AlreadyExists` from a concurrent create, or `Conflict` from a concurrent
update - by re-reading and retrying the compare/write with a fresh object.

User-visible behavior is unchanged: the object still ends up in the same desired state. The benefit
is narrower - fewer redundant write requests against the API server when nothing has changed.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

Validation performed locally (no live cluster available in this environment):
- `go build ./...` passes.
- `go vet ./pkg/secrets-store/...` is clean.
- `go test ./pkg/secrets-store/... -run TestCreateOrUpdateSecretProviderClassPodStatus -v` passes,
  including a new regression test,
  `TestCreateOrUpdateSecretProviderClassPodStatus_NoOpWhenUpToDate`, which seeds a fake client with
  an object that already matches the desired node label, status, and owner references, and wires
  `interceptor.Funcs` to fail the test if `Create` or `Update` is ever called. This test FAILS
  against the pre-fix code (both an unexpected `Create` attempt on `AlreadyExists` and an
  unexpected `Update` call fire) and PASSES against the post-fix code, which is the concrete
  reproduction of the bug described in the issue.
- The pre-existing `TestCreateOrUpdateSecretProviderClassPodStatus` create/update-different-node-label
  subtests still pass unmodified, confirming genuinely new or changed objects still take the
  create/update path correctly.
- Not run: a live cluster / e2e reproduction of the exact `POST 409` + `PUT` API server traffic
  pattern described in the issue. The change is a pure controller-logic fix validated with a
  targeted unit test that reproduces the defect (unconditional write on an unchanged object) and
  proves the fix; it does not depend on cluster or provider-specific runtime behavior.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

Fixes #2058

```release-note
fix: make SecretProviderClassPodStatus reconciliation idempotent
```