### PR TITLE
fix: call ctrl.SetLogger to route controller-runtime logs through klog

### DIFF
--- a/cmd/secrets-store-csi-driver/main.go
+++ b/cmd/secrets-store-csi-driver/main.go
@@ -88,6 +88,11 @@ func mainErr() error {
 
 	flag.Parse()
 
+	// controller-runtime logs a warning and drops its internal logs (e.g. from the
+	// priority work queue) if this isn't set before the manager starts. Route those
+	// logs through klog so they show up alongside the rest of the driver's logs.
+	ctrl.SetLogger(klog.NewKlogr())
+
 	ctx := withShutdownSignal(context.Background())
 
 	defer mlog.Setup()()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Since v1.6.1 the driver logs `[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.` on every startup, and controller-runtime's internal logs (e.g. from the priority work queue) are silently dropped from then on. The driver never calls `ctrl.SetLogger(...)`, so after controller-runtime's 30s grace period it falls back to a `NullLogSink`.

This PR calls `ctrl.SetLogger(klog.NewKlogr())` right after flag parsing, so controller-runtime's logs flow through the same klog/mlog pipeline as the rest of the driver. Logging-only change, no functional behavior changes.

**Which issue(s) this PR fixes**:

Fixes #2085

**Special notes for your reviewer**:

I don't have docker/kind in my sandbox, so I could not run this end-to-end against a live cluster and reproduce the 30s warning. I verified the root cause by reading controller-runtime's `pkg/log/log.go` (confirms the timeout/fallback behavior) and confirming no `SetLogger` call exists anywhere else in this repo, plus `go build`, `go vet`, and `golangci-lint` all pass clean.

**TODOs**:

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

```release-note
fix: call ctrl.SetLogger to route controller-runtime logs through klog
```
