### PR TITLE
fix: skip no-op Update in createOrUpdateK8sSecret

### DIFF
--- a/controllers/secretproviderclasspodstatus_controller.go
+++ b/controllers/secretproviderclasspodstatus_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -420,12 +421,61 @@ func (r *SecretProviderClassPodStatusReconciler) createOrUpdateK8sSecret(ctx con
 	}
 
 	klog.V(5).InfoS("Kubernetes secret is already created", "secret", klog.ObjectRef{Namespace: namespace, Name: name})
+
+	// Fetch the existing secret so we can (a) skip the Update when the desired
+	// state already matches what is stored, and (b) supply the current
+	// ResourceVersion so the Update goes through with proper optimistic
+	// concurrency instead of an unconditional overwrite.
+	//
+	// With CSIDriver.spec.requiresRepublish enabled, this reconciler runs on
+	// every kubelet-driven republish cycle. Without this short-circuit, each
+	// cycle issues an imperative Update() that causes the API server to record
+	// a new managedFields entry and bump resourceVersion even when the fetched
+	// provider content, labels, annotations, and type are byte-identical to
+	// what is already stored. Downstream watchers see a spurious Secret update
+	// event on every rotation-poll boundary. See kubernetes-sigs/secrets-store-csi-driver#XXXX.
+	existing := &corev1.Secret{}
+	getErr := r.reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, existing)
+	if getErr == nil && secretContentEqual(existing, secret) {
+		klog.V(5).InfoS("Kubernetes secret is up-to-date, skipping update", "secret", klog.ObjectRef{Namespace: namespace, Name: name})
+		return nil
+	}
+	if getErr == nil {
+		// Preserve the current ResourceVersion so the Update uses optimistic
+		// concurrency and does not silently blow away a concurrent write.
+		secret.ResourceVersion = existing.ResourceVersion
+	}
+
 	err = r.writer.Update(ctx, secret)
 	if err != nil {
 		return err
 	}
 	klog.V(5).InfoS("successfully updated Kubernetes secret", "secret", klog.ObjectRef{Namespace: namespace, Name: name})
 	return nil
+}
+
+// secretContentEqual reports whether the desired Secret already matches the
+// stored Secret for all fields this controller manages: data, type, labels, and
+// annotations. Server-populated metadata (managedFields, resourceVersion,
+// ownerReferences, uid, timestamps) is intentionally ignored — ownerReferences
+// are reconciled by patchSecretWithOwnerRef, not by createOrUpdateK8sSecret.
+func secretContentEqual(existing, desired *corev1.Secret) bool {
+	if existing == nil || desired == nil {
+		return false
+	}
+	if existing.Type != desired.Type {
+		return false
+	}
+	if !reflect.DeepEqual(existing.Data, desired.Data) {
+		return false
+	}
+	if !reflect.DeepEqual(existing.Labels, desired.Labels) {
+		return false
+	}
+	if !reflect.DeepEqual(existing.Annotations, desired.Annotations) {
+		return false
+	}
+	return true
 }
 
 // patchSecretWithOwnerRef patches the secret owner reference with the spc pod status

--- a/controllers/secretproviderclasspodstatus_controller_test.go
+++ b/controllers/secretproviderclasspodstatus_controller_test.go
@@ -188,6 +188,144 @@ func TestCreateOrUpdateK8sSecret(t *testing.T) {
 	g.Expect(secret.Name).To(Equal("my-secret2"))
 }
 
+// TestCreateOrUpdateK8sSecret_NoOpSkipsUpdate verifies that when the existing
+// Kubernetes Secret already matches the desired data/labels/annotations/type,
+// createOrUpdateK8sSecret does NOT issue an Update. We assert this by checking
+// that the stored ResourceVersion is unchanged — the fake client tracker only
+// bumps ResourceVersion on real writes. This guards against the v1.6.0
+// regression where every rotation-poll cycle produced a spurious Secret update
+// event even when the provider content was byte-identical.
+func TestCreateOrUpdateK8sSecret_NoOpSkipsUpdate(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme, err := setupScheme()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	labels := map[string]string{"environment": "test"}
+	annotations := map[string]string{"kubed.appscode.com/sync": "app=test"}
+	data := map[string][]byte{"value": []byte("this-is-a-secret")}
+
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-secret",
+			Namespace:       "default",
+			Labels:          labels,
+			Annotations:     annotations,
+			ResourceVersion: "100",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	reconciler := newReconciler(c, scheme, "node1")
+
+	err = reconciler.createOrUpdateK8sSecret(context.TODO(), "my-secret", "default", data, labels, annotations, corev1.SecretTypeOpaque)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	got := &corev1.Secret{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: "my-secret", Namespace: "default"}, got)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(got.ResourceVersion).To(Equal("100"), "expected no Update when content is byte-identical")
+	g.Expect(got.Data).To(Equal(data))
+}
+
+// TestCreateOrUpdateK8sSecret_UpdatesWhenDataChanges verifies that when the
+// provider content actually changes, createOrUpdateK8sSecret still performs
+// the Update.
+func TestCreateOrUpdateK8sSecret_UpdatesWhenDataChanges(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme, err := setupScheme()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	labels := map[string]string{"environment": "test"}
+	annotations := map[string]string{"kubed.appscode.com/sync": "app=test"}
+
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-secret",
+			Namespace:       "default",
+			Labels:          labels,
+			Annotations:     annotations,
+			ResourceVersion: "100",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{"value": []byte("old")},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	reconciler := newReconciler(c, scheme, "node1")
+
+	newData := map[string][]byte{"value": []byte("new")}
+	err = reconciler.createOrUpdateK8sSecret(context.TODO(), "my-secret", "default", newData, labels, annotations, corev1.SecretTypeOpaque)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	got := &corev1.Secret{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: "my-secret", Namespace: "default"}, got)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(got.Data).To(Equal(newData))
+	g.Expect(got.ResourceVersion).NotTo(Equal("100"), "expected ResourceVersion to change after a real content update")
+}
+
+func TestSecretContentEqual(t *testing.T) {
+	g := NewWithT(t)
+
+	base := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      map[string]string{"a": "1"},
+			Annotations: map[string]string{"b": "2"},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{"k": []byte("v")},
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(*corev1.Secret)
+		wantEq  bool
+	}{
+		{
+			name:   "identical",
+			mutate: func(s *corev1.Secret) {},
+			wantEq: true,
+		},
+		{
+			name:   "different data",
+			mutate: func(s *corev1.Secret) { s.Data = map[string][]byte{"k": []byte("v2")} },
+			wantEq: false,
+		},
+		{
+			name:   "different type",
+			mutate: func(s *corev1.Secret) { s.Type = corev1.SecretTypeBasicAuth },
+			wantEq: false,
+		},
+		{
+			name:   "different labels",
+			mutate: func(s *corev1.Secret) { s.Labels = map[string]string{"a": "2"} },
+			wantEq: false,
+		},
+		{
+			name:   "different annotations",
+			mutate: func(s *corev1.Secret) { s.Annotations = map[string]string{"b": "3"} },
+			wantEq: false,
+		},
+		{
+			name:   "server-side metadata differs but managed fields equal",
+			mutate: func(s *corev1.Secret) { s.ResourceVersion = "999"; s.UID = "abc" },
+			wantEq: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			desired := base.DeepCopy()
+			tc.mutate(desired)
+			g.Expect(secretContentEqual(base, desired)).To(Equal(tc.wantEq))
+		})
+	}
+
+	g.Expect(secretContentEqual(nil, base)).To(BeFalse())
+	g.Expect(secretContentEqual(base, nil)).To(BeFalse())
+}
+
 func TestGenerateEvent(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Fixes a regression introduced in v1.6.0 where the synced Kubernetes Secret is re-written on every kubelet republish cycle even when the provider content has not changed.

Since v1.6.0, `CSIDriver.spec.requiresRepublish` is set to `true` and the dedicated rotation reconciler was removed in favor of kubelet-driven `NodePublishVolume` republish.
`SecretProviderClassPodStatusReconciler.createOrUpdateK8sSecret` calls `client.Update()` unconditionally on every reconcile. Because the desired Secret is constructed fresh (no `ResourceVersion`, no
server-side fields), each Update causes the API server to record a new `managedFields` entry for the `csi-secrets-store` field manager, bump `resourceVersion`, and emit a watch event — even when `data`,
`labels`, `annotations`, and `type` are byte-identical to what is already stored.

Downstream controllers doing generic controller-runtime watches on the synced Secret (e.g., operators that reconcile StatefulSets on Secret update events) treat every republish cycle as a real rotation and
take disruptive action (pod recreation, rolling restart, etc.) even when nothing in the external secret store has changed.

This PR:
- Fetches the existing Secret before calling `Update()` and skips the write entirely when `type`, `data`, `labels`, and `annotations` already match.
- When an Update is still required, propagates the fetched `ResourceVersion` so the write uses proper optimistic concurrency instead of an unconditional overwrite.
- Adds a `secretContentEqual` helper covering the fields this controller manages.

Reproduction (v1.6.0-6 driver, v1.8.2-5 Azure provider, k8s 1.35, `enable-secret-rotation=true`, `rotation-poll-interval=2m`): synced Secret `resourceVersion` and `managedFields[csi-secrets-store].time`
advance every ~5 minutes while the Key Vault object version and content are unchanged. With this fix applied, the synced Secret stays at the same `resourceVersion` across cycles.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:
- Behavior parity with v1.5.x: v1.5.x invoked `createOrUpdateK8sSecret` only after a content-diff check inside the rotation reconciler, so no-op writes never reached the API server. Since v1.6.0 relies on
kubelet republish + unconditional Update, that diff needs to move into `createOrUpdateK8sSecret` itself; this PR does exactly that.
- Optional follow-up (not in this PR): switch the write to Server-Side Apply with a stable field manager. That would let the API server drop no-op applies natively, but is a larger change; the conservative
Get-then-compare approach here is enough to restore the pre-v1.6.0 contract.
- Reloader-style consumers (data-hash based) are unaffected either way.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
