### PR TITLE
Fix secret update hotloop

### DIFF
--- a/controllers/secretproviderclasspodstatus_controller.go
+++ b/controllers/secretproviderclasspodstatus_controller.go
@@ -18,7 +18,9 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -34,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -296,7 +299,6 @@ func (r *SecretProviderClassPodStatusReconciler) Reconcile(ctx context.Context, 
 			continue
 		}
 
-		var funcs []func() (bool, error)
 		secretType := secretutil.GetSecretType(strings.TrimSpace(secretObj.Type))
 
 		var datamap map[string][]byte
@@ -320,9 +322,19 @@ func (r *SecretProviderClassPodStatusReconciler) Reconcile(ctx context.Context, 
 		// only on secrets created and managed by the driver
 		labelsMap[SecretManagedLabel] = "true"
 
-		createFn := func() (bool, error) {
+		if err := wait.ExponentialBackoff(wait.Backoff{
+			Steps:    5,
+			Duration: 1 * time.Millisecond,
+			Factor:   1.0,
+			Jitter:   0.1,
+		}, func() (done bool, err error) {
 			if err := r.createOrUpdateK8sSecret(ctx, secretName, req.Namespace, datamap, labelsMap, annotationsMap, secretType); err != nil {
 				klog.ErrorS(err, "failed to create Kubernetes secret", "spc", klog.KObj(spc), "pod", klog.KObj(pod), "secret", klog.ObjectRef{Namespace: req.Namespace, Name: secretName}, "spcps", klog.KObj(spcPodStatus))
+				// error out here to break out of the backoff and retry the full Reconcile() early
+				if apierrors.IsConflict(err) || apierrors.IsAlreadyExists(err) {
+					return false, err
+				}
+
 				// syncSecret.enabled is set to false by default in the helm chart for installing the driver in v0.0.23+
 				// that would result in a forbidden error, so generate a warning that can be helpful for debugging
 				if apierrors.IsForbidden(err) {
@@ -331,19 +343,9 @@ func (r *SecretProviderClassPodStatusReconciler) Reconcile(ctx context.Context, 
 				return false, nil
 			}
 			return true, nil
-		}
-		funcs = append(funcs, createFn)
-
-		for _, f := range funcs {
-			if err := wait.ExponentialBackoff(wait.Backoff{
-				Steps:    5,
-				Duration: 1 * time.Millisecond,
-				Factor:   1.0,
-				Jitter:   0.1,
-			}, f); err != nil {
-				r.generateEvent(pod, corev1.EventTypeWarning, secretCreationFailedReason, err.Error())
-				return ctrl.Result{RequeueAfter: 5 * time.Second}, err
-			}
+		}); err != nil {
+			r.generateEvent(pod, corev1.EventTypeWarning, secretCreationFailedReason, err.Error())
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 		}
 	}
 
@@ -399,31 +401,63 @@ func (r *SecretProviderClassPodStatusReconciler) processIfBelongsToNode(objMeta 
 // createOrUpdateK8sSecret creates K8s secret with data from mounted files
 // If a secret with the same name already exists in the namespace of the pod, it will update that existing secret.
 func (r *SecretProviderClassPodStatusReconciler) createOrUpdateK8sSecret(ctx context.Context, name, namespace string, datamap map[string][]byte, labelsmap map[string]string, annotationsmap map[string]string, secretType corev1.SecretType) error {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   namespace,
-			Name:        name,
-			Labels:      labelsmap,
-			Annotations: annotationsmap,
-		},
-		Type: secretType,
-		Data: datamap,
+	secret := &corev1.Secret{}
+	getErr := r.reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret)
+
+	// Secret does not exist, create it
+	if apierrors.IsNotFound(getErr) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   namespace,
+				Name:        name,
+				Labels:      labelsmap,
+				Annotations: annotationsmap,
+			},
+			Type: secretType,
+			Data: datamap,
+		}
+
+		err := r.writer.Create(ctx, secret)
+		if err == nil {
+			klog.InfoS("successfully created Kubernetes secret", "secret", klog.ObjectRef{Namespace: namespace, Name: name})
+		}
+
+		return err
 	}
 
-	err := r.writer.Create(ctx, secret)
-	if err == nil {
-		klog.InfoS("successfully created Kubernetes secret", "secret", klog.ObjectRef{Namespace: namespace, Name: name})
+	if getErr != nil {
+		return getErr
+	}
+
+	// Secret exists, update it
+	klog.V(5).InfoS("Kubernetes secret is already created", "secret", klog.ObjectRef{Namespace: namespace, Name: name})
+
+	if reflect.DeepEqual(secret.Data, datamap) {
 		return nil
 	}
-	if !apierrors.IsAlreadyExists(err) {
+
+	oldData, err := json.Marshal(secret)
+	if err != nil {
+		return fmt.Errorf("failed to marshal old secret, err: %w", err)
+	}
+
+	secret.Data = datamap
+
+	newData, err := json.Marshal(secret)
+	if err != nil {
+		return fmt.Errorf("failed to marshal new secret, err: %w", err)
+	}
+
+	// Patching data clobbers existing data
+	patch, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, secret)
+	if err != nil {
+		return fmt.Errorf("failed to create patch, err: %w", err)
+	}
+
+	if err = r.writer.Patch(ctx, secret, client.RawPatch(types.MergePatchType, patch)); err != nil {
 		return err
 	}
 
-	klog.V(5).InfoS("Kubernetes secret is already created", "secret", klog.ObjectRef{Namespace: namespace, Name: name})
-	err = r.writer.Update(ctx, secret)
-	if err != nil {
-		return err
-	}
 	klog.V(5).InfoS("successfully updated Kubernetes secret", "secret", klog.ObjectRef{Namespace: namespace, Name: name})
 	return nil
 }

--- a/controllers/secretproviderclasspodstatus_controller_test.go
+++ b/controllers/secretproviderclasspodstatus_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 var (
@@ -121,6 +122,13 @@ func newReconciler(client client.Client, scheme *runtime.Scheme, nodeID string) 
 	}
 }
 
+// expectOwnerRefs asserts the secret's owner references match want exactly, by
+// full-struct equality and independent of order. ConsistOf uses DeepEqual, so
+// pointer fields (Controller, BlockOwnerDeletion) are compared by their pointees.
+func expectOwnerRefs(g Gomega, secret *corev1.Secret, want ...metav1.OwnerReference) {
+	g.Expect(secret.OwnerReferences).To(ConsistOf(want))
+}
+
 func TestPatchSecretWithOwnerRef(t *testing.T) {
 	g := NewWithT(t)
 
@@ -188,6 +196,257 @@ func TestCreateOrUpdateK8sSecret(t *testing.T) {
 	g.Expect(secret.Name).To(Equal("my-secret2"))
 }
 
+func TestCreateOrUpdateHotloop(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme, err := setupScheme()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	labels := map[string]string{"environment": "test"}
+	annotations := map[string]string{"kubed.appscode.com/sync": "app=test"}
+
+	// secret1 is intentionally NOT pre-seeded so the create path runs.
+	initObjects := []client.Object{
+		newSecretProviderClassPodStatus("pod1-default-spc1", "default", "node1"),
+		newSecretProviderClass("spc1", "default"),
+		newPod("pod1", "default", []metav1.OwnerReference{
+			{
+				APIVersion:         "apps/v1",
+				BlockOwnerDeletion: new(true),
+				Controller:         new(true),
+				Kind:               "ReplicaSet",
+				Name:               "pod-6886c65f8f",
+				UID:                "f39da13d-7246-4ef5-aed4-a6905f82cbcd",
+			},
+		}),
+	}
+
+	var createCount, updateCount, patchCount int
+	client := fake.
+		NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(initObjects...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				createCount++
+				return client.Create(ctx, obj, opts...)
+			},
+			Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				updateCount++
+				return client.Update(ctx, obj, opts...)
+			},
+			Patch: func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				patchCount++
+				return client.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := newReconciler(client, scheme, "node1")
+
+	// The Patcher copies only APIVersion/Kind/UID/Name from the pod's owner
+	// references; Controller/BlockOwnerDeletion are intentionally left nil.
+	wantRef := metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "ReplicaSet",
+		Name:       "pod-6886c65f8f",
+		UID:        "f39da13d-7246-4ef5-aed4-a6905f82cbcd",
+	}
+
+	secretKey := types.NamespacedName{Name: "secret1", Namespace: "default"}
+	getSecret := func() *corev1.Secret {
+		s := &corev1.Secret{}
+		g.Expect(client.Get(context.TODO(), secretKey, s)).NotTo(HaveOccurred())
+		return s
+	}
+
+	err = reconciler.createOrUpdateK8sSecret(context.TODO(), "secret1", "default", map[string][]byte{"foo": []byte("bar")}, labels, annotations, corev1.SecretTypeOpaque)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(createCount).To(Equal(1))
+	g.Expect(updateCount).To(Equal(0))
+	g.Expect(patchCount).To(Equal(0))
+
+	err = reconciler.Patcher(context.TODO())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(createCount).To(Equal(1))
+	g.Expect(updateCount).To(Equal(0))
+	g.Expect(patchCount).To(Equal(1))
+
+	s1 := getSecret()
+	expectOwnerRefs(g, s1, wantRef)
+
+	updateDataMap := map[string][]byte{"foo": []byte("baz")}
+	// update the secret with new content
+	err = reconciler.createOrUpdateK8sSecret(context.TODO(), "secret1", "default", updateDataMap, labels, annotations, corev1.SecretTypeOpaque)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(createCount).To(Equal(1))
+	g.Expect(updateCount).To(Equal(0))
+	g.Expect(patchCount).To(Equal(2))
+
+	// owner refs should be preserved
+	s2 := getSecret()
+	expectOwnerRefs(g, s2, wantRef)
+
+	// patching should be a no-op
+	err = reconciler.Patcher(context.TODO())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(createCount).To(Equal(1))
+	g.Expect(updateCount).To(Equal(0))
+	g.Expect(patchCount).To(Equal(2))
+
+	// attempt to update with unchanged data results in no-op (early return,
+	// i.e. no patch/update)
+	err = reconciler.createOrUpdateK8sSecret(context.TODO(), "secret1", "default", updateDataMap, labels, annotations, corev1.SecretTypeOpaque)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(createCount).To(Equal(1))
+	g.Expect(updateCount).To(Equal(0))
+	g.Expect(patchCount).To(Equal(2))
+
+	s3 := getSecret()
+	expectOwnerRefs(g, s3, wantRef)
+	g.Expect(s3.Name).To(Equal("secret1"))
+	g.Expect(s3.Labels).To(Equal(labels))
+	g.Expect(s3.Annotations).To(Equal(annotations))
+	g.Expect(s3.Data).To(Equal(map[string][]byte{"foo": []byte("baz")}))
+}
+
+func TestDataPatch(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme, err := setupScheme()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	labels := map[string]string{"environment": "test"}
+	annotations := map[string]string{"kubed.appscode.com/sync": "app=test"}
+
+	secretKey := types.NamespacedName{Name: "secret1", Namespace: "default"}
+	initSecret := newSecret(secretKey.Name, secretKey.Namespace, labels, annotations)
+	initSecret.Data = map[string][]byte{
+		"key1": []byte("key1origvalue"),
+		"key2": []byte("key2notdeleted"),
+	}
+
+	updateDataMap := map[string][]byte{
+		"key1": []byte("key1replaced"),
+		"key3": []byte("key3newkey"),
+	}
+
+	initObjects := []client.Object{
+		initSecret,
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+	reconciler := newReconciler(client, scheme, "node1")
+
+	err = reconciler.createOrUpdateK8sSecret(context.TODO(), secretKey.Name, secretKey.Namespace, updateDataMap, labels, annotations, corev1.SecretTypeOpaque)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	updated := &corev1.Secret{}
+	err = client.Get(context.TODO(), secretKey, updated)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(updated.Data).To(Equal(updateDataMap))
+}
+
+// TestUpdateOverwritesForeignLabelsAndAnnotations proves that when another controller modifies
+// only labels/annotations and adds its own owner ref, our controller notices
+// (reconcile + patch run) and overwrites the foreign labels and annotations.
+// TODO: we intend to change this in a future release as this behavior
+// is incorrect.
+func TestUpdateDoesNotModifyLabelsOrAnnotations(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme, err := setupScheme()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// driver* is what our SecretObject declares; the foreign* keys are added by a
+	// different controller and must not be stomped.
+	foreignLabels := map[string]string{
+		"key1": "key1foreignlabel", // value will be merged
+		"key2": "key2foreignlabel",
+	}
+	driverLabels := map[string]string{
+		"key1": "key1driverlabel",
+		"key3": "key3driverlabel",
+	}
+	foreignAnnotations := map[string]string{
+		"key1": "key1foreignannotation",
+		"key2": "key2foreignannotation",
+	}
+	driverAnnotations := map[string]string{
+		"key1": "key1driverannotation",
+		"key3": "key3driverannotation",
+	}
+
+	foreignRef := metav1.OwnerReference{
+		APIVersion: "example.com/v1",
+		Kind:       "ExternalThing",
+		Name:       "external-owner",
+		UID:        "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+	}
+	foreignSecret := newSecret("secret1", "default", foreignLabels, foreignAnnotations)
+	foreignSecret.OwnerReferences = []metav1.OwnerReference{foreignRef}
+
+	initObjects := []client.Object{
+		newSecretProviderClassPodStatus("pod1-default-spc1", "default", "node1"),
+		newSecretProviderClass("spc1", "default"),
+		newPod("pod1", "default", []metav1.OwnerReference{
+			{
+				APIVersion:         "apps/v1",
+				BlockOwnerDeletion: new(true),
+				Controller:         new(true),
+				Kind:               "ReplicaSet",
+				Name:               "pod-6886c65f8f",
+				UID:                "f39da13d-7246-4ef5-aed4-a6905f82cbcd",
+			},
+		}),
+		foreignSecret,
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+	reconciler := newReconciler(client, scheme, "node1")
+
+	driverRef := metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "ReplicaSet",
+		Name:       "pod-6886c65f8f",
+		UID:        "f39da13d-7246-4ef5-aed4-a6905f82cbcd",
+	}
+
+	secretKey := types.NamespacedName{Name: "secret1", Namespace: "default"}
+	getSecret := func() *corev1.Secret {
+		s := &corev1.Secret{}
+		g.Expect(client.Get(context.TODO(), secretKey, s)).NotTo(HaveOccurred())
+		return s
+	}
+
+	// annotations should not be modified with real update
+	err = reconciler.createOrUpdateK8sSecret(context.TODO(), "secret1", "default", map[string][]byte{"foo": []byte("bar")}, driverLabels, driverAnnotations, corev1.SecretTypeOpaque)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = reconciler.Patcher(context.TODO())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	s1 := getSecret()
+	expectOwnerRefs(g, s1, foreignRef, driverRef)
+	g.Expect(s1.Labels).To(Equal(foreignLabels))
+	g.Expect(s1.Annotations).To(Equal(foreignAnnotations))
+
+	// no-op update should leave labels and annotations alone
+	err = reconciler.createOrUpdateK8sSecret(context.TODO(), "secret1", "default", map[string][]byte{"foo": []byte("bar")}, driverLabels, driverAnnotations, corev1.SecretTypeOpaque)
+	s2 := getSecret()
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(s2.Labels).To(Equal(foreignLabels))
+	g.Expect(s2.Annotations).To(Equal(foreignAnnotations))
+
+	// patcher should leave labels and annotations alone
+	err = reconciler.Patcher(context.TODO())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	s3 := getSecret()
+	expectOwnerRefs(g, s3, foreignRef, driverRef)
+	g.Expect(s3.Labels).To(Equal(foreignLabels))
+	g.Expect(s3.Annotations).To(Equal(foreignAnnotations))
+}
+
 func TestGenerateEvent(t *testing.T) {
 	g := NewWithT(t)
 
@@ -246,7 +505,6 @@ func TestPatcherForPodWithOwner(t *testing.T) {
 
 	scheme, err := setupScheme()
 	g.Expect(err).NotTo(HaveOccurred())
-	tr := true
 
 	initObjects := []client.Object{
 		newSecretProviderClassPodStatus("pod1-default-spc1", "default", "node1"),
@@ -254,8 +512,8 @@ func TestPatcherForPodWithOwner(t *testing.T) {
 		newPod("pod1", "default", []metav1.OwnerReference{
 			{
 				APIVersion:         "apps/v1",
-				BlockOwnerDeletion: &tr,
-				Controller:         &tr,
+				BlockOwnerDeletion: new(true),
+				Controller:         new(true),
 				Kind:               "ReplicaSet",
 				Name:               "pod-6886c65f8f",
 				UID:                "f39da13d-7246-4ef5-aed4-a6905f82cbcd",
@@ -274,9 +532,12 @@ func TestPatcherForPodWithOwner(t *testing.T) {
 	err = client.Get(context.TODO(), types.NamespacedName{Name: "secret1", Namespace: "default"}, secret)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	g.Expect(len(secret.OwnerReferences)).To(Equal(1))
-	g.Expect(secret.OwnerReferences[0].APIVersion).To(Equal("apps/v1"))
-	g.Expect(secret.OwnerReferences[0].Kind).To(Equal("ReplicaSet"))
-	g.Expect(secret.OwnerReferences[0].Name).To(Equal("pod-6886c65f8f"))
-	g.Expect(secret.OwnerReferences[0].UID).To(Equal(types.UID("f39da13d-7246-4ef5-aed4-a6905f82cbcd")))
+	// Controller/BlockOwnerDeletion are intentionally dropped: the Patcher copies
+	// only APIVersion/Kind/UID/Name from the pod's owner references.
+	expectOwnerRefs(g, secret, metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       "ReplicaSet",
+		Name:       "pod-6886c65f8f",
+		UID:        "f39da13d-7246-4ef5-aed4-a6905f82cbcd",
+	})
 }


### PR DESCRIPTION
<!-- Please label this pull request according to what type of issue you are addressing -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->
/kind bug
**What this PR does / why we need it**:
fix: prevent secret update hotloop

The driver rewrote each managed secret on every reconcile, which kept triggering fresh reconciles for the same object. Now it fetches the existing secret first and skips the write entirely when the data hasn't changed.

When the data does change, apply it with a merge patch that only touches the Data field instead of doing a full Update. That leaves owner references, labels, and annotations in place.

Break out of the create/update backoff early on a conflict or already-exists error to enter the next reconcile more quickly.

Add tests covering the hotloop case, the data-only patch, and the fact that updates don't affect labels, annotations, or owner references.

Addresses issue 2057.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/manifest_staging/charts/secrets-store-csi-driver#configuration). 
-->
**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
