### PR TITLE
security: don't install ca-certificates in the driver image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,9 +28,16 @@ RUN export GOOS=$TARGETOS && \
 
 FROM $BASEIMAGE
 COPY --from=builder /go/src/sigs.k8s.io/secrets-store-csi-driver/_output/secrets-store-csi /secrets-store-csi
+
+# Deliberately not installing ca-certificates: debian-base already ships
+# /etc/ssl/certs/ca-certificates.crt, copied in without the package so that
+# openssl is not pulled in as a dependency. Re-installing the package here would
+# undo that and add openssl + libssl3 back to the image. The driver is built with
+# CGO_ENABLED=0, so it reads the trust bundle as a file via crypto/x509 and never
+# links libssl3 nor execs the openssl CLI.
 RUN apt update && \
     apt upgrade -y && \
-    clean-install ca-certificates mount
+    clean-install mount
 
 LABEL description="Secrets Store CSI Driver"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The driver image installs `ca-certificates`, which pulls `openssl` and `libssl3` back into the final image — undoing something the base image goes out of its way to avoid.

`registry.k8s.io/build-image/debian-base` deliberately ships `/etc/ssl/certs/ca-certificates.crt` copied in from a separate stage *without* the `ca-certificates` package, precisely so that openssl is not a dependency (see `images/build/debian-base/*/Dockerfile.build` in `kubernetes/release`). `clean-install ca-certificates mount` in `docker/Dockerfile` reverses that, because `ca-certificates` hard-`Depends` on `openssl (>= 1.1.1)`.

Neither package is reachable from the driver. It is built with `CGO_ENABLED=0`, so it reads the trust bundle as a file through `crypto/x509` — it never links `libssl3` and never execs the `openssl` CLI.

`mount` is already present in debian-base, so that half of the install is a no-op; I've kept it so the runtime dependency stays explicit.

**Why it's worth doing**: openssl and libssl3 are a recurring source of CVEs in image scans, and here they are entirely unused. In a recent scan of a cluster running v1.5.0, these two packages accounted for 11 findings on the driver image — 6 of which had no fixed Debian package available at any version, so they could not be resolved by patching, only by not shipping the packages. This change removes that surface permanently rather than waiting on Debian.

Note that this repo's `scan_vulns` workflow currently runs `govulncheck` only, so OS-package findings like these don't surface in CI.

**Verification**: built the image before and after the change.

- `openssl` and `libssl3` are no longer installed (82 → 79 packages)
- `/etc/ssl/certs/ca-certificates.crt` is still present (142 certs)
- a statically linked Go TLS probe run inside the image still completes a verified TLS 1.3 handshake to a public endpoint (2 verified chains), identically to the unmodified image
- `/usr/bin/mount` is still present and the driver binary still starts

**Special notes for your reviewer**:

There is a related, larger issue I'm raising separately against `kubernetes/release`: `perl-base` is inherited as `Essential: yes` from `debian:bookworm-slim` and is absent from debian-base's existing purge list, which affects every image built on that base. This PR is scoped only to what the driver image itself controls.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
